### PR TITLE
对齐 grok：上下文水位、full-replace 压缩与权限/会话恢复

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,6 +3512,7 @@ dependencies = [
  "zene-config",
  "zene-core",
  "zene-llm",
+ "zene-mcp",
  "zene-sandbox",
  "zene-session",
 ]

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -27,4 +27,5 @@ zene-core = { workspace = true }
 zene-sandbox = { workspace = true }
 zene-session = { workspace = true }
 zene-llm = { workspace = true }
+zene-mcp = { workspace = true }
 llm_providers = { workspace = true }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -5,9 +5,10 @@ use clap::{Parser, Subcommand};
 use parking_lot::Mutex;
 use tokio_util::sync::CancellationToken;
 use zene_config::{ensure_home, ZeneConfig};
-use zene_core::{Agent, PermissionMode};
+use zene_core::{Agent, AgentEvent, PermissionMode, PromptOptions};
 use zene_sandbox::LocalSandbox;
 use zene_session::{export_session, list_sessions_for_workdir, SessionRecord};
+use std::sync::Arc;
 
 mod repl;
 mod model_config;
@@ -67,6 +68,14 @@ pub struct Cli {
     /// Hide per-turn token usage line
     #[arg(long)]
     quiet_usage: bool,
+
+    /// Run a single prompt headlessly (no TUI/REPL) and exit
+    #[arg(short = 'p', long = "prompt")]
+    prompt: Option<String>,
+
+    /// Headless output format: `text` (default) or `json`
+    #[arg(long, default_value = "text")]
+    output_format: String,
 }
 
 #[derive(Subcommand)]
@@ -84,6 +93,17 @@ enum Commands {
         #[arg(long)]
         output: PathBuf,
     },
+    /// Probe configured MCP servers (stdio connectivity)
+    Mcp {
+        #[command(subcommand)]
+        command: McpCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum McpCommands {
+    /// List configured MCP servers and attempt a short connect
+    Doctor,
 }
 
 fn init_tracing(use_tui: bool) {
@@ -166,6 +186,14 @@ async fn main() -> Result<()> {
             println!("Exported session {} to {}", session, output.display());
             return Ok(());
         }
+        Some(Commands::Mcp { command }) => {
+            match command {
+                McpCommands::Doctor => {
+                    run_mcp_doctor(&workdir).await?;
+                }
+            }
+            return Ok(());
+        }
         None => {}
     }
 
@@ -177,13 +205,19 @@ async fn main() -> Result<()> {
     };
 
     let permission_mode = if cli.yolo {
-        PermissionMode::Yolo
+        PermissionMode::BypassPermissions
     } else {
         PermissionMode::parse(&config.permission_mode)
     };
 
     let sandbox = LocalSandbox::new(&workdir);
     let mut agent = Agent::new(config.clone(), sandbox, session, permission_mode).await?;
+
+    if let Some(prompt) = cli.prompt.as_deref() {
+        run_headless(&mut agent, prompt, &cli).await?;
+        agent.shutdown().await?;
+        return Ok(());
+    }
 
     if !cli.repl {
         return tui::run(agent, &config, &cli).await;
@@ -192,5 +226,110 @@ async fn main() -> Result<()> {
     repl::run_repl(&mut agent, &cli).await?;
     agent.shutdown().await?;
 
+    Ok(())
+}
+
+async fn run_headless(agent: &mut Agent, prompt: &str, cli: &Cli) -> Result<()> {
+    let json_mode = cli.output_format.eq_ignore_ascii_case("json");
+    let events: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
+    let events_for_handler = Arc::clone(&events);
+    let event_handler: Option<zene_core::EventHandler> = if json_mode {
+        Some(Arc::new(move |event: AgentEvent| {
+            if let Some(value) = headless_event_json(&event) {
+                events_for_handler.lock().push(value);
+            }
+        }))
+    } else {
+        None
+    };
+
+    let text = agent
+        .prompt(
+            prompt,
+            PromptOptions {
+                stream: !cli.no_stream && !json_mode,
+                cancel: None,
+                event_handler,
+                quiet: json_mode,
+            },
+        )
+        .await?;
+
+    if json_mode {
+        let payload = serde_json::json!({
+            "sessionId": agent.session().meta.id,
+            "model": agent.config().model,
+            "text": text,
+            "usage": {
+                "prompt_tokens": agent.turn_usage().prompt_tokens,
+                "completion_tokens": agent.turn_usage().completion_tokens,
+                "total_tokens": agent.turn_usage().total_tokens,
+            },
+            "context": {
+                "percent": agent.context_water().usage_percent(),
+                "window": agent.config().compaction.context_window_tokens,
+            },
+            "events": *events.lock(),
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else if cli.no_stream {
+        println!("{text}");
+    } else if !cli.quiet_usage {
+        let usage = agent.turn_usage();
+        eprintln!(
+            "tokens: input {} / output {} ({}) | ctx {}%",
+            usage.prompt_tokens,
+            usage.completion_tokens,
+            usage.total_tokens,
+            agent.context_water().usage_percent()
+        );
+    }
+    Ok(())
+}
+
+fn headless_event_json(event: &AgentEvent) -> Option<serde_json::Value> {
+    match event {
+        AgentEvent::ToolCall { name, arguments } => Some(serde_json::json!({
+            "type": "tool_call",
+            "name": name,
+            "arguments": arguments,
+        })),
+        AgentEvent::ToolResult {
+            name,
+            content,
+            is_error,
+            duration_ms,
+        } => Some(serde_json::json!({
+            "type": "tool_result",
+            "name": name,
+            "content": content,
+            "is_error": is_error,
+            "duration_ms": duration_ms,
+        })),
+        AgentEvent::Error { message } => Some(serde_json::json!({
+            "type": "error",
+            "message": message,
+        })),
+        _ => None,
+    }
+}
+
+async fn run_mcp_doctor(workdir: &std::path::Path) -> Result<()> {
+    use zene_mcp::McpManager;
+    let (manager, tools) = McpManager::connect(workdir).await?;
+    if manager.is_empty() {
+        println!("No MCP servers configured.");
+        println!(
+            "Add servers in {} or {}.",
+            zene_config::mcp_config_path().display(),
+            workdir.join(".zene").join("mcp.json").display()
+        );
+        return Ok(());
+    }
+    let defs = tools.definitions();
+    println!("Connected MCP tools: {}", defs.len());
+    for def in defs {
+        println!("  - {}", def.name);
+    }
     Ok(())
 }

--- a/apps/cli/src/repl.rs
+++ b/apps/cli/src/repl.rs
@@ -49,6 +49,51 @@ pub async fn run_repl(agent: &mut Agent, cli: &Cli) -> Result<()> {
                     eprintln!("Entered plan mode (read-only tools + ExitPlanMode).");
                     continue;
                 }
+                if input == "/compact" || input.starts_with("/compact ") {
+                    let hint = input.strip_prefix("/compact").unwrap_or("").trim();
+                    let hint = if hint.is_empty() { None } else { Some(hint) };
+                    match agent.compact_now(hint).await {
+                        Ok(Some(r)) => println!(
+                            "Compacted {} messages ({} → {} tokens, reason={}). ctx={}%.",
+                            r.compacted_count,
+                            r.stats.tokens_before,
+                            r.stats.tokens_after,
+                            r.reason,
+                            agent.context_water().usage_percent()
+                        ),
+                        Ok(None) => println!("Nothing to compact."),
+                        Err(err) => eprintln!("Compact failed: {err:#}"),
+                    }
+                    continue;
+                }
+                if input == "/rewind" || input.starts_with("/rewind ") {
+                    let id = input.strip_prefix("/rewind").unwrap_or("").trim();
+                    let id = if id.is_empty() { None } else { Some(id) };
+                    match agent.rewind_to_checkpoint(id) {
+                        Ok(cp) => println!("Rewound to checkpoint {cp}."),
+                        Err(err) => eprintln!("Rewind failed: {err:#}"),
+                    }
+                    continue;
+                }
+                if input == "/fork" {
+                    match agent.fork_session() {
+                        Ok(id) => println!("Forked session; now on {id}."),
+                        Err(err) => eprintln!("Fork failed: {err:#}"),
+                    }
+                    continue;
+                }
+                if input == "/session-info" {
+                    let water = agent.context_water();
+                    println!(
+                        "session={}\nmodel={}\ncontext={}% of {}\nmessages={}",
+                        agent.session().meta.id,
+                        agent.config().model,
+                        water.usage_percent(),
+                        agent.config().compaction.context_window_tokens,
+                        agent.session().messages.len()
+                    );
+                    continue;
+                }
                 if input == "/models" {
                     println!("{}", model_config::models_help_message(agent));
                     continue;

--- a/apps/cli/src/tui/app.rs
+++ b/apps/cli/src/tui/app.rs
@@ -132,6 +132,8 @@ pub struct App {
     pub session_id: String,
     pub model: String,
     pub usage: TokenUsage,
+    /// Context window occupancy percent (0..=100) from agent water level.
+    pub context_usage_percent: u8,
     pub permission_mode: PermissionMode,
     pub run_state: RunState,
     /// Short label for the current phase (shown in status bar while running).
@@ -172,6 +174,7 @@ impl App {
             session_id,
             model,
             usage: TokenUsage::default(),
+            context_usage_percent: 0,
             permission_mode,
             run_state: RunState::Idle,
             activity: String::new(),

--- a/apps/cli/src/tui/mod.rs
+++ b/apps/cli/src/tui/mod.rs
@@ -68,7 +68,7 @@ fn run_tui_sync(
     let session_id = agent.session().meta.id.clone();
     let model = config.model.clone();
     let permission_mode = if yolo {
-        PermissionMode::Yolo
+        PermissionMode::BypassPermissions
     } else {
         PermissionMode::parse(&config.permission_mode)
     };
@@ -167,10 +167,15 @@ fn run_tui_sync(
                     }
                 }
                 app.finish_turn();
-                if !quiet_usage {
-                    let usage = agent_rt
-                        .block_on(async { *agent.lock().await.turn_usage() });
-                    app.update_usage(&usage);
+                {
+                    let (usage, pct) = agent_rt.block_on(async {
+                        let g = agent.lock().await;
+                        (*g.turn_usage(), g.context_water().usage_percent())
+                    });
+                    if !quiet_usage {
+                        app.update_usage(&usage);
+                    }
+                    app.context_usage_percent = pct;
                 }
                 app.scroll_to_bottom();
                 try_start_next_pending(
@@ -368,6 +373,98 @@ fn run_tui_sync(
                             app.lines.push(app::ChatLine::Assistant(
                                 "Entered plan mode (read-only tools + ExitPlanMode).".to_string()
                             ));
+                            app.scroll_to_bottom();
+                            continue;
+                        }
+                        if input == "/compact" || input.starts_with("/compact ") {
+                            let hint = input.strip_prefix("/compact").unwrap_or("").trim();
+                            let hint = if hint.is_empty() { None } else { Some(hint) };
+                            let result = agent_rt.block_on(async {
+                                agent.lock().await.compact_now(hint).await
+                            });
+                            match result {
+                                Ok(Some(r)) => {
+                                    let pct = agent_rt.block_on(async {
+                                        agent.lock().await.context_water().usage_percent()
+                                    });
+                                    app.context_usage_percent = pct;
+                                    app.lines.push(app::ChatLine::Assistant(format!(
+                                        "Compacted {} messages ({} → {} tokens, reason={}).",
+                                        r.compacted_count,
+                                        r.stats.tokens_before,
+                                        r.stats.tokens_after,
+                                        r.reason
+                                    )));
+                                }
+                                Ok(None) => app.lines.push(app::ChatLine::Assistant(
+                                    "Nothing to compact.".to_string(),
+                                )),
+                                Err(err) => app.lines.push(app::ChatLine::Error(format!(
+                                    "Compact failed: {err:#}"
+                                ))),
+                            }
+                            app.scroll_to_bottom();
+                            continue;
+                        }
+                        if input == "/rewind" || input.starts_with("/rewind ") {
+                            let id = input
+                                .strip_prefix("/rewind")
+                                .unwrap_or("")
+                                .trim();
+                            let id = if id.is_empty() { None } else { Some(id) };
+                            let result = agent_rt.block_on(async {
+                                agent.lock().await.rewind_to_checkpoint(id)
+                            });
+                            match result {
+                                Ok(cp) => {
+                                    let pct = agent_rt.block_on(async {
+                                        agent.lock().await.context_water().usage_percent()
+                                    });
+                                    app.context_usage_percent = pct;
+                                    app.lines.push(app::ChatLine::Assistant(format!(
+                                        "Rewound to checkpoint {cp}."
+                                    )));
+                                }
+                                Err(err) => app.lines.push(app::ChatLine::Error(format!(
+                                    "Rewind failed: {err:#}"
+                                ))),
+                            }
+                            app.scroll_to_bottom();
+                            continue;
+                        }
+                        if input == "/fork" {
+                            let result = agent_rt.block_on(async {
+                                agent.lock().await.fork_session()
+                            });
+                            match result {
+                                Ok(id) => {
+                                    app.session_id = id.clone();
+                                    app.lines.push(app::ChatLine::Assistant(format!(
+                                        "Forked session; now on {id}."
+                                    )));
+                                }
+                                Err(err) => app.lines.push(app::ChatLine::Error(format!(
+                                    "Fork failed: {err:#}"
+                                ))),
+                            }
+                            app.scroll_to_bottom();
+                            continue;
+                        }
+                        if input == "/session-info" {
+                            let (sid, model, pct, window, msgs) = agent_rt.block_on(async {
+                                let g = agent.lock().await;
+                                (
+                                    g.session().meta.id.clone(),
+                                    g.config().model.clone(),
+                                    g.context_water().usage_percent(),
+                                    g.config().compaction.context_window_tokens,
+                                    g.session().messages.len(),
+                                )
+                            });
+                            app.context_usage_percent = pct;
+                            app.lines.push(app::ChatLine::Assistant(format!(
+                                "session={sid}\nmodel={model}\ncontext={pct}% of {window}\nmessages={msgs}"
+                            )));
                             app.scroll_to_bottom();
                             continue;
                         }

--- a/apps/cli/src/tui/ui.rs
+++ b/apps/cli/src/tui/ui.rs
@@ -294,8 +294,10 @@ fn draw_input(frame: &mut Frame, area: Rect, app: &mut App, visible_rows: u16) {
 
 fn draw_status(frame: &mut Frame, area: Rect, app: &App) {
     let mode = match app.permission_mode {
-        zene_core::PermissionMode::Yolo => "yolo",
-        zene_core::PermissionMode::Manual => "manual",
+        zene_core::PermissionMode::Yolo | zene_core::PermissionMode::BypassPermissions => "bypass",
+        zene_core::PermissionMode::Manual | zene_core::PermissionMode::Default => "default",
+        zene_core::PermissionMode::AcceptEdits => "accept_edits",
+        zene_core::PermissionMode::DontAsk => "dont_ask",
     };
     let state = match app.run_state {
         RunState::Idle => "ready",
@@ -313,9 +315,10 @@ fn draw_status(frame: &mut Frame, area: Rect, app: &App) {
         String::new()
     };
     let mut status = format!(
-        "{spinner}{} | session {} | in {} / out {} ({}) | {} | {}{} ",
+        "{spinner}{} | session {} | ctx {}% | in {} / out {} ({}) | {} | {}{} ",
         app.model,
         &app.session_id[..8.min(app.session_id.len())],
+        app.context_usage_percent,
         app.usage.prompt_tokens,
         app.usage.completion_tokens,
         app.usage.total_tokens,

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -254,6 +254,8 @@ pub struct ZeneConfig {
     #[serde(default = "default_permission_mode")]
     pub permission_mode: String,
     #[serde(default)]
+    pub permission_rules: PermissionRulesConfig,
+    #[serde(default)]
     pub hooks: Vec<HookEntry>,
     #[serde(default)]
     pub web_search: WebSearchConfig,
@@ -266,7 +268,51 @@ fn default_provider() -> String {
 }
 
 fn default_permission_mode() -> String {
-    "manual".to_string()
+    "default".to_string()
+}
+
+/// Permission allow/deny/ask rule loaded from config.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PermissionRuleConfig {
+    /// Tool name pattern (`Bash`, `mcp__*`, `*`).
+    pub pattern: String,
+    /// `allow` | `deny` | `ask`
+    pub action: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PermissionRulesConfig {
+    #[serde(default)]
+    pub allow: Vec<String>,
+    #[serde(default)]
+    pub deny: Vec<String>,
+    #[serde(default)]
+    pub ask: Vec<String>,
+}
+
+impl PermissionRulesConfig {
+    pub fn to_flat_rules(&self) -> Vec<PermissionRuleConfig> {
+        let mut out = Vec::new();
+        for pattern in &self.deny {
+            out.push(PermissionRuleConfig {
+                pattern: pattern.clone(),
+                action: "deny".into(),
+            });
+        }
+        for pattern in &self.allow {
+            out.push(PermissionRuleConfig {
+                pattern: pattern.clone(),
+                action: "allow".into(),
+            });
+        }
+        for pattern in &self.ask {
+            out.push(PermissionRuleConfig {
+                pattern: pattern.clone(),
+                action: "ask".into(),
+            });
+        }
+        out
+    }
 }
 
 fn default_include_workspace_context() -> bool {
@@ -310,6 +356,7 @@ impl Default for ZeneConfig {
             compaction: CompactionConfig::default(),
             include_workspace_context: default_include_workspace_context(),
             permission_mode: default_permission_mode(),
+            permission_rules: PermissionRulesConfig::default(),
             hooks: Vec::new(),
             web_search: WebSearchConfig::default(),
             agent_profile: AgentProfile::default(),

--- a/crates/core/src/compaction.rs
+++ b/crates/core/src/compaction.rs
@@ -4,14 +4,17 @@ use zene_config::CompactionConfig;
 use zene_llm::{ChatClient, ChatRequest, ChatResponse, Message, MessageKind, Role, ToolDefinition};
 use zene_session::SessionRecord;
 
+use crate::input_ladder::{prepare_summary_input, InputLadderStage};
 use crate::tokens::{self, TokenEstimator};
 
-const SUMMARY_SYSTEM_PROMPT: &str = "You summarize coding agent conversations. Preserve key user requests, files discussed or modified, tool outcomes, and current task state. Be concise.";
+const SUMMARY_SYSTEM_PROMPT: &str = "You summarize coding agent conversations. Preserve key user requests, files discussed or modified, tool outcomes, errors and fixes, and current task state. Prefer tight prose over verbatim dumps. Aim for a few hundred to a few thousand words.";
 
 /// Max chars kept in a tool result before truncate-only compaction replaces the body.
 const TRUNCATE_TOOL_RESULT_MAX_CHARS: usize = 800;
 /// Max chars kept in assistant text before truncate-only compaction replaces the body.
 const TRUNCATE_ASSISTANT_TEXT_MAX_CHARS: usize = 1_200;
+/// Cleaned summaries shorter than this are treated as degenerate and retried.
+const MIN_SUMMARY_SEED_CHARS: usize = 80;
 
 pub fn should_compact(estimated_tokens: u32, config: &CompactionConfig) -> bool {
     let threshold =
@@ -77,16 +80,71 @@ pub fn tail_start_index(
 }
 
 pub fn is_context_overflow_error(err: &anyhow::Error) -> bool {
-    let msg = err.to_string().to_lowercase();
-    msg.contains("context length")
-        || msg.contains("context window")
-        || msg.contains("maximum context")
-        || msg.contains("max context")
-        || msg.contains("token limit")
-        || msg.contains("too many tokens")
-        || msg.contains("context overflow")
-        || msg.contains("prompt is too long")
-        || msg.contains("request too large")
+    zene_llm::is_context_overflow(&err.to_string())
+}
+
+/// Whether a compaction summary is too short / empty to be useful.
+pub fn is_degenerate_summary(summary: &str) -> bool {
+    let cleaned = summary.trim();
+    cleaned.is_empty()
+        || cleaned == "(empty summary)"
+        || cleaned.chars().count() < MIN_SUMMARY_SEED_CHARS
+}
+
+/// Find the last real user turn (non-empty content) for full-replace assembly.
+pub fn last_user_query_index(messages: &[Message]) -> Option<usize> {
+    messages.iter().rposition(|m| {
+        m.role == Role::User
+            && m.content
+                .as_ref()
+                .is_some_and(|c| !c.trim().is_empty())
+    })
+}
+
+/// Rebuild history after LLM summarize (grok-style full-replace):
+/// `system + last_user_query + recent_after_query + summary + optional reminder`.
+pub fn assemble_full_replace_history(
+    system: Option<Message>,
+    last_user_query: Option<Message>,
+    recent_after_query: Vec<Message>,
+    summary: String,
+    system_reminder: Option<String>,
+) -> Vec<Message> {
+    let mut out = Vec::new();
+    if let Some(system) = system {
+        out.push(system);
+    }
+    if let Some(query) = last_user_query {
+        out.push(query);
+    }
+    out.extend(recent_after_query);
+    out.push(Message::compaction_summary(format!(
+        "[Previous conversation summary]\n{summary}"
+    )));
+    if let Some(reminder) = system_reminder {
+        if !reminder.trim().is_empty() {
+            out.push(Message::user(format!(
+                "<system-reminder>\n{reminder}\n</system-reminder>"
+            )));
+        }
+    }
+    out
+}
+
+fn build_todo_reminder(session: &SessionRecord) -> Option<String> {
+    if session.todos.is_empty() {
+        return None;
+    }
+    let mut lines = vec!["Active todos:".to_string()];
+    for item in &session.todos {
+        let status = match item.status {
+            zene_session::TodoStatus::Pending => "pending",
+            zene_session::TodoStatus::InProgress => "in_progress",
+            zene_session::TodoStatus::Completed => "completed",
+        };
+        lines.push(format!("- [{status}] {}", item.content));
+    }
+    Some(lines.join("\n"))
 }
 
 fn format_messages_for_summary(messages: &[Message]) -> String {
@@ -118,29 +176,73 @@ fn format_messages_for_summary(messages: &[Message]) -> String {
     out
 }
 
+/// Summarize with input ladder + degenerate-summary retries.
+#[allow(dead_code)]
 pub async fn summarize_messages(
     client: &ChatClient,
     model: &str,
     messages: &[Message],
 ) -> Result<String> {
-    let conversation = format_messages_for_summary(messages);
-    let request = ChatRequest {
-        model: model.to_string(),
-        messages: vec![
-            Message::system(SUMMARY_SYSTEM_PROMPT),
-            Message::user(format!(
-                "Summarize this conversation for a coding agent to continue work:\n\n{conversation}"
-            )),
-        ],
-        tools: Vec::<ToolDefinition>::new(),
-        stream: false,
-    };
+    summarize_messages_with_ladder(client, model, messages, None, &TokenEstimator::default()).await
+}
 
-    let response = client.chat(request).await.context("compaction summary")?;
-    Ok(response
-        .message
-        .content
-        .unwrap_or_else(|| "(empty summary)".to_string()))
+pub async fn summarize_messages_with_ladder(
+    client: &ChatClient,
+    model: &str,
+    messages: &[Message],
+    context_window: Option<u32>,
+    estimator: &TokenEstimator,
+) -> Result<String> {
+    let mut stage = InputLadderStage::Verbatim;
+    let budget = context_window.map(|w| (w as f32 * 0.7).floor() as u32);
+
+    loop {
+        let input = prepare_summary_input(messages, stage, budget, estimator);
+        let conversation = format_messages_for_summary(&input);
+        let request = ChatRequest {
+            model: model.to_string(),
+            messages: vec![
+                Message::system(SUMMARY_SYSTEM_PROMPT),
+                Message::user(format!(
+                    "Summarize this conversation for a coding agent to continue work:\n\n{conversation}"
+                )),
+            ],
+            tools: Vec::<ToolDefinition>::new(),
+            stream: false,
+        };
+
+        match client.chat(request).await {
+            Ok(response) => {
+                let summary = response
+                    .message
+                    .content
+                    .unwrap_or_else(|| "(empty summary)".to_string());
+                if is_degenerate_summary(&summary) {
+                    info!(
+                        stage = stage.as_str(),
+                        summary_chars = summary.chars().count(),
+                        "compaction summary degenerate; retrying"
+                    );
+                    if let Some(next) = stage.next() {
+                        stage = next;
+                        continue;
+                    }
+                }
+                return Ok(summary);
+            }
+            Err(err) if is_context_overflow_error(&err) => {
+                info!(
+                    stage = stage.as_str(),
+                    "compaction summary overflow; stepping input ladder"
+                );
+                match stage.next() {
+                    Some(next) => stage = next,
+                    None => return Err(err).context("compaction summary overflow at lossy stage"),
+                }
+            }
+            Err(err) => return Err(err).context("compaction summary"),
+        }
+    }
 }
 
 pub struct CompactionPlan {
@@ -426,17 +528,23 @@ pub fn apply_compaction_to_messages(
         .first()
         .filter(|m| m.role == Role::System)
         .cloned();
-    let tail = messages[tail_start..].to_vec();
-    let summary_message = Message::compaction_summary(format!(
-        "[Previous conversation summary]\n{summary}"
-    ));
+    let (last_user, recent) = match last_user_query_index(messages) {
+        Some(idx) if idx >= tail_start => {
+            let query = messages[idx].clone();
+            let recent = messages[idx + 1..].to_vec();
+            (Some(query), recent)
+        }
+        Some(idx) => {
+            // Last user query is in the compacted prefix — re-inject it and keep
+            // the planned recent tail (which may include later tool work).
+            let query = messages[idx].clone();
+            let recent = messages[tail_start..].to_vec();
+            (Some(query), recent)
+        }
+        None => (None, messages[tail_start..].to_vec()),
+    };
 
-    messages.clear();
-    if let Some(system) = system {
-        messages.push(system);
-    }
-    messages.push(summary_message);
-    messages.extend(tail);
+    *messages = assemble_full_replace_history(system, last_user, recent, summary, None);
     let _ = compacted_count;
 }
 
@@ -642,8 +750,15 @@ pub async fn compact_session(
     };
 
     let prefix_start = system_prefix_start(&session.messages);
-    let prefix = &session.messages[prefix_start..plan.tail_start];
-    let summary = summarize_messages(client, model, prefix).await?;
+    let prefix = session.messages[prefix_start..plan.tail_start].to_vec();
+    let summary = summarize_messages_with_ladder(
+        client,
+        model,
+        &prefix,
+        Some(config.context_window_tokens),
+        estimator,
+    )
+    .await?;
 
     info!(
         reason = reason,
@@ -651,16 +766,16 @@ pub async fn compact_session(
         tail_messages = session.messages.len() - plan.tail_start,
         summary_chars = summary.len(),
         tokens_before,
-        "context compaction applying LLM summarize"
+        "context compaction applying LLM summarize (full-replace)"
     );
 
-    session.replace_messages_after_compaction_with_stats(
-        summary.clone(),
+    apply_full_replace_to_session(
+        session,
+        summary,
         plan.tail_start,
         plan.compacted_count,
         reason,
-        Some(tokens_before),
-        None,
+        tokens_before,
     );
 
     let tokens_after = estimate_session_tokens(session, tools, estimator);
@@ -676,6 +791,124 @@ pub async fn compact_session(
             tokens_after,
         },
     }))
+}
+
+/// Force a compaction pass (manual `/compact`), skipping truncate/slice when
+/// `force_summarize` is true.
+pub async fn compact_session_forced(
+    session: &mut SessionRecord,
+    client: &ChatClient,
+    model: &str,
+    config: &CompactionConfig,
+    reason: &str,
+    tools: &[ToolDefinition],
+    estimator: &TokenEstimator,
+    force_summarize: bool,
+    user_hint: Option<&str>,
+) -> Result<Option<CompactionResult>> {
+    if !force_summarize {
+        return compact_session(session, client, model, config, reason, tools, estimator).await;
+    }
+
+    let tokens_before = estimate_session_tokens(session, tools, estimator);
+    let plan = match plan_compaction(&session.messages, config, estimator) {
+        Some(plan) => plan,
+        None => {
+            let prefix_start = system_prefix_start(&session.messages);
+            let min_keep = config.min_keep_messages.min(4).max(1);
+            if session.messages.len().saturating_sub(prefix_start) <= min_keep {
+                return Ok(None);
+            }
+            CompactionPlan {
+                tail_start: session.messages.len().saturating_sub(min_keep),
+                compacted_count: session
+                    .messages
+                    .len()
+                    .saturating_sub(prefix_start)
+                    .saturating_sub(min_keep),
+            }
+        }
+    };
+
+    let prefix_start = system_prefix_start(&session.messages);
+    let mut prefix = session.messages[prefix_start..plan.tail_start].to_vec();
+    if let Some(hint) = user_hint {
+        if !hint.trim().is_empty() {
+            prefix.push(Message::user(format!(
+                "Additional compaction guidance from the user: {hint}"
+            )));
+        }
+    }
+
+    let summary = summarize_messages_with_ladder(
+        client,
+        model,
+        &prefix,
+        Some(config.context_window_tokens),
+        estimator,
+    )
+    .await?;
+
+    apply_full_replace_to_session(
+        session,
+        summary,
+        plan.tail_start,
+        plan.compacted_count,
+        reason,
+        tokens_before,
+    );
+
+    let tokens_after = estimate_session_tokens(session, tools, estimator);
+    if let Some(entry) = session.compactions.last_mut() {
+        entry.tokens_after = Some(tokens_after);
+    }
+
+    Ok(Some(CompactionResult {
+        reason: reason.to_string(),
+        compacted_count: plan.compacted_count,
+        stats: CompactionStats {
+            tokens_before,
+            tokens_after,
+        },
+    }))
+}
+
+fn apply_full_replace_to_session(
+    session: &mut SessionRecord,
+    summary: String,
+    tail_start: usize,
+    compacted_count: usize,
+    reason: &str,
+    tokens_before: u32,
+) {
+    let system = session
+        .messages
+        .first()
+        .filter(|m| m.role == Role::System)
+        .cloned();
+    let (last_user, recent) = match last_user_query_index(&session.messages) {
+        Some(idx) if idx >= tail_start => {
+            let query = session.messages[idx].clone();
+            let recent = session.messages[idx + 1..].to_vec();
+            (Some(query), recent)
+        }
+        Some(idx) => {
+            let query = session.messages[idx].clone();
+            let recent = session.messages[tail_start..].to_vec();
+            (Some(query), recent)
+        }
+        None => (None, session.messages[tail_start..].to_vec()),
+    };
+    let reminder = build_todo_reminder(session);
+    session.messages =
+        assemble_full_replace_history(system, last_user, recent, summary.clone(), reminder);
+    session.record_compaction_event(
+        reason,
+        compacted_count,
+        Some(summary),
+        Some(tokens_before),
+        None,
+    );
 }
 
 #[cfg(test)]
@@ -861,6 +1094,34 @@ mod tests {
         )));
         assert!(is_context_overflow_error(&anyhow::anyhow!("prompt is too long")));
         assert!(!is_context_overflow_error(&anyhow::anyhow!("connection reset")));
+    }
+
+    #[test]
+    fn degenerate_summary_detection() {
+        assert!(is_degenerate_summary(""));
+        assert!(is_degenerate_summary("(empty summary)"));
+        assert!(is_degenerate_summary("short"));
+        assert!(!is_degenerate_summary(&"x".repeat(120)));
+    }
+
+    #[test]
+    fn full_replace_keeps_last_user_and_summary() {
+        let history = assemble_full_replace_history(
+            Some(Message::system("sys")),
+            Some(Message::user("do the thing")),
+            vec![Message::assistant("working")],
+            "long enough summary ".repeat(10),
+            Some("Active todos:\n- [pending] ship".into()),
+        );
+        assert_eq!(history[0].role, Role::System);
+        assert_eq!(history[1].content.as_deref(), Some("do the thing"));
+        assert_eq!(history[2].content.as_deref(), Some("working"));
+        assert_eq!(history[3].kind, Some(MessageKind::CompactionSummary));
+        assert!(history[4]
+            .content
+            .as_deref()
+            .unwrap()
+            .contains("system-reminder"));
     }
 
     #[test]

--- a/crates/core/src/context_water.rs
+++ b/crates/core/src/context_water.rs
@@ -1,0 +1,95 @@
+//! Usage-driven context water level (aligned with grok's session signals).
+//!
+//! Prefers the last provider-reported prompt token count when available;
+//! falls back to the heuristic estimator for pre-sample checks.
+
+use zene_config::CompactionConfig;
+use zene_llm::TokenUsage;
+
+/// Live context occupancy used for auto-compact and UI status.
+#[derive(Debug, Clone, Default)]
+pub struct ContextWaterLevel {
+    /// Last successful request `prompt_tokens` from the provider (if any).
+    pub last_prompt_tokens: Option<u32>,
+    /// Last heuristic estimate computed before a sample.
+    pub last_estimate_tokens: Option<u32>,
+    /// Configured context window for the active model.
+    pub context_window_tokens: u32,
+}
+
+impl ContextWaterLevel {
+    pub fn new(context_window_tokens: u32) -> Self {
+        Self {
+            last_prompt_tokens: None,
+            last_estimate_tokens: None,
+            context_window_tokens,
+        }
+    }
+
+    pub fn set_window(&mut self, context_window_tokens: u32) {
+        self.context_window_tokens = context_window_tokens;
+    }
+
+    pub fn record_estimate(&mut self, estimate: u32) {
+        self.last_estimate_tokens = Some(estimate);
+    }
+
+    pub fn record_usage(&mut self, usage: &TokenUsage) {
+        if usage.prompt_tokens > 0 {
+            self.last_prompt_tokens = Some(usage.prompt_tokens.min(u64::from(u32::MAX)) as u32);
+        }
+    }
+
+    /// Effective tokens for compaction trigger: prefer real usage, else estimate.
+    pub fn effective_tokens(&self) -> u32 {
+        match (self.last_prompt_tokens, self.last_estimate_tokens) {
+            (Some(usage), Some(est)) => usage.max(est),
+            (Some(usage), None) => usage,
+            (None, Some(est)) => est,
+            (None, None) => 0,
+        }
+    }
+
+    /// Percentage of the context window used (0..=100).
+    pub fn usage_percent(&self) -> u8 {
+        let window = self.context_window_tokens.max(1);
+        let used = self.effective_tokens() as u64;
+        ((used * 100) / u64::from(window)).min(100) as u8
+    }
+
+    pub fn should_compact(&self, config: &CompactionConfig) -> bool {
+        let threshold =
+            (config.context_window_tokens as f32 * config.trigger_ratio).floor() as u32;
+        self.effective_tokens() >= threshold
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefers_usage_when_higher_than_estimate() {
+        let mut water = ContextWaterLevel::new(1000);
+        water.record_estimate(400);
+        water.record_usage(&TokenUsage {
+            prompt_tokens: 700,
+            completion_tokens: 10,
+            total_tokens: 710,
+        });
+        assert_eq!(water.effective_tokens(), 700);
+        assert_eq!(water.usage_percent(), 70);
+    }
+
+    #[test]
+    fn uses_estimate_when_no_usage() {
+        let mut water = ContextWaterLevel::new(1000);
+        water.record_estimate(850);
+        assert!(water.should_compact(&CompactionConfig {
+            trigger_ratio: 0.85,
+            keep_recent_ratio: 0.25,
+            context_window_tokens: 1000,
+            min_keep_messages: 4,
+        }));
+    }
+}

--- a/crates/core/src/input_ladder.rs
+++ b/crates/core/src/input_ladder.rs
@@ -1,0 +1,172 @@
+//! Compaction input ladder: verbatim → fitted → lossy.
+//!
+//! When summarizing history, start with the full prefix. On context-length
+//! overflow (or when the fitted budget is exceeded), step down to a truncated
+//! then aggressively reduced view so compaction itself can fit.
+
+use zene_llm::{Message, MessageKind, Role};
+
+use crate::tokens::TokenEstimator;
+
+/// Stage of the summarization input ladder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputLadderStage {
+    Verbatim,
+    Fitted,
+    Lossy,
+}
+
+impl InputLadderStage {
+    pub fn next(self) -> Option<Self> {
+        match self {
+            Self::Verbatim => Some(Self::Fitted),
+            Self::Fitted => Some(Self::Lossy),
+            Self::Lossy => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Verbatim => "verbatim",
+            Self::Fitted => "fitted",
+            Self::Lossy => "lossy",
+        }
+    }
+}
+
+const FITTED_TOOL_CHARS: usize = 400;
+const FITTED_ASSISTANT_CHARS: usize = 600;
+const LOSSY_TOOL_CHARS: usize = 120;
+const LOSSY_ASSISTANT_CHARS: usize = 200;
+
+fn truncate_body(content: &str, max_chars: usize) -> String {
+    let count = content.chars().count();
+    if count <= max_chars {
+        return content.to_string();
+    }
+    let kept: String = content.chars().take(max_chars).collect();
+    format!("{kept}…[truncated {count} chars]")
+}
+
+fn shrink_message(message: &Message, tool_max: usize, assistant_max: usize) -> Message {
+    let mut out = message.clone();
+    if let Some(content) = out.content.as_ref() {
+        let max = match out.role {
+            Role::Tool => tool_max,
+            Role::Assistant if out.kind != Some(MessageKind::CompactionSummary) => assistant_max,
+            Role::User => assistant_max.saturating_mul(2),
+            _ => content.chars().count(),
+        };
+        if content.chars().count() > max {
+            out.content = Some(truncate_body(content, max));
+        }
+    }
+    out
+}
+
+/// Prepare messages for the summarizer at the given ladder stage.
+pub fn prepare_summary_input(
+    messages: &[Message],
+    stage: InputLadderStage,
+    token_budget: Option<u32>,
+    estimator: &TokenEstimator,
+) -> Vec<Message> {
+    let prepared: Vec<Message> = match stage {
+        InputLadderStage::Verbatim => messages.to_vec(),
+        InputLadderStage::Fitted => messages
+            .iter()
+            .map(|m| shrink_message(m, FITTED_TOOL_CHARS, FITTED_ASSISTANT_CHARS))
+            .collect(),
+        InputLadderStage::Lossy => {
+            let shrunk: Vec<Message> = messages
+                .iter()
+                .map(|m| shrink_message(m, LOSSY_TOOL_CHARS, LOSSY_ASSISTANT_CHARS))
+                .collect();
+            // Keep only the most recent half of non-system messages when still large.
+            if shrunk.len() > 6 {
+                let keep_from = shrunk.len() / 2;
+                let mut out = Vec::new();
+                if shrunk
+                    .first()
+                    .is_some_and(|m| m.role == Role::System)
+                {
+                    out.push(shrunk[0].clone());
+                    out.extend(shrunk[keep_from.max(1)..].iter().cloned());
+                } else {
+                    out.extend(shrunk[keep_from..].iter().cloned());
+                }
+                out
+            } else {
+                shrunk
+            }
+        }
+    };
+
+    let Some(budget) = token_budget else {
+        return prepared;
+    };
+
+    // Trim from the front (after system) until under budget.
+    let mut out = prepared;
+    while estimator.estimate_messages_tokens(&out) > budget && out.len() > 2 {
+        let drop_at = if out.first().is_some_and(|m| m.role == Role::System) {
+            1
+        } else {
+            0
+        };
+        if drop_at >= out.len().saturating_sub(1) {
+            break;
+        }
+        out.remove(drop_at);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zene_llm::Message;
+
+    #[test]
+    fn fitted_shortens_tool_bodies() {
+        let messages = vec![
+            Message::system("sys"),
+            Message::tool_result("1", "Read", "x".repeat(2000)),
+            Message::user("continue"),
+        ];
+        let fitted = prepare_summary_input(
+            &messages,
+            InputLadderStage::Fitted,
+            None,
+            &TokenEstimator::default(),
+        );
+        let tool = fitted[1].content.as_deref().unwrap();
+        assert!(tool.contains("truncated"));
+        assert!(tool.chars().count() < 500);
+    }
+
+    #[test]
+    fn lossy_drops_older_messages() {
+        let mut messages = vec![Message::system("sys")];
+        for i in 0..20 {
+            messages.push(Message::user(format!("msg {i} {}", "x".repeat(80))));
+        }
+        let lossy = prepare_summary_input(
+            &messages,
+            InputLadderStage::Lossy,
+            Some(200),
+            &TokenEstimator::default(),
+        );
+        assert!(lossy.len() < messages.len());
+        assert_eq!(lossy[0].role, Role::System);
+    }
+
+    #[test]
+    fn stage_advances() {
+        assert_eq!(
+            InputLadderStage::Verbatim.next(),
+            Some(InputLadderStage::Fitted)
+        );
+        assert_eq!(InputLadderStage::Lossy.next(), None);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,7 +10,10 @@ use tracing::{debug, info, warn};
 use zene_config::ZeneConfig;
 use zene_llm::{ChatClient, ChatRequest, Message, StreamEvent, TokenUsage, ToolCall};
 use zene_sandbox::LocalSandbox;
-use zene_session::{AgentRecordWriter, RecordEntry, SessionRecord};
+use zene_session::{
+    fork_session, latest_checkpoint_id, load_checkpoint, restore_checkpoint, save_checkpoint,
+    AgentRecordWriter, RecordEntry, SessionRecord,
+};
 use zene_tools::{
     default_ask_user_prompter, shared_todo_store_from, SharedAskUserPrompter, SharedTodoStore,
     shared_plan_mode, PlanModeState, SharedPlanMode, SharedToolPermission, SubagentEnv,
@@ -19,8 +22,10 @@ use zene_tools::{
 use zene_mcp::McpManager;
 
 mod compaction;
+mod context_water;
 mod events;
 mod hooks;
+mod input_ladder;
 mod permission;
 mod plan_mode;
 mod skills;
@@ -31,14 +36,19 @@ pub mod tool_scheduler;
 mod turn;
 
 use compaction::{
-    apply_overflow_truncate_pass, compact_session, is_context_overflow_error, should_compact,
-    CompactionResult,
+    apply_overflow_truncate_pass, compact_session, compact_session_forced, is_context_overflow_error,
 };
+pub use compaction::CompactionResult;
 mod workspace;
 
+pub use context_water::ContextWaterLevel;
 pub use events::{emit_event, AgentEvent, EventHandler};
 pub use hooks::{HookBlock, HookRunner};
-pub use permission::{approve_tool_call, policy_denied, PermissionGate, PermissionMode, PermissionPrompter, PromptChoice};
+pub use input_ladder::InputLadderStage;
+pub use permission::{
+    approve_tool_call, policy_denied, PermissionGate, PermissionMode, PermissionPrompter,
+    PermissionRule, PromptChoice, RuleAction,
+};
 pub use plan_mode::PlanApprovalPrompter;
 pub use subagent::{run_subagent, ChatBackend, CoreSubagentRunner};
 pub use tokens::{estimate_context, TokenEstimator};
@@ -57,6 +67,7 @@ pub struct Agent {
     sandbox: Arc<LocalSandbox>,
     session: SessionRecord,
     turn_usage: TokenUsage,
+    context_water: ContextWaterLevel,
     active_turn: Option<TurnState>,
     steer_buffer: Arc<Mutex<SteerBuffer>>,
     system_prompt: String,
@@ -120,6 +131,12 @@ impl Agent {
         });
         let hooks = HookRunner::new(hook_entries, workdir.clone());
         let todos = shared_todo_store_from(session.todos.clone());
+        let context_water =
+            ContextWaterLevel::new(config.compaction.context_window_tokens);
+        let permission = shared_permission_with_rules(
+            permission_mode,
+            permission_rules_from_config(&config),
+        );
 
         Ok(Self {
             config,
@@ -128,10 +145,11 @@ impl Agent {
             sandbox: Arc::new(sandbox),
             session,
             turn_usage: TokenUsage::default(),
+            context_water,
             active_turn: None,
             steer_buffer: Arc::new(Mutex::new(SteerBuffer::default())),
             system_prompt,
-            permission: shared_permission(permission_mode),
+            permission,
             plan_mode: shared_plan_mode(),
             plan_approval: Arc::new(default_plan_approval_prompter),
             todos,
@@ -224,6 +242,8 @@ impl Agent {
         }
 
         self.config.refresh_model_context_window();
+        self.context_water
+            .set_window(self.config.compaction.context_window_tokens);
 
         // Recreate the client
         self.client = zene_llm::ChatClient::from_config(&self.config).await?;
@@ -231,6 +251,68 @@ impl Agent {
             .persist_connection_settings()
             .context("save model settings to ~/.zene/config.toml")?;
         Ok(())
+    }
+
+    pub fn context_water(&self) -> &ContextWaterLevel {
+        &self.context_water
+    }
+
+    /// Manually compact the conversation (`/compact [hint]`).
+    pub async fn compact_now(&mut self, user_hint: Option<&str>) -> Result<Option<CompactionResult>> {
+        let tools = self.tool_definitions_for_llm();
+        let estimator = self.token_estimator();
+        let _ = save_checkpoint(&self.session, "pre_manual_compact");
+        let result = compact_session_forced(
+            &mut self.session,
+            &self.client,
+            &self.config.model,
+            &self.config.compaction,
+            "manual",
+            &tools,
+            &estimator,
+            true,
+            user_hint,
+        )
+        .await?;
+        if let Some(result) = &result {
+            self.record_compaction(result)?;
+            let _ = save_checkpoint(&self.session, "post_manual_compact");
+            self.sync_context_water_from_estimate();
+        }
+        self.session.ensure_system_message(&self.system_prompt);
+        self.session.save()?;
+        Ok(result)
+    }
+
+    /// Rewind to the latest compaction checkpoint (or a specific id).
+    pub fn rewind_to_checkpoint(&mut self, checkpoint_id: Option<&str>) -> Result<String> {
+        let id = match checkpoint_id {
+            Some(id) => id.to_string(),
+            None => latest_checkpoint_id(&self.session.meta.id)?
+                .ok_or_else(|| anyhow::anyhow!("no compaction checkpoint available to rewind"))?,
+        };
+        let checkpoint = load_checkpoint(&self.session.meta.id, &id)?;
+        restore_checkpoint(&mut self.session, &checkpoint);
+        self.session.ensure_system_message(&self.system_prompt);
+        if let Some(tokens) = self.session.context_tokens_used {
+            self.context_water.last_prompt_tokens = Some(tokens);
+            self.context_water.last_estimate_tokens = Some(tokens);
+        }
+        self.session.save()?;
+        Ok(id)
+    }
+
+    /// Fork the current session into a new saved session and switch to it.
+    pub fn fork_session(&mut self) -> Result<String> {
+        let workdir = self.sandbox.workdir().to_path_buf();
+        let forked = fork_session(&self.session, &workdir);
+        let id = forked.meta.id.clone();
+        forked.save()?;
+        let _ = save_checkpoint(&forked, "fork");
+        self.session = forked;
+        self.record_writer = AgentRecordWriter::for_session(&id)?;
+        self.todos = shared_todo_store_from(self.session.todos.clone());
+        Ok(id)
     }
 
     pub fn session(&self) -> &SessionRecord {
@@ -438,6 +520,11 @@ impl Agent {
                     "llm response usage"
                 );
                 self.turn_usage.accumulate(&usage);
+                self.context_water.record_usage(&usage);
+                self.session.update_context_usage(
+                    self.context_water.effective_tokens(),
+                    self.config.compaction.context_window_tokens,
+                );
             }
 
             if had_tool_calls {
@@ -525,16 +612,22 @@ impl Agent {
         let messages = self.build_messages();
         let tools = self.tool_definitions_for_llm();
         let estimated_tokens = self.estimated_context_tokens(&messages, &tools);
+        self.context_water.record_estimate(estimated_tokens as u32);
+        self.context_water
+            .set_window(self.config.compaction.context_window_tokens);
         debug!(
             estimated_context_tokens = estimated_tokens,
+            effective_tokens = self.context_water.effective_tokens(),
+            usage_percent = self.context_water.usage_percent(),
             message_count = messages.len(),
             tool_count = tools.len(),
             chars_per_token = self.config.chars_per_token_for_model(),
-            "llm request context estimate"
+            "llm request context water level"
         );
-        self.warn_if_near_context_limit(estimated_tokens);
+        self.warn_if_near_context_limit(self.context_water.effective_tokens() as usize);
 
-        if should_compact(estimated_tokens as u32, &self.config.compaction) {
+        if self.context_water.should_compact(&self.config.compaction) {
+            let _ = save_checkpoint(&self.session, "pre_auto_compact");
             let estimator = self.token_estimator();
             if let Some(result) = compact_session(
                 &mut self.session,
@@ -548,11 +641,26 @@ impl Agent {
             .await?
             {
                 self.record_compaction(&result)?;
+                let _ = save_checkpoint(&self.session, "post_auto_compact");
+                self.sync_context_water_from_estimate();
             }
             self.session
                 .ensure_system_message(&self.system_prompt);
         }
         Ok(())
+    }
+
+    fn sync_context_water_from_estimate(&mut self) {
+        let messages = self.build_messages();
+        let tools = self.tool_definitions_for_llm();
+        let estimated = self.estimated_context_tokens(&messages, &tools) as u32;
+        self.context_water.record_estimate(estimated);
+        // After compaction, prefer the fresh estimate over stale provider usage.
+        self.context_water.last_prompt_tokens = Some(estimated);
+        self.session.update_context_usage(
+            estimated,
+            self.config.compaction.context_window_tokens,
+        );
     }
 
     async fn run_llm_step(
@@ -613,6 +721,7 @@ impl Agent {
                     }
                     if !overflow_summarized {
                         overflow_summarized = true;
+                        let _ = save_checkpoint(&self.session, "pre_overflow_compact");
                         let estimator = self.token_estimator();
                         if let Some(result) = compact_session(
                             &mut self.session,
@@ -626,6 +735,8 @@ impl Agent {
                         .await?
                         {
                             self.record_compaction(&result)?;
+                            let _ = save_checkpoint(&self.session, "post_overflow_compact");
+                            self.sync_context_water_from_estimate();
                         }
                         self.session
                             .ensure_system_message(&self.system_prompt);
@@ -1028,8 +1139,31 @@ fn truncate(input: &str, max: usize) -> String {
     }
 }
 
-fn shared_permission(mode: PermissionMode) -> SharedToolPermission {
-    Arc::new(Mutex::new(PermissionGate::new(mode)))
+fn shared_permission_with_rules(
+    mode: PermissionMode,
+    rules: Vec<PermissionRule>,
+) -> SharedToolPermission {
+    Arc::new(Mutex::new(PermissionGate::new(mode).with_rules(rules)))
+}
+
+fn permission_rules_from_config(config: &ZeneConfig) -> Vec<PermissionRule> {
+    config
+        .permission_rules
+        .to_flat_rules()
+        .into_iter()
+        .filter_map(|rule| {
+            let action = match rule.action.trim().to_lowercase().as_str() {
+                "allow" => RuleAction::Allow,
+                "deny" => RuleAction::Deny,
+                "ask" => RuleAction::Ask,
+                _ => return None,
+            };
+            Some(PermissionRule {
+                pattern: rule.pattern,
+                action,
+            })
+        })
+        .collect()
 }
 
 fn merge_event_handler(

--- a/crates/core/src/permission.rs
+++ b/crates/core/src/permission.rs
@@ -4,9 +4,19 @@ use std::io::{self, Write};
 use serde_json::Value;
 use zene_tools::ToolPermission;
 
+/// Permission modes aligned with grok-style agent safety.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PermissionMode {
+    /// Ask before Write / Edit / Bash / MCP (default).
     #[default]
+    Default,
+    /// Auto-approve file edits (Write/Edit); still ask for Bash / MCP.
+    AcceptEdits,
+    /// Never prompt; deny anything that would have required confirmation.
+    DontAsk,
+    /// Auto-approve all gated tools (alias: yolo / bypassPermissions).
+    BypassPermissions,
+    /// Legacy aliases kept for config compatibility.
     Manual,
     Yolo,
 }
@@ -14,9 +24,39 @@ pub enum PermissionMode {
 impl PermissionMode {
     pub fn parse(s: &str) -> Self {
         match s.trim().to_lowercase().as_str() {
-            "yolo" => Self::Yolo,
-            _ => Self::Manual,
+            "yolo" | "bypass" | "bypasspermissions" | "bypass_permissions" => {
+                Self::BypassPermissions
+            }
+            "accept_edits" | "acceptedits" | "accept-edits" => Self::AcceptEdits,
+            "dont_ask" | "dontask" | "dont-ask" => Self::DontAsk,
+            "plan" => Self::Default, // plan mode is orthogonal; treat as default ask
+            "manual" | "default" | "" => Self::Default,
+            _ => Self::Default,
         }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Default | Self::Manual => "default",
+            Self::AcceptEdits => "accept_edits",
+            Self::DontAsk => "dont_ask",
+            Self::BypassPermissions | Self::Yolo => "bypass",
+        }
+    }
+
+    fn auto_approves_all(self) -> bool {
+        matches!(self, Self::BypassPermissions | Self::Yolo)
+    }
+
+    fn auto_approves_edits(self) -> bool {
+        matches!(
+            self,
+            Self::AcceptEdits | Self::BypassPermissions | Self::Yolo
+        )
+    }
+
+    fn denies_without_prompt(self) -> bool {
+        matches!(self, Self::DontAsk)
     }
 }
 
@@ -27,12 +67,43 @@ pub enum PromptChoice {
     Deny,
 }
 
+/// A single allow/deny/ask rule matched against tool name (glob-ish prefix/suffix `*`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PermissionRule {
+    pub pattern: String,
+    pub action: RuleAction,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuleAction {
+    Allow,
+    Deny,
+    Ask,
+}
+
+impl PermissionRule {
+    pub fn matches(&self, tool_name: &str) -> bool {
+        let pat = self.pattern.as_str();
+        if pat == "*" {
+            return true;
+        }
+        if let Some(prefix) = pat.strip_suffix('*') {
+            return tool_name.starts_with(prefix);
+        }
+        if let Some(suffix) = pat.strip_prefix('*') {
+            return tool_name.ends_with(suffix);
+        }
+        tool_name == pat
+    }
+}
+
 pub type PermissionPrompter = dyn Fn(&str, &str) -> io::Result<PromptChoice> + Send + Sync;
 
 /// Gate for Write / Edit / Bash before execution.
 pub struct PermissionGate {
     mode: PermissionMode,
     approved_session: HashSet<String>,
+    rules: Vec<PermissionRule>,
     prompter: Box<PermissionPrompter>,
 }
 
@@ -41,6 +112,7 @@ impl PermissionGate {
         Self {
             mode,
             approved_session: HashSet::new(),
+            rules: Vec::new(),
             prompter: Box::new(default_prompter),
         }
     }
@@ -49,16 +121,35 @@ impl PermissionGate {
         Self {
             mode,
             approved_session: HashSet::new(),
+            rules: Vec::new(),
             prompter,
         }
     }
 
+    pub fn with_rules(mut self, rules: Vec<PermissionRule>) -> Self {
+        self.rules = rules;
+        self
+    }
+
+    pub fn set_rules(&mut self, rules: Vec<PermissionRule>) {
+        self.rules = rules;
+    }
+
     pub fn mode(&self) -> PermissionMode {
-        self.mode
+        // Normalize legacy aliases for display.
+        match self.mode {
+            PermissionMode::Manual => PermissionMode::Default,
+            PermissionMode::Yolo => PermissionMode::BypassPermissions,
+            other => other,
+        }
     }
 
     pub fn requires_confirmation(tool_name: &str) -> bool {
         matches!(tool_name, "Write" | "Edit" | "Bash") || tool_name.starts_with("mcp__")
+    }
+
+    fn matching_rule(&self, tool_name: &str) -> Option<&PermissionRule> {
+        self.rules.iter().find(|r| r.matches(tool_name))
     }
 
     /// Returns `Ok(true)` if the tool may run, `Ok(false)` if denied.
@@ -67,8 +158,37 @@ impl PermissionGate {
             return Ok(false);
         }
 
-        if self.mode == PermissionMode::Yolo || !Self::requires_confirmation(tool_name) {
-            return Ok(true);
+        let forced_ask = matches!(
+            self.matching_rule(tool_name).map(|r| r.action),
+            Some(RuleAction::Ask)
+        );
+
+        if let Some(rule) = self.matching_rule(tool_name) {
+            match rule.action {
+                RuleAction::Allow => return Ok(true),
+                RuleAction::Deny => return Ok(false),
+                RuleAction::Ask => { /* force prompt below */ }
+            }
+        }
+
+        if !forced_ask {
+            if self.mode.auto_approves_all() {
+                return Ok(true);
+            }
+
+            if !Self::requires_confirmation(tool_name) {
+                return Ok(true);
+            }
+
+            if self.mode.auto_approves_edits() && matches!(tool_name, "Write" | "Edit") {
+                return Ok(true);
+            }
+
+            if self.mode.denies_without_prompt() {
+                return Ok(false);
+            }
+        } else if self.mode.denies_without_prompt() {
+            return Ok(false);
         }
 
         if let Some(key) = session_approval_key(tool_name, arguments) {
@@ -215,6 +335,67 @@ mod tests {
     }
 
     #[test]
+    fn accept_edits_auto_allows_write_but_asks_bash() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_clone = Arc::clone(&calls);
+        let mut gate = PermissionGate::with_prompter(PermissionMode::AcceptEdits, {
+            Box::new(move |_tool, _args| {
+                calls_clone.fetch_add(1, Ordering::SeqCst);
+                Ok(PromptChoice::AllowOnce)
+            })
+        });
+        assert!(gate
+            .check("Write", r#"{"path":"a.txt","content":"x"}"#)
+            .unwrap());
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(gate.check("Bash", r#"{"command":"ls"}"#).unwrap());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn dont_ask_denies_gated_tools() {
+        let mut gate = PermissionGate::new(PermissionMode::DontAsk);
+        assert!(!gate
+            .check("Bash", r#"{"command":"ls"}"#)
+            .unwrap());
+        assert!(gate.check("Read", r#"{"path":"a.txt"}"#).unwrap());
+    }
+
+    #[test]
+    fn deny_rule_beats_bypass() {
+        let mut gate = PermissionGate::new(PermissionMode::BypassPermissions).with_rules(vec![
+            PermissionRule {
+                pattern: "Bash".into(),
+                action: RuleAction::Deny,
+            },
+        ]);
+        assert!(!gate.check("Bash", r#"{"command":"ls"}"#).unwrap());
+        assert!(gate
+            .check("Write", r#"{"path":"a.txt","content":"x"}"#)
+            .unwrap());
+    }
+
+    #[test]
+    fn allow_rule_skips_prompt() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_clone = Arc::clone(&calls);
+        let mut gate = PermissionGate::with_prompter(PermissionMode::Default, {
+            Box::new(move |_tool, _args| {
+                calls_clone.fetch_add(1, Ordering::SeqCst);
+                Ok(PromptChoice::Deny)
+            })
+        })
+        .with_rules(vec![PermissionRule {
+            pattern: "mcp__*".into(),
+            action: RuleAction::Allow,
+        }]);
+        assert!(gate
+            .check("mcp__git__status", r#"{"repo":"."}"#)
+            .unwrap());
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
     fn manual_prompts_and_session_approve() {
         let mut gate = PermissionGate::with_prompter(PermissionMode::Manual, {
             Box::new(|_tool, _args| Ok(PromptChoice::AllowSession))
@@ -272,5 +453,13 @@ mod tests {
             session_approval_key("Bash", r#"{"command":"ls"}"#).as_deref(),
             Some("Bash:ls")
         );
+    }
+
+    #[test]
+    fn parse_aliases() {
+        assert_eq!(PermissionMode::parse("yolo"), PermissionMode::BypassPermissions);
+        assert_eq!(PermissionMode::parse("accept_edits"), PermissionMode::AcceptEdits);
+        assert_eq!(PermissionMode::parse("dont_ask"), PermissionMode::DontAsk);
+        assert_eq!(PermissionMode::parse("manual"), PermissionMode::Default);
     }
 }

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -13,6 +13,9 @@ pub use message::{ContentPart, Message, MessageKind, Role, ToolCall};
 pub use models::context_window_for_model;
 pub use zene_config::default_context_window_for_model;
 pub use provider::{ChatRequest, ChatResponse, Provider, StreamEvent};
-pub use retry::{is_context_overflow, is_retryable, with_llm_retry, MAX_LLM_ATTEMPTS};
+pub use retry::{
+    classify_llm_error, is_context_overflow, is_retryable, with_llm_retry, LlmErrorClass,
+    MAX_LLM_ATTEMPTS, RATE_LIMIT_RETRY_THRESHOLD,
+};
 pub use tool::ToolDefinition;
 pub use usage::{parse_usage_from_raw, TokenUsage};

--- a/crates/llm/src/retry.rs
+++ b/crates/llm/src/retry.rs
@@ -3,49 +3,69 @@ use std::time::Duration;
 use anyhow::Result;
 use tokio::time::sleep;
 
-pub const MAX_LLM_ATTEMPTS: u32 = 3;
+/// Default max retries for transient server/transport errors (~aligned with grok budget).
+pub const MAX_LLM_ATTEMPTS: u32 = 5;
+/// Rate-limit (429) retries are capped lower to avoid long waits.
+pub const RATE_LIMIT_RETRY_THRESHOLD: u32 = 2;
 
 const CONTEXT_OVERFLOW_KEYWORDS: &[&str] = &[
     "context length",
     "context_length",
+    "context window",
     "maximum context",
     "max context",
     "token limit",
     "tokens exceed",
     "too many tokens",
     "input is too long",
+    "prompt is too long",
     "request too large",
+    "context overflow",
+    "model_context_window_exceeded",
 ];
 
-/// HTTP 400-style context overflow — do not retry; compaction should handle.
+/// Error class for sampling decisions (retry / compact / fatal).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LlmErrorClass {
+    ContextOverflow,
+    RateLimited,
+    Transient,
+    EmptyResponse,
+    Fatal,
+}
+
+/// Context overflow — do not retry at the transport layer; compaction should handle.
 pub fn is_context_overflow(err: &str) -> bool {
     let lower = err.to_ascii_lowercase();
-    if !(lower.contains("400") || lower.contains("bad request") || lower.contains("invalid_request")) {
-        return CONTEXT_OVERFLOW_KEYWORDS
-            .iter()
-            .any(|kw| lower.contains(kw));
-    }
     CONTEXT_OVERFLOW_KEYWORDS
         .iter()
         .any(|kw| lower.contains(kw))
 }
 
-/// Retryable: transport failures, rate limits, server errors.
-pub fn is_retryable(err: &str) -> bool {
-    if is_context_overflow(err) {
-        return false;
-    }
-    let lower = err.to_ascii_lowercase();
-    if lower.contains("429")
+fn is_rate_limited(lower: &str) -> bool {
+    lower.contains("429")
         || lower.contains("too many requests")
         || lower.contains("rate limit")
-    {
-        return true;
-    }
+}
+
+fn is_auth_or_client_fatal(lower: &str) -> bool {
+    lower.contains("401")
+        || lower.contains("403")
+        || lower.contains("404")
+        || lower.contains("invalid_api_key")
+        || lower.contains("authentication")
+        || lower.contains("unauthorized")
+        || (lower.contains("400") && !is_context_overflow(lower))
+        || lower.contains("invalid_request")
+        || lower.contains("invalid tool")
+}
+
+fn is_transient_transport(lower: &str) -> bool {
     if lower.contains("502")
         || lower.contains("503")
         || lower.contains("504")
         || lower.contains("500")
+        || lower.contains("520")
         || lower.contains("internal server error")
         || lower.contains("bad gateway")
         || lower.contains("service unavailable")
@@ -66,6 +86,40 @@ pub fn is_retryable(err: &str) -> bool {
         || lower.contains("network")
 }
 
+fn is_empty_response(lower: &str) -> bool {
+    lower.contains("empty response")
+        || lower.contains("no content")
+        || lower.contains("model returned no")
+}
+
+pub fn classify_llm_error(err: &str) -> LlmErrorClass {
+    let lower = err.to_ascii_lowercase();
+    if is_context_overflow(&lower) {
+        return LlmErrorClass::ContextOverflow;
+    }
+    if is_empty_response(&lower) {
+        return LlmErrorClass::EmptyResponse;
+    }
+    if is_rate_limited(&lower) {
+        return LlmErrorClass::RateLimited;
+    }
+    if is_auth_or_client_fatal(&lower) {
+        return LlmErrorClass::Fatal;
+    }
+    if is_transient_transport(&lower) {
+        return LlmErrorClass::Transient;
+    }
+    LlmErrorClass::Fatal
+}
+
+/// Retryable: transport failures, rate limits, server errors, empty responses.
+pub fn is_retryable(err: &str) -> bool {
+    matches!(
+        classify_llm_error(err),
+        LlmErrorClass::RateLimited | LlmErrorClass::Transient | LlmErrorClass::EmptyResponse
+    )
+}
+
 pub fn retry_delay(attempt: u32) -> Duration {
     let ms = 500u64.saturating_mul(1u64 << attempt.saturating_sub(1).min(4));
     Duration::from_millis(ms.min(8_000))
@@ -76,16 +130,28 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = Result<T>>,
 {
+    let mut rate_limit_hits = 0u32;
     for attempt in 1..=MAX_LLM_ATTEMPTS {
         match operation().await {
             Ok(value) => return Ok(value),
             Err(err) => {
                 let msg = err.to_string();
-                if is_context_overflow(&msg) {
-                    return Err(err);
-                }
-                if !is_retryable(&msg) || attempt >= MAX_LLM_ATTEMPTS {
-                    return Err(err);
+                let class = classify_llm_error(&msg);
+                match class {
+                    LlmErrorClass::ContextOverflow | LlmErrorClass::Fatal => return Err(err),
+                    LlmErrorClass::RateLimited => {
+                        rate_limit_hits += 1;
+                        if rate_limit_hits > RATE_LIMIT_RETRY_THRESHOLD
+                            || attempt >= MAX_LLM_ATTEMPTS
+                        {
+                            return Err(err);
+                        }
+                    }
+                    LlmErrorClass::Transient | LlmErrorClass::EmptyResponse => {
+                        if attempt >= MAX_LLM_ATTEMPTS {
+                            return Err(err);
+                        }
+                    }
                 }
                 sleep(retry_delay(attempt)).await;
             }
@@ -103,6 +169,12 @@ mod tests {
         let err = "400 bad request: context length exceeded for model";
         assert!(is_context_overflow(err));
         assert!(!is_retryable(err));
+        assert_eq!(classify_llm_error(err), LlmErrorClass::ContextOverflow);
+    }
+
+    #[test]
+    fn prompt_too_long_is_overflow() {
+        assert!(is_context_overflow("prompt is too long"));
     }
 
     #[test]
@@ -110,6 +182,7 @@ mod tests {
         let err = "HTTP 429 Too Many Requests";
         assert!(!is_context_overflow(err));
         assert!(is_retryable(err));
+        assert_eq!(classify_llm_error(err), LlmErrorClass::RateLimited);
     }
 
     #[test]
@@ -123,8 +196,22 @@ mod tests {
     }
 
     #[test]
+    fn auth_error_not_retryable() {
+        assert!(!is_retryable("401 unauthorized: invalid api key"));
+    }
+
+    #[test]
     fn connection_error_retryable() {
         assert!(is_retryable("reqwest::Error: connection timed out"));
+    }
+
+    #[test]
+    fn empty_response_retryable() {
+        assert!(is_retryable("empty response from model"));
+        assert_eq!(
+            classify_llm_error("empty response from model"),
+            LlmErrorClass::EmptyResponse
+        );
     }
 
     #[test]

--- a/crates/session/src/checkpoint.rs
+++ b/crates/session/src/checkpoint.rs
@@ -1,0 +1,153 @@
+//! Compaction checkpoints for rewind / fork (aligned with grok compaction_checkpoints).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{session_record_dir, CompactionEntry, SessionRecord, TodoItem};
+use zene_llm::Message;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionCheckpoint {
+    pub id: String,
+    pub created_at: DateTime<Utc>,
+    pub reason: String,
+    pub messages: Vec<Message>,
+    pub todos: Vec<TodoItem>,
+    pub compactions: Vec<CompactionEntry>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window_usage: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_tokens_used: Option<u32>,
+}
+
+impl SessionCheckpoint {
+    pub fn from_session(session: &SessionRecord, reason: &str) -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            created_at: Utc::now(),
+            reason: reason.to_string(),
+            messages: session.messages.clone(),
+            todos: session.todos.clone(),
+            compactions: session.compactions.clone(),
+            context_window_usage: session.context_window_usage,
+            context_tokens_used: session.context_tokens_used,
+        }
+    }
+}
+
+pub fn checkpoints_dir(session_id: &str) -> PathBuf {
+    session_record_dir(session_id).join("compaction_checkpoints")
+}
+
+pub fn save_checkpoint(session: &SessionRecord, reason: &str) -> Result<SessionCheckpoint> {
+    let dir = checkpoints_dir(&session.meta.id);
+    fs::create_dir_all(&dir).context("create compaction_checkpoints dir")?;
+    let checkpoint = SessionCheckpoint::from_session(session, reason);
+    let path = dir.join(format!("{}.json", checkpoint.id));
+    let raw = serde_json::to_string_pretty(&checkpoint).context("serialize checkpoint")?;
+    fs::write(&path, raw).with_context(|| format!("write checkpoint {}", path.display()))?;
+
+    // Keep a pointer to the latest checkpoint for `/rewind`.
+    let latest = dir.join("LATEST");
+    fs::write(&latest, checkpoint.id.as_bytes()).context("write LATEST checkpoint pointer")?;
+    Ok(checkpoint)
+}
+
+pub fn load_checkpoint(session_id: &str, checkpoint_id: &str) -> Result<SessionCheckpoint> {
+    let path = checkpoints_dir(session_id).join(format!("{checkpoint_id}.json"));
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("read checkpoint {}", path.display()))?;
+    serde_json::from_str(&raw).context("parse checkpoint")
+}
+
+pub fn latest_checkpoint_id(session_id: &str) -> Result<Option<String>> {
+    let path = checkpoints_dir(session_id).join("LATEST");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let id = fs::read_to_string(&path).context("read LATEST checkpoint")?;
+    let id = id.trim();
+    if id.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(id.to_string()))
+    }
+}
+
+pub fn list_checkpoints(session_id: &str) -> Result<Vec<SessionCheckpoint>> {
+    let dir = checkpoints_dir(session_id);
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in fs::read_dir(&dir).context("read checkpoints dir")? {
+        let entry = entry.context("read checkpoint entry")?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let raw = fs::read_to_string(&path).context("read checkpoint file")?;
+        if let Ok(cp) = serde_json::from_str::<SessionCheckpoint>(&raw) {
+            out.push(cp);
+        }
+    }
+    out.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    Ok(out)
+}
+
+pub fn restore_checkpoint(session: &mut SessionRecord, checkpoint: &SessionCheckpoint) {
+    session.messages = checkpoint.messages.clone();
+    session.todos = checkpoint.todos.clone();
+    session.compactions = checkpoint.compactions.clone();
+    session.context_window_usage = checkpoint.context_window_usage;
+    session.context_tokens_used = checkpoint.context_tokens_used;
+    session.meta.updated_at = Utc::now();
+}
+
+/// Fork a session into a new id, copying messages/todos/compactions.
+pub fn fork_session(session: &SessionRecord, workdir: &Path) -> SessionRecord {
+    let mut forked = SessionRecord::new(workdir);
+    forked.meta.title = format!("{} (fork)", session.meta.title);
+    forked.messages = session.messages.clone();
+    forked.todos = session.todos.clone();
+    forked.compactions = session.compactions.clone();
+    forked.context_window_usage = session.context_window_usage;
+    forked.context_tokens_used = session.context_tokens_used;
+    forked
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SessionRecord;
+    use std::env;
+    use std::path::Path;
+
+    #[test]
+    fn checkpoint_roundtrip() {
+        let _guard = crate::ZENE_HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let prev = env::var("ZENE_HOME").ok();
+        env::set_var("ZENE_HOME", dir.path());
+        let mut session = SessionRecord::new(Path::new("."));
+        session.ensure_system_message("sys");
+        session.push_message(zene_llm::Message::user("hi"));
+        let cp = save_checkpoint(&session, "test").expect("save");
+        session.push_message(zene_llm::Message::assistant("later"));
+        let loaded = load_checkpoint(&session.meta.id, &cp.id).expect("load");
+        assert_eq!(loaded.messages.len(), 2);
+        restore_checkpoint(&mut session, &loaded);
+        assert_eq!(session.messages.len(), 2);
+        match prev {
+            Some(v) => env::set_var("ZENE_HOME", v),
+            None => env::remove_var("ZENE_HOME"),
+        }
+    }
+}

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -1,3 +1,4 @@
+mod checkpoint;
 mod record;
 mod todo;
 
@@ -11,6 +12,10 @@ use uuid::Uuid;
 use zene_config::{sessions_dir, workdir_slug, zene_home};
 use zene_llm::Message;
 
+pub use checkpoint::{
+    fork_session, latest_checkpoint_id, list_checkpoints, load_checkpoint, restore_checkpoint,
+    save_checkpoint, SessionCheckpoint,
+};
 pub use todo::{TodoItem, TodoStatus};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,6 +49,12 @@ pub struct SessionRecord {
     pub compactions: Vec<CompactionEntry>,
     #[serde(default)]
     pub todos: Vec<TodoItem>,
+    /// Last observed context occupancy percent (0..=100).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window_usage: Option<u8>,
+    /// Last observed effective prompt tokens used for water-level checks.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_tokens_used: Option<u32>,
 }
 
 impl SessionRecord {
@@ -60,7 +71,18 @@ impl SessionRecord {
             messages: Vec::new(),
             compactions: Vec::new(),
             todos: Vec::new(),
+            context_window_usage: None,
+            context_tokens_used: None,
         }
+    }
+
+    pub fn update_context_usage(&mut self, tokens_used: u32, context_window: u32) {
+        self.context_tokens_used = Some(tokens_used);
+        if context_window > 0 {
+            let pct = ((u64::from(tokens_used) * 100) / u64::from(context_window)).min(100) as u8;
+            self.context_window_usage = Some(pct);
+        }
+        self.meta.updated_at = Utc::now();
     }
 
     pub fn push_message(&mut self, message: Message) {
@@ -234,6 +256,9 @@ pub fn ensure_zene_home() -> Result<()> {
 }
 
 pub use record::{export_session, record_path, session_record_dir, AgentRecordWriter, RecordEntry};
+
+#[cfg(test)]
+pub(crate) static ZENE_HOME_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[cfg(test)]
 mod tests {

--- a/crates/session/src/record.rs
+++ b/crates/session/src/record.rs
@@ -156,8 +156,9 @@ mod tests {
     use std::env;
 
     fn with_temp_home<F: FnOnce()>(test: F) {
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = LOCK.lock().expect("test lock");
+        let _guard = crate::ZENE_HOME_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let temp = tempfile::tempdir().expect("tempdir");
         let prev = env::var("ZENE_HOME").ok();
         env::set_var("ZENE_HOME", temp.path());

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -70,20 +70,42 @@ Config (`compaction` in `config.toml`):
 On provider context-overflow errors in `run_llm_step`:
 
 1. **First retry** — phase-1 truncate pass only (`apply_overflow_truncate_pass`)
-2. **Second retry** — full compaction pipeline (phases 1→3)
+2. **Second retry** — full compaction pipeline (phases 1→3) with input ladder
 
 Avoids paying for LLM summarize when truncation alone fixes the overflow.
 
-## Permission policy (lite)
+### Usage-driven water level
 
-- Hard deny **Write/Edit** on paths containing `node_modules` or `.git` segments (aligned with sandbox `.git` write deny).
-- Applies in all permission modes including `yolo`.
-- User-facing message via `PermissionGate::permission_denied_message`.
+`ContextWaterLevel` (`context_water.rs`) tracks the last provider `prompt_tokens` and the heuristic estimate. Auto-compact triggers on `max(usage, estimate)` vs `context_window * trigger_ratio` (default 85%). Session persists `context_window_usage` / `context_tokens_used`; TUI status shows `ctx N%`.
+
+### Full-replace assemble + input ladder
+
+LLM summarize rebuilds history as:
+
+`system + last_user_query + recent_after_query + compaction_summary + optional <system-reminder> (todos)`
+
+Summarizer input steps `verbatim → fitted → lossy` on overflow or degenerate (too-short) summaries (`input_ladder.rs`). Manual `/compact [hint]` forces summarize and writes compaction checkpoints.
+
+## Permission modes (grok-aligned)
+
+| Mode | Behavior |
+|------|----------|
+| `default` / `manual` | Ask for Write/Edit/Bash/MCP |
+| `accept_edits` | Auto-approve Write/Edit; ask Bash/MCP |
+| `dont_ask` | Deny gated tools without prompting |
+| `bypass` / `yolo` | Auto-approve gated tools |
+
+Config `[permission_rules]` supports `allow` / `deny` / `ask` patterns (`Bash`, `mcp__*`). Hard deny Write/Edit under `node_modules` / `.git` still applies in all modes. Explicit `ask` rules force a prompt even under bypass.
+
+## Session recovery
+
+Before/after compaction, checkpoints are saved under `~/.zene/sessions/<id>/compaction_checkpoints/`. Slash commands: `/rewind [id]`, `/fork`, `/session-info`.
 
 ## LLM layer
 
 - `OpenAiCompatibleProvider` (`crates/llm`) intentionally depends on [`unigateway-sdk`](https://crates.io/crates/unigateway-sdk) from **crates.io** (not a sibling path repo). It drives proxy chat via `UniGatewayEngine` (pools, retry, streaming).
 - Anthropic uses a separate native Messages API client in the same crate.
+- Retry classification (`LlmErrorClass`): context overflow (no transport retry), rate-limit (capped), transient/empty-response (retry), fatal auth/4xx.
 
 ## Coordination
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -403,4 +403,17 @@ TUI、record/replay、安装分发。
 
 ---
 
-*最后更新：2026-05-30（Batch 7：WebSearch、compaction v2、todo 持久化；`agent_profile` 配置；`unigateway-sdk` crates.io）*
+---
+
+## Grok 对齐迭代（2026-07）
+
+| 阶段 | 状态 | 内容 |
+|------|------|------|
+| P1 采样/上下文 | [x] | usage 水位、full-replace、输入阶梯、LLM 错误分类、`/compact` |
+| P2 权限 | [x] | default/accept_edits/dont_ask/bypass + allow/deny/ask 规则 |
+| P3 会话恢复 | [x] | compaction checkpoints、`/rewind`、`/fork`、`/session-info` |
+| P4 运行时 | [ ] | 后台 Bash、worktree、更深 subagent（后续） |
+| P5 MCP/扩展 | [~] | `zene mcp doctor`；HTTP MCP 后续 |
+| P6 集成/产品化 | [~] | `zene -p` headless + `--output-format json`；ACP 后续 |
+
+*最后更新：2026-07-18（对齐 grok：上下文水位 / full-replace / 权限模式 / checkpoint / headless）*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

按与 grok-build 的差距表推进引擎对齐，本 PR 落地 P1–P3 主体，并补部分 P5/P6。

### P1 采样 / 上下文
- `ContextWaterLevel`：优先用 provider `prompt_tokens` 驱动 auto-compact（默认 85%）
- full-replace 重建：`system + last_user + recent + summary + todo reminder`
- 输入阶梯 `verbatim → fitted → lossy`，退化摘要重试
- LLM 错误分类：overflow / rate-limit / transient / empty / fatal
- `/compact [hint]`、`/session-info`；状态栏显示 `ctx N%`

### P2 权限
- 模式：`default` / `accept_edits` / `dont_ask` / `bypass`（兼容 yolo/manual）
- 配置 `[permission_rules]`：`allow` / `deny` / `ask` 模式匹配

### P3 会话恢复
- compaction checkpoints（`compaction_checkpoints/`）
- `/rewind [id]`、`/fork`

### P5 / P6（薄层）
- `zene mcp doctor`
- `zene -p "..."` headless；`--output-format json`

### 暂缓
- 后台 Bash / worktree / 更深 subagent
- MCP HTTP、ACP

文档：`docs/ENGINE.md`、`docs/ROADMAP.md` 已更新。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

