### PR TITLE
Release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.2.0 (2026-07-18)
+## v0.1.6 (2026-07-18)
 
 ### Added
 - Usage-driven context water level, full-replace compaction, and input ladder (`verbatim → fitted → lossy`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "zene-cli"
-version = "0.2.0"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "zene-config"
-version = "0.2.0"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "zene-core"
-version = "0.2.0"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3558,7 +3558,7 @@ dependencies = [
 
 [[package]]
 name = "zene-llm"
-version = "0.2.0"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "zene-mcp"
-version = "0.2.0"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3594,7 +3594,7 @@ dependencies = [
 
 [[package]]
 name = "zene-sandbox"
-version = "0.2.0"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "zene-session"
-version = "0.2.0"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3627,7 +3627,7 @@ dependencies = [
 
 [[package]]
 name = "zene-tools"
-version = "0.2.0"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.1.6"
 edition = "2021"
 license = "MIT"
 authors = ["Zene Contributors"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
修正版本号为 **0.1.6**（仓库已有历史 `v0.2.0` tag/release，避免冲突）。

合并后打 `v0.1.6` tag 触发 GitHub Release 构建。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

