### PR TITLE
P4/P5：后台任务、git worktree 与 MCP HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,6 +3579,7 @@ version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand};
 use parking_lot::Mutex;
 use tokio_util::sync::CancellationToken;
 use zene_config::{ensure_home, ZeneConfig};
-use zene_core::{Agent, AgentEvent, PermissionMode, PromptOptions};
+use zene_core::{ensure_session_worktree, Agent, AgentEvent, PermissionMode, PromptOptions};
 use zene_sandbox::LocalSandbox;
 use zene_session::{export_session, list_sessions_for_workdir, SessionRecord};
 use std::sync::Arc;
@@ -76,6 +76,10 @@ pub struct Cli {
     /// Headless output format: `text` (default) or `json`
     #[arg(long, default_value = "text")]
     output_format: String,
+
+    /// Run the session inside a dedicated git worktree under `.zene/worktrees/`
+    #[arg(long)]
+    worktree: bool,
 }
 
 #[derive(Subcommand)]
@@ -198,10 +202,20 @@ async fn main() -> Result<()> {
     }
 
     let config = ZeneConfig::load(&workdir).map_err(|err| anyhow::anyhow!(err.to_string()))?;
-    let session = if let Some(ref id) = cli.session {
+    let mut session = if let Some(ref id) = cli.session {
         SessionRecord::load(id).context("load session")?
     } else {
         SessionRecord::new(&workdir)
+    };
+
+    let agent_workdir = if cli.worktree {
+        let wt = ensure_session_worktree(&workdir, &session.meta.id)
+            .context("create session git worktree")?;
+        eprintln!("Using git worktree: {}", wt.display());
+        session.meta.workdir = wt.display().to_string();
+        wt
+    } else {
+        workdir.clone()
     };
 
     let permission_mode = if cli.yolo {
@@ -210,7 +224,7 @@ async fn main() -> Result<()> {
         PermissionMode::parse(&config.permission_mode)
     };
 
-    let sandbox = LocalSandbox::new(&workdir);
+    let sandbox = LocalSandbox::new(&agent_workdir);
     let mut agent = Agent::new(config.clone(), sandbox, session, permission_mode).await?;
 
     if let Some(prompt) = cli.prompt.as_deref() {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,9 +15,10 @@ use zene_session::{
     AgentRecordWriter, RecordEntry, SessionRecord,
 };
 use zene_tools::{
-    default_ask_user_prompter, shared_todo_store_from, SharedAskUserPrompter, SharedTodoStore,
-    shared_plan_mode, PlanModeState, SharedPlanMode, SharedToolPermission, SubagentEnv,
-    ToolContext, ToolRegistry, DEFAULT_SUBAGENT_MAX_DEPTH,
+    default_ask_user_prompter, shared_background_tasks, shared_todo_store_from,
+    SharedAskUserPrompter, SharedBackgroundTasks, SharedTodoStore, shared_plan_mode, PlanModeState,
+    SharedPlanMode, SharedToolPermission, SubagentEnv, ToolContext, ToolRegistry,
+    DEFAULT_SUBAGENT_MAX_DEPTH,
 };
 use zene_mcp::McpManager;
 
@@ -34,6 +35,7 @@ mod tokens;
 mod tool_dedup;
 pub mod tool_scheduler;
 mod turn;
+mod worktree;
 
 use compaction::{
     apply_overflow_truncate_pass, compact_session, compact_session_forced, is_context_overflow_error,
@@ -59,6 +61,7 @@ use plan_mode::{
 };
 pub use tool_dedup::{append_reminder, ToolDedup};
 pub use tool_scheduler::{classify_tool_accesses, ToolScheduler};
+pub use worktree::ensure_session_worktree;
 
 pub struct Agent {
     config: ZeneConfig,
@@ -80,6 +83,7 @@ pub struct Agent {
     hooks: HookRunner,
     record_writer: AgentRecordWriter,
     mcp: Option<McpManager>,
+    background: SharedBackgroundTasks,
 }
 
 pub struct PromptOptions {
@@ -158,6 +162,7 @@ impl Agent {
             hooks,
             record_writer,
             mcp,
+            background: shared_background_tasks(),
         })
     }
 
@@ -869,6 +874,7 @@ impl Agent {
             plan_mode: Some(Arc::clone(&plan_mode)),
             todos: Some(Arc::clone(&self.todos)),
             ask_user: Some(Arc::clone(&self.ask_user)),
+            background: Some(Arc::clone(&self.background)),
         };
 
         struct PreparedTool {
@@ -1010,6 +1016,7 @@ impl Agent {
                     plan_mode: ctx.plan_mode.clone(),
                     todos: ctx.todos.clone(),
                     ask_user: ctx.ask_user.clone(),
+                    background: ctx.background.clone(),
                 };
                 let tools = Arc::clone(&tools);
                 let name = name.clone();

--- a/crates/core/src/subagent.rs
+++ b/crates/core/src/subagent.rs
@@ -205,6 +205,7 @@ async fn run_subagent_tools(
         plan_mode: None,
         todos: None,
         ask_user: None,
+        background: None,
     };
 
     for call in tool_calls {
@@ -551,6 +552,7 @@ mod tests {
             plan_mode: None,
             todos: None,
             ask_user: None,
+            background: None,
         };
 
         let result = default_builtin_tools()

--- a/crates/core/src/worktree.rs
+++ b/crates/core/src/worktree.rs
@@ -1,0 +1,96 @@
+//! Git worktree isolation for agent sessions (`--worktree`).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+
+/// Create (or reuse) a git worktree under `.zene/worktrees/<slug>` for this session.
+pub fn ensure_session_worktree(repo_root: &Path, session_id: &str) -> Result<PathBuf> {
+    if !repo_root.join(".git").exists() {
+        bail!(
+            "--worktree requires a git repository (no .git in {})",
+            repo_root.display()
+        );
+    }
+
+    let slug: String = session_id.chars().take(8).collect();
+    let worktree_dir = repo_root.join(".zene").join("worktrees").join(&slug);
+    if worktree_dir.exists() {
+        return Ok(worktree_dir);
+    }
+
+    std::fs::create_dir_all(worktree_dir.parent().unwrap())
+        .context("create .zene/worktrees directory")?;
+
+    let branch = format!("zene/{slug}");
+    let status = Command::new("git")
+        .args([
+            "worktree",
+            "add",
+            "-B",
+            &branch,
+            worktree_dir.to_str().unwrap_or_default(),
+            "HEAD",
+        ])
+        .current_dir(repo_root)
+        .status()
+        .context("spawn git worktree add")?;
+
+    if !status.success() {
+        bail!("git worktree add failed with status {status}");
+    }
+
+    Ok(worktree_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+    use tempfile::tempdir;
+
+    #[test]
+    fn creates_worktree_in_git_repo() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        assert!(Command::new("git")
+            .args(["init"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["config", "user.email", "zene@test"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["config", "user.name", "zene"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        std::fs::write(root.join("README.md"), "hi").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "."])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(root)
+            .status()
+            .unwrap()
+            .success());
+
+        let wt = ensure_session_worktree(root, "abcdef12-xxxx").unwrap();
+        assert!(wt.exists());
+        assert!(wt.join("README.md").exists());
+        // Reuse path on second call.
+        let wt2 = ensure_session_worktree(root, "abcdef12-yyyy").unwrap();
+        assert_eq!(wt, wt2);
+    }
+}

--- a/crates/core/tests/todo_persist.rs
+++ b/crates/core/tests/todo_persist.rs
@@ -25,6 +25,7 @@ async fn todo_write_persists_across_session_reload() {
         plan_mode: None,
         todos: Some(Arc::clone(&store)),
         ask_user: None,
+        background: None,
     };
 
     let result = default_builtin_tools()
@@ -64,6 +65,7 @@ async fn todo_write_persists_across_session_reload() {
         plan_mode: None,
         todos: Some(reloaded_store),
         ask_user: None,
+        background: None,
     };
     let list_result = default_builtin_tools()
         .execute("TodoList", "{}", &list_ctx)

--- a/crates/core/tests/tool_parallel.rs
+++ b/crates/core/tests/tool_parallel.rs
@@ -17,6 +17,7 @@ fn ctx(workdir: &std::path::Path) -> ToolContext {
         plan_mode: None,
         todos: None,
         ask_user: None,
+        background: None,
     }
 }
 
@@ -40,6 +41,7 @@ async fn parallel_read_calls_both_succeed() {
             plan_mode: tool_ctx.plan_mode.clone(),
             todos: tool_ctx.todos.clone(),
             ask_user: tool_ctx.ask_user.clone(),
+            background: tool_ctx.background.clone(),
         };
         let tools = Arc::clone(&tools);
         let args = format!(r#"{{"path":"{path}"}}"#);
@@ -92,6 +94,7 @@ async fn parallel_read_results_preserve_provider_order() {
             plan_mode: base_ctx.plan_mode.clone(),
             todos: base_ctx.todos.clone(),
             ask_user: base_ctx.ask_user.clone(),
+            background: base_ctx.background.clone(),
         };
         let tools = Arc::clone(&tools);
         let args = format!(r#"{{"path":"{path}"}}"#);

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/mcp/src/client.rs
+++ b/crates/mcp/src/client.rs
@@ -29,7 +29,11 @@ pub struct McpStdioClient {
 
 impl McpStdioClient {
     pub async fn connect(server_name: &str, config: &McpServerConfig) -> Result<Self> {
-        let mut command = Command::new(&config.command);
+        let cmd = config
+            .command
+            .as_deref()
+            .ok_or_else(|| anyhow!("MCP server `{server_name}` missing stdio command"))?;
+        let mut command = Command::new(cmd);
         command
             .args(&config.args)
             .envs(&config.env)
@@ -40,7 +44,7 @@ impl McpStdioClient {
 
         let mut child = command
             .spawn()
-            .with_context(|| format!("spawn MCP server `{server_name}` ({})", config.command))?;
+            .with_context(|| format!("spawn MCP server `{server_name}` ({cmd})"))?;
 
         let stdin = child
             .stdin

--- a/crates/mcp/src/config.rs
+++ b/crates/mcp/src/config.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use zene_config::zene_home;
 
@@ -14,11 +14,41 @@ pub struct McpConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct McpServerConfig {
-    pub command: String,
+    /// stdio transport: command to spawn.
+    #[serde(default)]
+    pub command: Option<String>,
     #[serde(default)]
     pub args: Vec<String>,
     #[serde(default)]
     pub env: HashMap<String, String>,
+    /// HTTP / Streamable HTTP transport endpoint.
+    #[serde(default)]
+    pub url: Option<String>,
+    /// Extra HTTP headers (Authorization, etc.).
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+}
+
+impl McpServerConfig {
+    pub fn is_http(&self) -> bool {
+        self.url.as_ref().is_some_and(|u| !u.trim().is_empty())
+    }
+
+    pub fn is_stdio(&self) -> bool {
+        self.command.as_ref().is_some_and(|c| !c.trim().is_empty())
+    }
+
+    pub fn validate(&self, name: &str) -> Result<()> {
+        match (self.is_stdio(), self.is_http()) {
+            (true, false) | (false, true) => Ok(()),
+            (true, true) => bail!(
+                "MCP server `{name}` sets both `command` and `url`; choose one transport"
+            ),
+            (false, false) => bail!(
+                "MCP server `{name}` needs either `command` (stdio) or `url` (HTTP)"
+            ),
+        }
+    }
 }
 
 pub fn global_mcp_config_path() -> PathBuf {
@@ -78,9 +108,27 @@ mod tests {
         }"#;
         let config: McpConfig = serde_json::from_str(raw).unwrap();
         let server = config.servers.get("demo").unwrap();
-        assert_eq!(server.command, "node");
+        assert_eq!(server.command.as_deref(), Some("node"));
         assert_eq!(server.args, vec!["server.js"]);
         assert_eq!(server.env.get("FOO").map(String::as_str), Some("bar"));
+        assert!(server.is_stdio());
+    }
+
+    #[test]
+    fn parses_http_server_config() {
+        let raw = r#"{
+            "servers": {
+                "remote": {
+                    "url": "https://example.com/mcp",
+                    "headers": { "Authorization": "Bearer tok" }
+                }
+            }
+        }"#;
+        let config: McpConfig = serde_json::from_str(raw).unwrap();
+        let server = config.servers.get("remote").unwrap();
+        assert!(server.is_http());
+        assert_eq!(server.url.as_deref(), Some("https://example.com/mcp"));
+        server.validate("remote").unwrap();
     }
 
     #[test]
@@ -89,9 +137,11 @@ mod tests {
             servers: HashMap::from([(
                 "a".to_string(),
                 McpServerConfig {
-                    command: "global".to_string(),
+                    command: Some("global".to_string()),
                     args: vec![],
                     env: HashMap::new(),
+                    url: None,
+                    headers: HashMap::new(),
                 },
             )]),
         };
@@ -100,24 +150,28 @@ mod tests {
                 (
                     "a".to_string(),
                     McpServerConfig {
-                        command: "project".to_string(),
+                        command: Some("project".to_string()),
                         args: vec!["--local".to_string()],
                         env: HashMap::new(),
+                        url: None,
+                        headers: HashMap::new(),
                     },
                 ),
                 (
                     "b".to_string(),
                     McpServerConfig {
-                        command: "other".to_string(),
+                        command: Some("other".to_string()),
                         args: vec![],
                         env: HashMap::new(),
+                        url: None,
+                        headers: HashMap::new(),
                     },
                 ),
             ]),
         });
         assert_eq!(base.servers.len(), 2);
-        assert_eq!(base.servers["a"].command, "project");
-        assert_eq!(base.servers["b"].command, "other");
+        assert_eq!(base.servers["a"].command.as_deref(), Some("project"));
+        assert_eq!(base.servers["b"].command.as_deref(), Some("other"));
     }
 
     #[test]
@@ -135,7 +189,6 @@ mod tests {
         let _guard = EnvOverride::set("ZENE_HOME", temp.path());
         let global_path = global_mcp_config_path();
 
-        // Write to the actual global path under temp ZENE_HOME
         fs::write(
             global_path,
             r#"{"servers":{"shared":{"command":"global","args":[],"env":{}}}}"#,
@@ -144,8 +197,8 @@ mod tests {
 
         let loaded = load_mcp_config(&workdir).unwrap();
         assert_eq!(loaded.servers.len(), 2);
-        assert_eq!(loaded.servers["shared"].command, "project");
-        assert_eq!(loaded.servers["local"].command, "local-cmd");
+        assert_eq!(loaded.servers["shared"].command.as_deref(), Some("project"));
+        assert_eq!(loaded.servers["local"].command.as_deref(), Some("local-cmd"));
     }
 
     struct EnvOverride;

--- a/crates/mcp/src/http.rs
+++ b/crates/mcp/src/http.rs
@@ -1,0 +1,245 @@
+//! Minimal Streamable-HTTP MCP client (JSON-RPC over POST).
+
+use std::collections::HashMap;
+
+use anyhow::{anyhow, Context, Result};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
+use serde_json::{json, Value};
+use tracing::debug;
+
+use crate::client::McpToolInfo;
+
+const PROTOCOL_VERSION: &str = "2024-11-05";
+
+pub struct McpHttpClient {
+    server_name: String,
+    url: String,
+    http: reqwest::Client,
+    session_id: Option<String>,
+    next_id: u64,
+}
+
+impl McpHttpClient {
+    pub async fn connect(
+        server_name: &str,
+        url: &str,
+        headers: &HashMap<String, String>,
+    ) -> Result<Self> {
+        let mut default_headers = HeaderMap::new();
+        for (k, v) in headers {
+            let name = HeaderName::from_bytes(k.as_bytes())
+                .with_context(|| format!("invalid header name `{k}`"))?;
+            let value = HeaderValue::from_str(v)
+                .with_context(|| format!("invalid header value for `{k}`"))?;
+            default_headers.insert(name, value);
+        }
+        default_headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        let http = reqwest::Client::builder()
+            .default_headers(default_headers)
+            .build()
+            .context("build MCP HTTP client")?;
+
+        let mut client = Self {
+            server_name: server_name.to_string(),
+            url: url.trim_end_matches('/').to_string(),
+            http,
+            session_id: None,
+            next_id: 1,
+        };
+        client.initialize().await?;
+        Ok(client)
+    }
+
+    pub fn server_name(&self) -> &str {
+        &self.server_name
+    }
+
+    async fn initialize(&mut self) -> Result<()> {
+        let result = self
+            .request(
+                "initialize",
+                json!({
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": { "name": "zene", "version": env!("CARGO_PKG_VERSION") },
+                }),
+            )
+            .await
+            .context("mcp http initialize")?;
+        debug!(server = %self.server_name, ?result, "mcp http initialized");
+        let _ = self
+            .notify("notifications/initialized", json!({}))
+            .await;
+        Ok(())
+    }
+
+    pub async fn list_tools(&mut self) -> Result<Vec<McpToolInfo>> {
+        let response = self
+            .request("tools/list", json!({}))
+            .await
+            .context("tools/list")?;
+        let tools = response
+            .get("tools")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let mut parsed = Vec::new();
+        for tool in tools {
+            let info: McpToolInfo =
+                serde_json::from_value(tool).context("parse MCP tool definition")?;
+            parsed.push(info);
+        }
+        Ok(parsed)
+    }
+
+    pub async fn call_tool(&mut self, name: &str, arguments: Value) -> Result<(String, bool)> {
+        let response = self
+            .request(
+                "tools/call",
+                json!({
+                    "name": name,
+                    "arguments": arguments,
+                }),
+            )
+            .await
+            .context("tools/call")?;
+
+        let is_error = response
+            .get("isError")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let content = extract_text_content(&response);
+        Ok((content, is_error))
+    }
+
+    pub async fn disconnect(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn notify(&mut self, method: &str, params: Value) -> Result<()> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        let mut req = self.http.post(&self.url).json(&body);
+        if let Some(session) = &self.session_id {
+            req = req.header("Mcp-Session-Id", session);
+        }
+        let _ = req.send().await.context("mcp http notify")?;
+        Ok(())
+    }
+
+    async fn request(&mut self, method: &str, params: Value) -> Result<Value> {
+        let id = self.next_id;
+        self.next_id += 1;
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+
+        let mut req = self.http.post(&self.url).json(&body);
+        if let Some(session) = &self.session_id {
+            req = req.header("Mcp-Session-Id", session);
+        }
+
+        let response = req
+            .send()
+            .await
+            .with_context(|| format!("POST MCP `{method}` to {}", self.url))?;
+
+        if let Some(session) = response.headers().get("mcp-session-id") {
+            if let Ok(s) = session.to_str() {
+                self.session_id = Some(s.to_string());
+            }
+        }
+
+        let status = response.status();
+        let text = response.text().await.context("read MCP HTTP body")?;
+        if !status.is_success() {
+            return Err(anyhow!(
+                "MCP HTTP `{method}` failed with {status}: {}",
+                truncate(&text, 400)
+            ));
+        }
+
+        // Streamable HTTP may return a single JSON object or SSE frames.
+        let value = parse_json_or_sse(&text)
+            .with_context(|| format!("parse MCP HTTP response for `{method}`"))?;
+
+        if let Some(err) = value.get("error") {
+            return Err(anyhow!("MCP error: {err}"));
+        }
+        Ok(value.get("result").cloned().unwrap_or(Value::Null))
+    }
+}
+
+fn parse_json_or_sse(text: &str) -> Result<Value> {
+    let trimmed = text.trim();
+    if trimmed.starts_with('{') {
+        return Ok(serde_json::from_str(trimmed)?);
+    }
+    // Take the last `data: {...}` SSE payload.
+    let mut last = None;
+    for line in trimmed.lines() {
+        let line = line.trim();
+        if let Some(data) = line.strip_prefix("data:") {
+            let data = data.trim();
+            if data.starts_with('{') {
+                last = Some(data.to_string());
+            }
+        }
+    }
+    let Some(data) = last else {
+        anyhow::bail!("no JSON payload in MCP HTTP response");
+    };
+    Ok(serde_json::from_str(&data)?)
+}
+
+fn extract_text_content(response: &Value) -> String {
+    let Some(items) = response.get("content").and_then(Value::as_array) else {
+        return response.to_string();
+    };
+    let mut parts = Vec::new();
+    for item in items {
+        if item.get("type").and_then(Value::as_str) == Some("text") {
+            if let Some(text) = item.get("text").and_then(Value::as_str) {
+                parts.push(text.to_string());
+            }
+        }
+    }
+    if parts.is_empty() {
+        response.to_string()
+    } else {
+        parts.join("\n")
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", s.chars().take(max).collect::<String>())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_json() {
+        let v = parse_json_or_sse(r#"{"jsonrpc":"2.0","id":1,"result":{"ok":true}}"#).unwrap();
+        assert_eq!(v["result"]["ok"], true);
+    }
+
+    #[test]
+    fn parses_sse_data() {
+        let raw = "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[]}}\n\n";
+        let v = parse_json_or_sse(raw).unwrap();
+        assert!(v["result"]["tools"].is_array());
+    }
+}

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -1,7 +1,9 @@
 mod client;
 mod config;
+mod http;
 mod manager;
 mod tool;
+mod transport;
 
 pub use client::mcp_tool_registry_name;
 pub use config::{

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -8,10 +8,12 @@ use zene_tools::ToolRegistry;
 
 use crate::client::McpStdioClient;
 use crate::config::{load_mcp_config, McpConfig};
+use crate::http::McpHttpClient;
 use crate::tool::McpTool;
+use crate::transport::McpClientHandle;
 
 pub struct McpManager {
-    clients: Vec<Arc<Mutex<McpStdioClient>>>,
+    clients: Vec<Arc<Mutex<McpClientHandle>>>,
 }
 
 impl McpManager {
@@ -25,7 +27,23 @@ impl McpManager {
         let mut tool_boxes: Vec<Box<dyn zene_tools::Tool>> = Vec::new();
 
         for (server_name, server_config) in config.servers {
-            match McpStdioClient::connect(&server_name, &server_config).await {
+            if let Err(err) = server_config.validate(&server_name) {
+                warn!(server = %server_name, error = %err, "mcp config invalid");
+                continue;
+            }
+
+            let connected = if server_config.is_http() {
+                let url = server_config.url.as_deref().unwrap();
+                McpHttpClient::connect(&server_name, url, &server_config.headers)
+                    .await
+                    .map(McpClientHandle::Http)
+            } else {
+                McpStdioClient::connect(&server_name, &server_config)
+                    .await
+                    .map(McpClientHandle::Stdio)
+            };
+
+            match connected {
                 Ok(mut client) => {
                     let tools = match client.list_tools().await {
                         Ok(tools) => tools,
@@ -46,7 +64,12 @@ impl McpManager {
                             Arc::clone(&client),
                         )));
                     }
-                    info!(server = %server_name, tool_count = registered, "mcp connected");
+                    info!(
+                        server = %server_name,
+                        tool_count = registered,
+                        transport = if server_config.is_http() { "http" } else { "stdio" },
+                        "mcp connected"
+                    );
                 }
                 Err(err) => {
                     warn!(server = %server_name, error = %err, "mcp connect failed");
@@ -54,10 +77,7 @@ impl McpManager {
             }
         }
 
-        Ok((
-            Self { clients },
-            ToolRegistry::new(tool_boxes),
-        ))
+        Ok((Self { clients }, ToolRegistry::new(tool_boxes)))
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/mcp/src/tool.rs
+++ b/crates/mcp/src/tool.rs
@@ -7,7 +7,8 @@ use tokio::sync::Mutex;
 use zene_llm::ToolDefinition;
 use zene_tools::{Tool, ToolContext, ToolResult};
 
-use crate::client::{McpStdioClient, McpToolInfo, mcp_tool_registry_name};
+use crate::client::{McpToolInfo, mcp_tool_registry_name};
+use crate::transport::McpClientHandle;
 
 pub struct McpTool {
     server_name: String,
@@ -15,14 +16,14 @@ pub struct McpTool {
     registry_name: String,
     description: String,
     input_schema: Value,
-    client: Arc<Mutex<McpStdioClient>>,
+    client: Arc<Mutex<McpClientHandle>>,
 }
 
 impl McpTool {
     pub fn from_info(
         server_name: &str,
         info: McpToolInfo,
-        client: Arc<Mutex<McpStdioClient>>,
+        client: Arc<Mutex<McpClientHandle>>,
     ) -> Self {
         let registry_name = mcp_tool_registry_name(server_name, &info.name);
         Self {

--- a/crates/mcp/src/transport.rs
+++ b/crates/mcp/src/transport.rs
@@ -1,0 +1,42 @@
+//! Unified MCP client handle for stdio and HTTP transports.
+
+use anyhow::Result;
+use serde_json::Value;
+
+use crate::client::{McpStdioClient, McpToolInfo};
+use crate::http::McpHttpClient;
+
+pub enum McpClientHandle {
+    Stdio(McpStdioClient),
+    Http(McpHttpClient),
+}
+
+impl McpClientHandle {
+    pub fn server_name(&self) -> &str {
+        match self {
+            Self::Stdio(c) => c.server_name(),
+            Self::Http(c) => c.server_name(),
+        }
+    }
+
+    pub async fn list_tools(&mut self) -> Result<Vec<McpToolInfo>> {
+        match self {
+            Self::Stdio(c) => c.list_tools().await,
+            Self::Http(c) => c.list_tools().await,
+        }
+    }
+
+    pub async fn call_tool(&mut self, name: &str, arguments: Value) -> Result<(String, bool)> {
+        match self {
+            Self::Stdio(c) => c.call_tool(name, arguments).await,
+            Self::Http(c) => c.call_tool(name, arguments).await,
+        }
+    }
+
+    pub async fn disconnect(&mut self) -> Result<()> {
+        match self {
+            Self::Stdio(c) => c.disconnect().await,
+            Self::Http(c) => c.disconnect().await,
+        }
+    }
+}

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -90,12 +90,30 @@ impl LocalSandbox {
         cwd: Option<&str>,
         cancel: Option<&CancellationToken>,
     ) -> Result<ExecResult> {
+        self.exec_with_timeout(
+            command,
+            cwd,
+            cancel,
+            Duration::from_secs(BASH_TIMEOUT_SECS),
+        )
+        .await
+    }
+
+    /// Like [`Self::exec`] but with an explicit timeout (used by background Bash).
+    pub async fn exec_with_timeout(
+        &self,
+        command: &str,
+        cwd: Option<&str>,
+        cancel: Option<&CancellationToken>,
+        timeout: Duration,
+    ) -> Result<ExecResult> {
         if cancel.is_some_and(CancellationToken::is_cancelled) {
             anyhow::bail!("aborted");
         }
 
+        let timeout_secs = timeout.as_secs().max(1);
         let work = self.exec_inner(command, cwd);
-        let timed = tokio::time::timeout(Duration::from_secs(BASH_TIMEOUT_SECS), work);
+        let timed = tokio::time::timeout(timeout, work);
 
         if let Some(token) = cancel {
             tokio::select! {
@@ -103,18 +121,14 @@ impl LocalSandbox {
                 result = timed => match result {
                     Ok(inner) => inner,
                     Err(_) => anyhow::bail!(
-                        "command timed out after {} seconds",
-                        BASH_TIMEOUT_SECS
+                        "command timed out after {timeout_secs} seconds"
                     ),
                 },
             }
         } else {
             match timed.await {
                 Ok(inner) => inner,
-                Err(_) => anyhow::bail!(
-                    "command timed out after {} seconds",
-                    BASH_TIMEOUT_SECS
-                ),
+                Err(_) => anyhow::bail!("command timed out after {timeout_secs} seconds"),
             }
         }
     }

--- a/crates/tools/src/background.rs
+++ b/crates/tools/src/background.rs
@@ -1,0 +1,185 @@
+//! Background task store for Bash / Task jobs (grok-aligned minimal set).
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tokio_util::sync::CancellationToken;
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackgroundTaskKind {
+    Bash,
+    Subagent,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackgroundTaskStatus {
+    Running,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl BackgroundTaskStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Running => "running",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BackgroundTask {
+    pub id: String,
+    pub kind: BackgroundTaskKind,
+    pub status: BackgroundTaskStatus,
+    pub label: String,
+    pub output: String,
+    pub exit_code: Option<i32>,
+}
+
+#[derive(Debug, Default)]
+pub struct BackgroundTaskStore {
+    tasks: HashMap<String, BackgroundTask>,
+    cancels: HashMap<String, CancellationToken>,
+}
+
+impl BackgroundTaskStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn alloc_id(prefix: &str) -> String {
+        let n = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+        format!("{prefix}-{n}")
+    }
+
+    pub fn insert_running(
+        &mut self,
+        id: String,
+        kind: BackgroundTaskKind,
+        label: String,
+        cancel: CancellationToken,
+    ) {
+        self.cancels.insert(id.clone(), cancel);
+        self.tasks.insert(
+            id.clone(),
+            BackgroundTask {
+                id,
+                kind,
+                status: BackgroundTaskStatus::Running,
+                label,
+                output: String::new(),
+                exit_code: None,
+            },
+        );
+    }
+
+    pub fn cancel_token(&self, id: &str) -> Option<CancellationToken> {
+        self.cancels.get(id).cloned()
+    }
+
+    pub fn finish(
+        &mut self,
+        id: &str,
+        status: BackgroundTaskStatus,
+        output: String,
+        exit_code: Option<i32>,
+    ) {
+        if let Some(task) = self.tasks.get_mut(id) {
+            // Don't overwrite an explicit cancel with a late worker finish.
+            if task.status == BackgroundTaskStatus::Cancelled
+                && status != BackgroundTaskStatus::Cancelled
+            {
+                return;
+            }
+            task.status = status;
+            if !output.is_empty() {
+                task.output = output;
+            }
+            task.exit_code = exit_code;
+        }
+        self.cancels.remove(id);
+    }
+
+    pub fn request_cancel(&mut self, id: &str) -> bool {
+        let Some(task) = self.tasks.get(id) else {
+            return false;
+        };
+        if task.status != BackgroundTaskStatus::Running {
+            return false;
+        }
+        if let Some(token) = self.cancels.get(id) {
+            token.cancel();
+        }
+        let output = format!("{}\n[cancelled by TaskOutput]", task.output);
+        self.finish(id, BackgroundTaskStatus::Cancelled, output, None);
+        true
+    }
+
+    pub fn get(&self, id: &str) -> Option<BackgroundTask> {
+        self.tasks.get(id).cloned()
+    }
+
+    pub fn list(&self) -> Vec<BackgroundTask> {
+        let mut tasks: Vec<_> = self.tasks.values().cloned().collect();
+        tasks.sort_by(|a, b| a.id.cmp(&b.id));
+        tasks
+    }
+}
+
+pub type SharedBackgroundTasks = Arc<Mutex<BackgroundTaskStore>>;
+
+pub fn shared_background_tasks() -> SharedBackgroundTasks {
+    Arc::new(Mutex::new(BackgroundTaskStore::new()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finish_updates_status() {
+        let mut store = BackgroundTaskStore::new();
+        store.insert_running(
+            "bg-1".into(),
+            BackgroundTaskKind::Bash,
+            "ls".into(),
+            CancellationToken::new(),
+        );
+        store.finish(
+            "bg-1",
+            BackgroundTaskStatus::Completed,
+            "ok\n".into(),
+            Some(0),
+        );
+        let task = store.get("bg-1").unwrap();
+        assert_eq!(task.status, BackgroundTaskStatus::Completed);
+        assert_eq!(task.output, "ok\n");
+        assert_eq!(task.exit_code, Some(0));
+    }
+
+    #[test]
+    fn request_cancel_marks_cancelled() {
+        let mut store = BackgroundTaskStore::new();
+        let token = CancellationToken::new();
+        store.insert_running(
+            "bg-2".into(),
+            BackgroundTaskKind::Bash,
+            "sleep".into(),
+            token.clone(),
+        );
+        assert!(store.request_cancel("bg-2"));
+        assert!(token.is_cancelled());
+        assert_eq!(
+            store.get("bg-2").unwrap().status,
+            BackgroundTaskStatus::Cancelled
+        );
+    }
+}

--- a/crates/tools/src/bash.rs
+++ b/crates/tools/src/bash.rs
@@ -1,10 +1,19 @@
+use std::sync::Arc;
+use std::time::Duration;
+
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::json;
+use tokio_util::sync::CancellationToken;
 use zene_llm::ToolDefinition;
+use zene_sandbox::LocalSandbox;
 
+use crate::background::{BackgroundTaskKind, BackgroundTaskStatus, BackgroundTaskStore};
 use crate::registry::{Tool, ToolContext, ToolResult};
+
+/// Background Bash jobs may run longer than interactive Bash.
+const BACKGROUND_BASH_TIMEOUT_SECS: u64 = 30 * 60;
 
 pub struct BashTool;
 
@@ -13,6 +22,8 @@ struct BashArgs {
     command: String,
     #[serde(default)]
     cwd: Option<String>,
+    #[serde(default)]
+    run_in_background: bool,
 }
 
 #[async_trait]
@@ -24,12 +35,16 @@ impl Tool for BashTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "Bash".to_string(),
-            description: "Run a shell command in the workspace.".to_string(),
+            description: "Run a shell command in the workspace. Set run_in_background=true for long jobs; poll with TaskOutput.".to_string(),
             parameters: json!({
                 "type": "object",
                 "properties": {
                     "command": { "type": "string" },
-                    "cwd": { "type": "string", "description": "Optional working directory relative to workspace" }
+                    "cwd": { "type": "string", "description": "Optional working directory relative to workspace" },
+                    "run_in_background": {
+                        "type": "boolean",
+                        "description": "If true, start the command in the background and return a task_id immediately"
+                    }
                 },
                 "required": ["command"]
             }),
@@ -38,6 +53,11 @@ impl Tool for BashTool {
 
     async fn execute(&self, arguments: &str, ctx: &ToolContext) -> Result<ToolResult> {
         let args: BashArgs = serde_json::from_str(arguments).context("parse Bash args")?;
+
+        if args.run_in_background {
+            return spawn_background_bash(ctx, &args.command, args.cwd.as_deref()).await;
+        }
+
         let result = ctx
             .sandbox
             .exec(
@@ -46,22 +66,120 @@ impl Tool for BashTool {
                 ctx.cancel.as_ref(),
             )
             .await?;
-        let mut content = String::new();
-        if !result.stdout.is_empty() {
-            content.push_str(&result.stdout);
+        Ok(format_exec_result(result))
+    }
+}
+
+async fn spawn_background_bash(
+    ctx: &ToolContext,
+    command: &str,
+    cwd: Option<&str>,
+) -> Result<ToolResult> {
+    let Some(store) = ctx.background.clone() else {
+        return Ok(ToolResult {
+            content: "Background tasks are not available in this context.".into(),
+            is_error: true,
+        });
+    };
+
+    let id = BackgroundTaskStore::alloc_id("bash");
+    let cancel = CancellationToken::new();
+    store.lock().insert_running(
+        id.clone(),
+        BackgroundTaskKind::Bash,
+        command.to_string(),
+        cancel.clone(),
+    );
+
+    let sandbox = Arc::clone(&ctx.sandbox);
+    let cwd = cwd.map(str::to_string);
+    let store_worker = Arc::clone(&store);
+    let id_worker = id.clone();
+    let command = command.to_string();
+
+    tokio::spawn(async move {
+        let result = exec_with_timeout(
+            &sandbox,
+            &command,
+            cwd.as_deref(),
+            Some(&cancel),
+            BACKGROUND_BASH_TIMEOUT_SECS,
+        )
+        .await;
+
+        let mut guard = store_worker.lock();
+        if cancel.is_cancelled()
+            || guard
+                .get(&id_worker)
+                .is_some_and(|t| t.status == BackgroundTaskStatus::Cancelled)
+        {
+            return;
         }
-        if !result.stderr.is_empty() {
-            if !content.is_empty() {
-                content.push('\n');
+        match result {
+            Ok(exec) => {
+                let content = format_exec_result(exec.clone()).content;
+                let status = if exec.exit_code == 0 {
+                    BackgroundTaskStatus::Completed
+                } else {
+                    BackgroundTaskStatus::Failed
+                };
+                guard.finish(&id_worker, status, content, Some(exec.exit_code));
             }
-            content.push_str(&result.stderr);
+            Err(err) => {
+                let msg = err.to_string();
+                let status = if msg.contains("aborted") {
+                    BackgroundTaskStatus::Cancelled
+                } else {
+                    BackgroundTaskStatus::Failed
+                };
+                guard.finish(&id_worker, status, msg, None);
+            }
         }
-        if content.is_empty() {
-            content = format!("exit code {}", result.exit_code);
+    });
+
+    Ok(ToolResult {
+        content: format!(
+            "Started background bash task `{id}`.\nUse TaskOutput with task_id=\"{id}\" to poll output, or action=\"kill\" to cancel."
+        ),
+        is_error: false,
+    })
+}
+
+async fn exec_with_timeout(
+    sandbox: &LocalSandbox,
+    command: &str,
+    cwd: Option<&str>,
+    cancel: Option<&CancellationToken>,
+    timeout_secs: u64,
+) -> Result<zene_sandbox::ExecResult> {
+    if cancel.is_some_and(CancellationToken::is_cancelled) {
+        anyhow::bail!("aborted");
+    }
+
+    // LocalSandbox::exec uses a fixed timeout; for background we wrap with our own
+    // longer timeout and cancellation by racing against the cancel token after start.
+    // Reuse exec but the sandbox timeout is 120s — for longer jobs we call a dedicated path.
+    sandbox
+        .exec_with_timeout(command, cwd, cancel, Duration::from_secs(timeout_secs))
+        .await
+}
+
+fn format_exec_result(result: zene_sandbox::ExecResult) -> ToolResult {
+    let mut content = String::new();
+    if !result.stdout.is_empty() {
+        content.push_str(&result.stdout);
+    }
+    if !result.stderr.is_empty() {
+        if !content.is_empty() {
+            content.push('\n');
         }
-        Ok(ToolResult {
-            content,
-            is_error: result.exit_code != 0,
-        })
+        content.push_str(&result.stderr);
+    }
+    if content.is_empty() {
+        content = format!("exit code {}", result.exit_code);
+    }
+    ToolResult {
+        content,
+        is_error: result.exit_code != 0,
     }
 }

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -10,6 +10,7 @@ use crate::registry::ToolRegistry;
 use crate::skill::SkillTool;
 use crate::subagent::SubagentProfile;
 use crate::task::TaskTool;
+use crate::task_output::TaskOutputTool;
 use crate::todo::{TodoListTool, TodoWriteTool};
 use crate::web_search::WebSearchTool;
 use crate::write::WriteTool;
@@ -59,6 +60,7 @@ fn all_builtin_tool_boxes(web_search: WebSearchConfig) -> Vec<Box<dyn crate::reg
         Box::new(GlobTool),
         Box::new(SkillTool),
         Box::new(TaskTool),
+        Box::new(TaskOutputTool),
         Box::new(AskUserQuestionTool),
         Box::new(TodoWriteTool),
         Box::new(TodoListTool),
@@ -95,6 +97,7 @@ fn coder_agent_tool_boxes(web_search: WebSearchConfig) -> Vec<Box<dyn crate::reg
         Box::new(GlobTool),
         Box::new(SkillTool),
         Box::new(TaskTool),
+        Box::new(TaskOutputTool),
         Box::new(AskUserQuestionTool),
         Box::new(TodoWriteTool),
         Box::new(TodoListTool),

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -1,4 +1,5 @@
 mod ask_user;
+mod background;
 mod bash;
 mod builtin;
 mod edit;
@@ -14,12 +15,17 @@ mod registry;
 mod skill;
 mod subagent;
 mod task;
+mod task_output;
 mod todo;
 mod todo_store;
 mod web_search;
 mod write;
 
 pub use ask_user::{default_ask_user_prompter, AskUserOption, AskUserPrompter, SharedAskUserPrompter};
+pub use background::{
+    shared_background_tasks, BackgroundTask, BackgroundTaskKind, BackgroundTaskStatus,
+    BackgroundTaskStore, SharedBackgroundTasks,
+};
 pub use builtin::{agent_tools, builtin_tools, default_builtin_tools, tools_for_profile};
 pub use todo_store::{shared_todo_store, shared_todo_store_from, SharedTodoStore, TodoItem, TodoStatus, TodoStore};
 pub use subagent::{

--- a/crates/tools/src/registry.rs
+++ b/crates/tools/src/registry.rs
@@ -9,6 +9,7 @@ use zene_llm::ToolDefinition;
 use zene_sandbox::LocalSandbox;
 
 use crate::ask_user::SharedAskUserPrompter;
+use crate::background::SharedBackgroundTasks;
 use crate::permission::SharedToolPermission;
 use crate::plan_mode::SharedPlanMode;
 use crate::subagent::SubagentEnv;
@@ -22,6 +23,7 @@ pub struct ToolContext {
     pub plan_mode: Option<SharedPlanMode>,
     pub todos: Option<SharedTodoStore>,
     pub ask_user: Option<SharedAskUserPrompter>,
+    pub background: Option<SharedBackgroundTasks>,
 }
 
 impl ToolContext {
@@ -34,6 +36,7 @@ impl ToolContext {
             plan_mode: None,
             todos: None,
             ask_user: None,
+            background: None,
         }
     }
 }

--- a/crates/tools/src/task.rs
+++ b/crates/tools/src/task.rs
@@ -1,11 +1,14 @@
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::json;
+use tokio_util::sync::CancellationToken;
 use zene_llm::ToolDefinition;
 
+use crate::background::{BackgroundTaskKind, BackgroundTaskStatus, BackgroundTaskStore};
 use crate::registry::{Tool, ToolContext, ToolResult};
 use crate::subagent::SubagentProfile;
 
@@ -18,6 +21,8 @@ struct TaskArgs {
     agent: Option<SubagentProfile>,
     #[serde(default)]
     cwd: Option<String>,
+    #[serde(default)]
+    run_in_background: bool,
 }
 
 #[async_trait]
@@ -29,7 +34,7 @@ impl Tool for TaskTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "Task".to_string(),
-            description: "Spawn a subagent with its own context to handle a focused subtask. Returns the subagent's final report.".to_string(),
+            description: "Spawn a subagent with its own context to handle a focused subtask. Returns the subagent's final report. Set run_in_background=true and poll with TaskOutput.".to_string(),
             parameters: json!({
                 "type": "object",
                 "properties": {
@@ -45,6 +50,10 @@ impl Tool for TaskTool {
                     "cwd": {
                         "type": "string",
                         "description": "Optional working directory relative to the workspace"
+                    },
+                    "run_in_background": {
+                        "type": "boolean",
+                        "description": "If true, start the subagent in the background and return a task_id immediately"
                     }
                 },
                 "required": ["prompt"]
@@ -73,6 +82,10 @@ impl Tool for TaskTool {
             });
         }
 
+        if args.run_in_background {
+            return spawn_background_task(ctx, &args.prompt, profile, args.cwd.as_deref()).await;
+        }
+
         let cwd = args.cwd.as_deref().map(Path::new);
         match env
             .runner
@@ -80,7 +93,7 @@ impl Tool for TaskTool {
             .await
         {
             Ok(text) => Ok(ToolResult {
-                content: text,
+                content: format_subagent_report(profile, &text),
                 is_error: false,
             }),
             Err(err) => Ok(ToolResult {
@@ -88,5 +101,108 @@ impl Tool for TaskTool {
                 is_error: true,
             }),
         }
+    }
+}
+
+async fn spawn_background_task(
+    ctx: &ToolContext,
+    prompt: &str,
+    profile: SubagentProfile,
+    cwd: Option<&str>,
+) -> Result<ToolResult> {
+    let Some(store) = ctx.background.clone() else {
+        return Ok(ToolResult {
+            content: "Background tasks are not available in this context.".into(),
+            is_error: true,
+        });
+    };
+    let Some(env) = ctx.subagent.clone() else {
+        return Ok(ToolResult {
+            content: "Task tool is not available in this context.".into(),
+            is_error: true,
+        });
+    };
+
+    let id = BackgroundTaskStore::alloc_id("task");
+    let cancel = CancellationToken::new();
+    let label = format!("[{profile:?}] {}", truncate(prompt, 120));
+    store.lock().insert_running(
+        id.clone(),
+        BackgroundTaskKind::Subagent,
+        label,
+        cancel.clone(),
+    );
+
+    let prompt = prompt.to_string();
+    let cwd_owned = cwd.map(str::to_string);
+    let parent_ctx = ToolContext {
+        sandbox: Arc::clone(&ctx.sandbox),
+        cancel: Some(cancel.clone()),
+        subagent: Some(env.clone()),
+        permission: ctx.permission.clone(),
+        plan_mode: None,
+        todos: None,
+        ask_user: None,
+        background: None,
+    };
+    let store_worker = Arc::clone(&store);
+    let id_worker = id.clone();
+
+    tokio::spawn(async move {
+        let cwd = cwd_owned.as_deref().map(Path::new);
+        let result = env
+            .runner
+            .run_subagent(&prompt, profile, cwd, &parent_ctx)
+            .await;
+
+        let mut guard = store_worker.lock();
+        if cancel.is_cancelled()
+            || guard
+                .get(&id_worker)
+                .is_some_and(|t| t.status == BackgroundTaskStatus::Cancelled)
+        {
+            return;
+        }
+        match result {
+            Ok(text) => {
+                let report = format_subagent_report(profile, &text);
+                guard.finish(
+                    &id_worker,
+                    BackgroundTaskStatus::Completed,
+                    report,
+                    Some(0),
+                );
+            }
+            Err(err) => {
+                let msg = err.to_string();
+                let status = if msg.contains("aborted") {
+                    BackgroundTaskStatus::Cancelled
+                } else {
+                    BackgroundTaskStatus::Failed
+                };
+                guard.finish(&id_worker, status, msg, None);
+            }
+        }
+    });
+
+    Ok(ToolResult {
+        content: format!(
+            "Started background subagent task `{id}` (profile={profile:?}).\nUse TaskOutput with task_id=\"{id}\" to poll the report, or action=\"kill\" to cancel."
+        ),
+        is_error: false,
+    })
+}
+
+fn format_subagent_report(profile: SubagentProfile, text: &str) -> String {
+    format!(
+        "<subagent-report profile=\"{profile:?}\">\n{text}\n</subagent-report>"
+    )
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", s.chars().take(max).collect::<String>())
     }
 }

--- a/crates/tools/src/task_output.rs
+++ b/crates/tools/src/task_output.rs
@@ -1,0 +1,172 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::json;
+use zene_llm::ToolDefinition;
+
+use crate::background::{BackgroundTaskKind, BackgroundTaskStatus};
+use crate::registry::{Tool, ToolContext, ToolResult};
+
+pub struct TaskOutputTool;
+
+#[derive(Debug, Deserialize)]
+struct TaskOutputArgs {
+    #[serde(default)]
+    task_id: Option<String>,
+    #[serde(default)]
+    action: Option<String>,
+}
+
+#[async_trait]
+impl Tool for TaskOutputTool {
+    fn name(&self) -> &str {
+        "TaskOutput"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: "TaskOutput".to_string(),
+            description: "Inspect or cancel background Bash/Task jobs. Use action=list, get (default), or kill.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "task_id": {
+                        "type": "string",
+                        "description": "Background task id returned by Bash/Task when run_in_background=true"
+                    },
+                    "action": {
+                        "type": "string",
+                        "enum": ["list", "get", "kill"],
+                        "description": "list all tasks, get one task's output, or kill a running task"
+                    }
+                },
+                "required": []
+            }),
+        }
+    }
+
+    async fn execute(&self, arguments: &str, ctx: &ToolContext) -> Result<ToolResult> {
+        let args: TaskOutputArgs =
+            serde_json::from_str(arguments).context("parse TaskOutput args")?;
+        let Some(store) = ctx.background.as_ref() else {
+            return Ok(ToolResult {
+                content: "Background tasks are not available in this context.".into(),
+                is_error: true,
+            });
+        };
+
+        let action = args
+            .action
+            .as_deref()
+            .unwrap_or(if args.task_id.is_some() {
+                "get"
+            } else {
+                "list"
+            })
+            .to_ascii_lowercase();
+
+        match action.as_str() {
+            "list" => {
+                let tasks = store.lock().list();
+                if tasks.is_empty() {
+                    return Ok(ToolResult {
+                        content: "No background tasks.".into(),
+                        is_error: false,
+                    });
+                }
+                let mut lines = Vec::new();
+                for task in tasks {
+                    let kind = match task.kind {
+                        BackgroundTaskKind::Bash => "bash",
+                        BackgroundTaskKind::Subagent => "task",
+                    };
+                    lines.push(format!(
+                        "{} [{}] {} — {}",
+                        task.id,
+                        task.status.as_str(),
+                        kind,
+                        truncate(&task.label, 80)
+                    ));
+                }
+                Ok(ToolResult {
+                    content: lines.join("\n"),
+                    is_error: false,
+                })
+            }
+            "get" => {
+                let Some(id) = args.task_id.as_deref() else {
+                    return Ok(ToolResult {
+                        content: "task_id is required for action=get".into(),
+                        is_error: true,
+                    });
+                };
+                let Some(task) = store.lock().get(id) else {
+                    return Ok(ToolResult {
+                        content: format!("Unknown task_id `{id}`"),
+                        is_error: true,
+                    });
+                };
+                let mut content = format!(
+                    "task_id: {}\nstatus: {}\nlabel: {}\n",
+                    task.id,
+                    task.status.as_str(),
+                    task.label
+                );
+                if let Some(code) = task.exit_code {
+                    content.push_str(&format!("exit_code: {code}\n"));
+                }
+                content.push_str("--- output ---\n");
+                content.push_str(if task.output.is_empty() {
+                    "(no output yet)"
+                } else {
+                    &task.output
+                });
+                Ok(ToolResult {
+                    content,
+                    is_error: task.status == BackgroundTaskStatus::Failed,
+                })
+            }
+            "kill" => {
+                let Some(id) = args.task_id.as_deref() else {
+                    return Ok(ToolResult {
+                        content: "task_id is required for action=kill".into(),
+                        is_error: true,
+                    });
+                };
+                let mut guard = store.lock();
+                let Some(task) = guard.get(id) else {
+                    return Ok(ToolResult {
+                        content: format!("Unknown task_id `{id}`"),
+                        is_error: true,
+                    });
+                };
+                if task.status != BackgroundTaskStatus::Running {
+                    return Ok(ToolResult {
+                        content: format!(
+                            "Task `{id}` is already {}.",
+                            task.status.as_str()
+                        ),
+                        is_error: false,
+                    });
+                }
+                let _ = guard.request_cancel(id);
+                Ok(ToolResult {
+                    content: format!("Cancelled task `{id}`."),
+                    is_error: false,
+                })
+            }
+            other => Ok(ToolResult {
+                content: format!("Unknown action `{other}`; use list|get|kill"),
+                is_error: true,
+            }),
+        }
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", s.chars().take(max).collect::<String>())
+    }
+}

--- a/crates/tools/tests/background_bash.rs
+++ b/crates/tools/tests/background_bash.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tempfile::tempdir;
+use zene_config::WebSearchConfig;
+use zene_sandbox::LocalSandbox;
+use zene_tools::{builtin_tools, shared_background_tasks, ToolContext};
+
+fn ctx(workdir: &std::path::Path) -> ToolContext {
+    ToolContext {
+        sandbox: Arc::new(LocalSandbox::new(workdir)),
+        cancel: None,
+        subagent: None,
+        permission: None,
+        plan_mode: None,
+        todos: None,
+        ask_user: None,
+        background: Some(shared_background_tasks()),
+    }
+}
+
+#[tokio::test]
+async fn background_bash_completes_and_is_readable() {
+    let dir = tempdir().unwrap();
+    let ctx = ctx(dir.path());
+    let tools = builtin_tools(WebSearchConfig::default());
+
+    let started = tools
+        .execute(
+            "Bash",
+            r#"{"command":"echo hello-bg","run_in_background":true}"#,
+            &ctx,
+        )
+        .await
+        .unwrap();
+    assert!(!started.is_error);
+    assert!(started.content.contains("bash-"));
+
+    let task_id = started
+        .content
+        .split('`')
+        .nth(1)
+        .expect("task id in backticks")
+        .to_string();
+
+    // Poll until complete.
+    let mut output = String::new();
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        let result = tools
+            .execute(
+                "TaskOutput",
+                &serde_json::json!({ "task_id": task_id, "action": "get" }).to_string(),
+                &ctx,
+            )
+            .await
+            .unwrap();
+        output = result.content.clone();
+        if output.contains("status: completed") {
+            break;
+        }
+    }
+    assert!(
+        output.contains("hello-bg"),
+        "expected command output, got: {output}"
+    );
+}

--- a/crates/tools/tests/collaboration_web.rs
+++ b/crates/tools/tests/collaboration_web.rs
@@ -14,6 +14,7 @@ fn ctx(workdir: &std::path::Path) -> ToolContext {
         plan_mode: None,
         todos: Some(shared_todo_store()),
         ask_user: None,
+        background: None,
     }
 }
 

--- a/crates/tools/tests/edit_write.rs
+++ b/crates/tools/tests/edit_write.rs
@@ -14,6 +14,7 @@ fn ctx(workdir: &std::path::Path) -> ToolContext {
         plan_mode: None,
         todos: None,
         ask_user: None,
+        background: None,
     }
 }
 

--- a/crates/tools/tests/read_glob.rs
+++ b/crates/tools/tests/read_glob.rs
@@ -14,6 +14,7 @@ fn ctx(workdir: &std::path::Path) -> ToolContext {
         plan_mode: None,
         todos: None,
         ask_user: None,
+        background: None,
     }
 }
 

--- a/crates/tools/tests/web_search.rs
+++ b/crates/tools/tests/web_search.rs
@@ -14,6 +14,7 @@ fn ctx(workdir: &std::path::Path) -> ToolContext {
         plan_mode: None,
         todos: None,
         ask_user: None,
+        background: None,
     }
 }
 

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -101,6 +101,23 @@ Config `[permission_rules]` supports `allow` / `deny` / `ask` patterns (`Bash`, 
 
 Before/after compaction, checkpoints are saved under `~/.zene/sessions/<id>/compaction_checkpoints/`. Slash commands: `/rewind [id]`, `/fork`, `/session-info`.
 
+## Background tasks
+
+`Bash` and `Task` accept `run_in_background=true`. They return a `task_id` immediately; poll or cancel with `TaskOutput` (`action=list|get|kill`). Background Bash uses a longer timeout (30m). Store lives on the main `Agent` for the session.
+
+## Git worktree
+
+`zene --worktree` creates (or reuses) `.zene/worktrees/<session-slug>` via `git worktree add -B zene/<slug>` and runs the agent sandbox there.
+
+## MCP transports
+
+`~/.zene/mcp.json` / `.zene/mcp.json` servers may use:
+
+- **stdio**: `{ "command", "args", "env" }`
+- **HTTP**: `{ "url", "headers" }` (Streamable HTTP / JSON-RPC POST; SSE `data:` frames accepted)
+
+`zene mcp doctor` probes configured servers.
+
 ## LLM layer
 
 - `OpenAiCompatibleProvider` (`crates/llm`) intentionally depends on [`unigateway-sdk`](https://crates.io/crates/unigateway-sdk) from **crates.io** (not a sibling path repo). It drives proxy chat via `UniGatewayEngine` (pools, retry, streaming).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -412,8 +412,8 @@ TUI、record/replay、安装分发。
 | P1 采样/上下文 | [x] | usage 水位、full-replace、输入阶梯、LLM 错误分类、`/compact` |
 | P2 权限 | [x] | default/accept_edits/dont_ask/bypass + allow/deny/ask 规则 |
 | P3 会话恢复 | [x] | compaction checkpoints、`/rewind`、`/fork`、`/session-info` |
-| P4 运行时 | [ ] | 后台 Bash、worktree、更深 subagent（后续） |
-| P5 MCP/扩展 | [~] | `zene mcp doctor`；HTTP MCP 后续 |
+| P4 运行时 | [x] | 后台 Bash/Task + TaskOutput、`--worktree`、subagent 报告包装 |
+| P5 MCP/扩展 | [x] | stdio + HTTP MCP、`zene mcp doctor` |
 | P6 集成/产品化 | [~] | `zene -p` headless + `--output-format json`；ACP 后续 |
 
-*最后更新：2026-07-18（对齐 grok：上下文水位 / full-replace / 权限模式 / checkpoint / headless）*
+*最后更新：2026-07-18（P4/P5：background tasks、worktree、MCP HTTP）*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 摘要

承接已合并的 PR #2，继续对齐 grok 的运行时与 MCP 扩展面。

### 后台任务
- `Bash` / `Task` 支持 `run_in_background=true`，立即返回 `task_id`
- 新工具 `TaskOutput`：`list` / `get` / `kill`
- 后台 Bash 超时 30 分钟；subagent 结果包装为 `<subagent-report>`

### Git worktree
- `zene --worktree`：在 `.zene/worktrees/<slug>` 创建隔离 worktree（`git worktree add -B zene/<slug>`）

### MCP HTTP
- `mcp.json` 支持 `{ "url", "headers" }`（与 stdio `command` 二选一）
- Streamable HTTP JSON-RPC POST，兼容 SSE `data:` 帧
- `zene mcp doctor` 继续可用

文档：`docs/ENGINE.md`、`docs/ROADMAP.md` 已更新。

### 后续
- ACP 编辑器协议仍待做（P6）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

