### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.2.0 (2026-07-18)
+
+### Added
+- Usage-driven context water level, full-replace compaction, and input ladder (`verbatim → fitted → lossy`).
+- Permission modes: `default` / `accept_edits` / `dont_ask` / `bypass`, plus allow/deny/ask rules.
+- Session recovery: compaction checkpoints, `/rewind`, `/fork`, `/session-info`, `/compact`.
+- Background `Bash`/`Task` with `TaskOutput`; `zene --worktree` session git worktrees.
+- MCP HTTP transport alongside stdio; `zene mcp doctor`.
+- Headless `zene -p` with `--output-format json`.
+- Minimal ACP stdio agent: `zene acp` (`initialize`, `session/*`, permission bridge).
+
+### Changed
+- LLM retry classification for overflow / rate-limit / transient errors.
+- Grok-alignment roadmap items P1–P6 marked complete in `docs/ROADMAP.md` / `docs/ENGINE.md`.
+
+## v0.1.5 (2026-05-31)
+
+### Changed
+- Default CLI startup to TUI; `--repl` for line REPL.
+- TUI turn UX, model/provider configuration, and permission prompting improvements.
+
 ## v0.1.4 (2026-05-30)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "zene-cli"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "zene-config"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "zene-core"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "zene-llm"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "zene-mcp"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "zene-sandbox"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "zene-session"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "zene-tools"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Zene Contributors"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
将 workspace 版本升至 **0.2.0**，并更新 `CHANGELOG.md`，覆盖 Grok 对齐迭代（P1–P6）合入后的功能。

合并后将在 `main` 打 `v0.2.0` tag 以触发 GitHub Release 构建。

已删除已合并的远程分支：`cursor/acp-stdio-bc01`、`cursor/align-grok-engine-bc01`、`cursor/runtime-mcp-next-bc01`。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

