### PR TITLE
Stronger grok-build alignment for sampling/context

### DIFF
--- a/apps/cli/src/repl.rs
+++ b/apps/cli/src/repl.rs
@@ -82,6 +82,10 @@ pub async fn run_repl(agent: &mut Agent, cli: &Cli) -> Result<()> {
                     }
                     continue;
                 }
+                if input == "/context" || input == "/tokens" {
+                    println!("{}", agent.context_report());
+                    continue;
+                }
                 if input == "/session-info" {
                     let water = agent.context_water();
                     println!(

--- a/apps/cli/src/tui/mod.rs
+++ b/apps/cli/src/tui/mod.rs
@@ -450,6 +450,16 @@ fn run_tui_sync(
                             app.scroll_to_bottom();
                             continue;
                         }
+                        if input == "/context" || input == "/tokens" {
+                            let (report, pct) = agent_rt.block_on(async {
+                                let g = agent.lock().await;
+                                (g.context_report(), g.context_water().usage_percent())
+                            });
+                            app.context_usage_percent = pct;
+                            app.lines.push(app::ChatLine::Assistant(report));
+                            app.scroll_to_bottom();
+                            continue;
+                        }
                         if input == "/session-info" {
                             let (sid, model, pct, window, msgs) = agent_rt.block_on(async {
                                 let g = agent.lock().await;

--- a/crates/core/src/compaction.rs
+++ b/crates/core/src/compaction.rs
@@ -1,8 +1,9 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use tracing::info;
 use zene_config::CompactionConfig;
 use zene_llm::{ChatClient, ChatRequest, ChatResponse, Message, MessageKind, Role, ToolDefinition};
 use zene_session::SessionRecord;
+use zene_tools::{BackgroundTask, BackgroundTaskStatus};
 
 use crate::input_ladder::{prepare_summary_input, InputLadderStage};
 use crate::tokens::{self, TokenEstimator};
@@ -13,8 +14,9 @@ const SUMMARY_SYSTEM_PROMPT: &str = "You summarize coding agent conversations. P
 const TRUNCATE_TOOL_RESULT_MAX_CHARS: usize = 800;
 /// Max chars kept in assistant text before truncate-only compaction replaces the body.
 const TRUNCATE_ASSISTANT_TEXT_MAX_CHARS: usize = 1_200;
-/// Cleaned summaries shorter than this are treated as degenerate and retried.
-const MIN_SUMMARY_SEED_CHARS: usize = 80;
+/// Cleaned summaries shorter than this are treated as degenerate and retried
+/// (aligned with grok-build `MIN_SUMMARY_SEED_CHARS`).
+pub const MIN_SUMMARY_SEED_CHARS: usize = 500;
 
 pub fn should_compact(estimated_tokens: u32, config: &CompactionConfig) -> bool {
     let threshold =
@@ -70,6 +72,11 @@ pub fn tail_start_index(
     let max_tail_start = messages.len().saturating_sub(min_keep_messages);
     if tail_start > max_tail_start {
         tail_start = max_tail_start;
+    }
+
+    // Never split assistant tool_calls from their tool results (grok tool-pair snap).
+    while tail_start > prefix_start && messages[tail_start].role == Role::Tool {
+        tail_start -= 1;
     }
 
     if tail_start <= prefix_start {
@@ -131,20 +138,54 @@ pub fn assemble_full_replace_history(
     out
 }
 
-fn build_todo_reminder(session: &SessionRecord) -> Option<String> {
-    if session.todos.is_empty() {
-        return None;
+/// Post-compaction `<system-reminder>`: actionable todos + running background tasks.
+pub fn build_compaction_reminder(
+    session: &SessionRecord,
+    background_tasks: &[BackgroundTask],
+) -> Option<String> {
+    let mut sections = Vec::new();
+
+    let actionable: Vec<_> = session
+        .todos
+        .iter()
+        .filter(|item| {
+            !matches!(item.status, zene_session::TodoStatus::Completed)
+        })
+        .collect();
+    if !actionable.is_empty() {
+        let mut lines = vec!["Active todos:".to_string()];
+        for item in actionable {
+            let status = match item.status {
+                zene_session::TodoStatus::Pending => "pending",
+                zene_session::TodoStatus::InProgress => "in_progress",
+                zene_session::TodoStatus::Completed => "completed",
+            };
+            lines.push(format!("- [{status}] {}", item.content));
+        }
+        sections.push(lines.join("\n"));
     }
-    let mut lines = vec!["Active todos:".to_string()];
-    for item in &session.todos {
-        let status = match item.status {
-            zene_session::TodoStatus::Pending => "pending",
-            zene_session::TodoStatus::InProgress => "in_progress",
-            zene_session::TodoStatus::Completed => "completed",
-        };
-        lines.push(format!("- [{status}] {}", item.content));
+
+    let running: Vec<_> = background_tasks
+        .iter()
+        .filter(|t| t.status == BackgroundTaskStatus::Running)
+        .collect();
+    if !running.is_empty() {
+        let mut lines = vec!["Background tasks still running:".to_string()];
+        for task in running {
+            let kind = match task.kind {
+                zene_tools::BackgroundTaskKind::Bash => "bash",
+                zene_tools::BackgroundTaskKind::Subagent => "task",
+            };
+            lines.push(format!("- {} ({kind}): {}", task.id, task.label));
+        }
+        sections.push(lines.join("\n"));
     }
-    Some(lines.join("\n"))
+
+    if sections.is_empty() {
+        None
+    } else {
+        Some(sections.join("\n\n"))
+    }
 }
 
 fn format_messages_for_summary(messages: &[Message]) -> String {
@@ -227,6 +268,11 @@ pub async fn summarize_messages_with_ladder(
                         stage = next;
                         continue;
                     }
+                    bail!(
+                        "compaction summary too short ({} chars; need ≥ {}); refusing to discard conversation state",
+                        summary.chars().count(),
+                        MIN_SUMMARY_SEED_CHARS
+                    );
                 }
                 return Ok(summary);
             }
@@ -734,6 +780,7 @@ pub async fn compact_session(
     reason: &str,
     tools: &[ToolDefinition],
     estimator: &TokenEstimator,
+    background_tasks: &[BackgroundTask],
 ) -> Result<Option<CompactionResult>> {
     if let Some(result) = try_truncate_only_compaction(session, config, tools, estimator) {
         return Ok(Some(result));
@@ -776,6 +823,7 @@ pub async fn compact_session(
         plan.compacted_count,
         reason,
         tokens_before,
+        background_tasks,
     );
 
     let tokens_after = estimate_session_tokens(session, tools, estimator);
@@ -805,9 +853,20 @@ pub async fn compact_session_forced(
     estimator: &TokenEstimator,
     force_summarize: bool,
     user_hint: Option<&str>,
+    background_tasks: &[BackgroundTask],
 ) -> Result<Option<CompactionResult>> {
     if !force_summarize {
-        return compact_session(session, client, model, config, reason, tools, estimator).await;
+        return compact_session(
+            session,
+            client,
+            model,
+            config,
+            reason,
+            tools,
+            estimator,
+            background_tasks,
+        )
+        .await;
     }
 
     let tokens_before = estimate_session_tokens(session, tools, estimator);
@@ -856,6 +915,7 @@ pub async fn compact_session_forced(
         plan.compacted_count,
         reason,
         tokens_before,
+        background_tasks,
     );
 
     let tokens_after = estimate_session_tokens(session, tools, estimator);
@@ -880,6 +940,7 @@ fn apply_full_replace_to_session(
     compacted_count: usize,
     reason: &str,
     tokens_before: u32,
+    background_tasks: &[BackgroundTask],
 ) {
     let system = session
         .messages
@@ -899,7 +960,7 @@ fn apply_full_replace_to_session(
         }
         None => (None, session.messages[tail_start..].to_vec()),
     };
-    let reminder = build_todo_reminder(session);
+    let reminder = build_compaction_reminder(session, background_tasks);
     session.messages =
         assemble_full_replace_history(system, last_user, recent, summary.clone(), reminder);
     session.record_compaction_event(
@@ -1101,7 +1162,8 @@ mod tests {
         assert!(is_degenerate_summary(""));
         assert!(is_degenerate_summary("(empty summary)"));
         assert!(is_degenerate_summary("short"));
-        assert!(!is_degenerate_summary(&"x".repeat(120)));
+        assert!(is_degenerate_summary(&"x".repeat(120)));
+        assert!(!is_degenerate_summary(&"x".repeat(500)));
     }
 
     #[test]

--- a/crates/core/src/context_water.rs
+++ b/crates/core/src/context_water.rs
@@ -15,6 +15,9 @@ pub struct ContextWaterLevel {
     pub last_estimate_tokens: Option<u32>,
     /// Configured context window for the active model.
     pub context_window_tokens: u32,
+    /// When true, skip auto-compact until a successful compact or manual `/compact`
+    /// (grok sticky suppression after hard failure).
+    pub auto_compact_suppressed: bool,
 }
 
 impl ContextWaterLevel {
@@ -23,6 +26,7 @@ impl ContextWaterLevel {
             last_prompt_tokens: None,
             last_estimate_tokens: None,
             context_window_tokens,
+            auto_compact_suppressed: false,
         }
     }
 
@@ -57,10 +61,33 @@ impl ContextWaterLevel {
         ((used * 100) / u64::from(window)).min(100) as u8
     }
 
+    pub fn auto_compact_threshold_percent(config: &CompactionConfig) -> u8 {
+        ((config.trigger_ratio * 100.0).round() as u8).clamp(1, 100)
+    }
+
+    pub fn threshold_tokens(config: &CompactionConfig) -> u32 {
+        (config.context_window_tokens as f32 * config.trigger_ratio).floor() as u32
+    }
+
+    /// Over hard window (preflight after large tool results).
+    pub fn exceeds_window(&self) -> bool {
+        self.context_window_tokens > 0
+            && self.effective_tokens() >= self.context_window_tokens
+    }
+
     pub fn should_compact(&self, config: &CompactionConfig) -> bool {
-        let threshold =
-            (config.context_window_tokens as f32 * config.trigger_ratio).floor() as u32;
-        self.effective_tokens() >= threshold
+        if self.auto_compact_suppressed {
+            return false;
+        }
+        self.effective_tokens() >= Self::threshold_tokens(config)
+    }
+
+    pub fn suppress_auto_compact(&mut self) {
+        self.auto_compact_suppressed = true;
+    }
+
+    pub fn clear_auto_compact_suppression(&mut self) {
+        self.auto_compact_suppressed = false;
     }
 }
 
@@ -85,6 +112,26 @@ mod tests {
     fn uses_estimate_when_no_usage() {
         let mut water = ContextWaterLevel::new(1000);
         water.record_estimate(850);
+        assert!(water.should_compact(&CompactionConfig {
+            trigger_ratio: 0.85,
+            keep_recent_ratio: 0.25,
+            context_window_tokens: 1000,
+            min_keep_messages: 4,
+        }));
+    }
+
+    #[test]
+    fn suppression_blocks_auto_compact() {
+        let mut water = ContextWaterLevel::new(1000);
+        water.record_estimate(900);
+        water.suppress_auto_compact();
+        assert!(!water.should_compact(&CompactionConfig {
+            trigger_ratio: 0.85,
+            keep_recent_ratio: 0.25,
+            context_window_tokens: 1000,
+            min_keep_messages: 4,
+        }));
+        water.clear_auto_compact_suppression();
         assert!(water.should_compact(&CompactionConfig {
             trigger_ratio: 0.85,
             keep_recent_ratio: 0.25,

--- a/crates/core/src/input_ladder.rs
+++ b/crates/core/src/input_ladder.rs
@@ -1,8 +1,8 @@
-//! Compaction input ladder: verbatim → fitted → lossy.
+//! Compaction input ladder: verbatim → fitted → lossy (grok-aligned).
 //!
-//! When summarizing history, start with the full prefix. On context-length
-//! overflow (or when the fitted budget is exceeded), step down to a truncated
-//! then aggressively reduced view so compaction itself can fit.
+//! - **Verbatim**: keep tool I/O and bodies (best for quality / cache-shaped prefix).
+//! - **Fitted**: drop oldest whole turns (never split tool pairs), mild body shrink.
+//! - **Lossy**: flatten tool results to names, aggressive shrink, then fit to budget.
 
 use zene_llm::{Message, MessageKind, Role};
 
@@ -36,7 +36,6 @@ impl InputLadderStage {
 
 const FITTED_TOOL_CHARS: usize = 400;
 const FITTED_ASSISTANT_CHARS: usize = 600;
-const LOSSY_TOOL_CHARS: usize = 120;
 const LOSSY_ASSISTANT_CHARS: usize = 200;
 
 fn truncate_body(content: &str, max_chars: usize) -> String {
@@ -64,6 +63,52 @@ fn shrink_message(message: &Message, tool_max: usize, assistant_max: usize) -> M
     out
 }
 
+fn flatten_tool_result(message: &Message) -> Message {
+    let mut out = message.clone();
+    if out.role == Role::Tool {
+        let name = out.name.as_deref().unwrap_or("tool");
+        let bytes = out.content.as_ref().map(|c| c.len()).unwrap_or(0);
+        out.content = Some(format!("[{name} result omitted for compaction; {bytes} bytes]"));
+    }
+    out
+}
+
+/// Drop oldest non-system messages until under budget, never splitting tool pairs.
+pub fn fit_messages_to_budget(
+    messages: &[Message],
+    budget: u32,
+    estimator: &TokenEstimator,
+) -> Vec<Message> {
+    let mut out = messages.to_vec();
+    while estimator.estimate_messages_tokens(&out) > budget && out.len() > 2 {
+        let drop_at = if out.first().is_some_and(|m| m.role == Role::System) {
+            1
+        } else {
+            0
+        };
+        if drop_at >= out.len().saturating_sub(1) {
+            break;
+        }
+        // If dropping would leave orphan tool results, drop the whole pair.
+        let mut end = drop_at + 1;
+        if out[drop_at].role == Role::Assistant
+            && out[drop_at]
+                .tool_calls
+                .as_ref()
+                .is_some_and(|c| !c.is_empty())
+        {
+            while end < out.len() && out[end].role == Role::Tool {
+                end += 1;
+            }
+        }
+        if end >= out.len() {
+            break;
+        }
+        out.drain(drop_at..end);
+    }
+    out
+}
+
 /// Prepare messages for the summarizer at the given ladder stage.
 pub fn prepare_summary_input(
     messages: &[Message],
@@ -77,55 +122,25 @@ pub fn prepare_summary_input(
             .iter()
             .map(|m| shrink_message(m, FITTED_TOOL_CHARS, FITTED_ASSISTANT_CHARS))
             .collect(),
-        InputLadderStage::Lossy => {
-            let shrunk: Vec<Message> = messages
-                .iter()
-                .map(|m| shrink_message(m, LOSSY_TOOL_CHARS, LOSSY_ASSISTANT_CHARS))
-                .collect();
-            // Keep only the most recent half of non-system messages when still large.
-            if shrunk.len() > 6 {
-                let keep_from = shrunk.len() / 2;
-                let mut out = Vec::new();
-                if shrunk
-                    .first()
-                    .is_some_and(|m| m.role == Role::System)
-                {
-                    out.push(shrunk[0].clone());
-                    out.extend(shrunk[keep_from.max(1)..].iter().cloned());
-                } else {
-                    out.extend(shrunk[keep_from..].iter().cloned());
-                }
-                out
-            } else {
-                shrunk
-            }
-        }
+        InputLadderStage::Lossy => messages
+            .iter()
+            .map(|m| {
+                let flat = flatten_tool_result(m);
+                shrink_message(&flat, 80, LOSSY_ASSISTANT_CHARS)
+            })
+            .collect(),
     };
 
     let Some(budget) = token_budget else {
         return prepared;
     };
-
-    // Trim from the front (after system) until under budget.
-    let mut out = prepared;
-    while estimator.estimate_messages_tokens(&out) > budget && out.len() > 2 {
-        let drop_at = if out.first().is_some_and(|m| m.role == Role::System) {
-            1
-        } else {
-            0
-        };
-        if drop_at >= out.len().saturating_sub(1) {
-            break;
-        }
-        out.remove(drop_at);
-    }
-    out
+    fit_messages_to_budget(&prepared, budget, estimator)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use zene_llm::Message;
+    use zene_llm::{Message, ToolCall};
 
     #[test]
     fn fitted_shortens_tool_bodies() {
@@ -146,19 +161,48 @@ mod tests {
     }
 
     #[test]
-    fn lossy_drops_older_messages() {
+    fn lossy_flattens_tool_results() {
+        let messages = vec![
+            Message::system("sys"),
+            Message::assistant_with_tools(
+                None,
+                vec![ToolCall {
+                    id: "1".into(),
+                    name: "Read".into(),
+                    arguments: "{}".into(),
+                }],
+            ),
+            Message::tool_result("1", "Read", "x".repeat(5000)),
+            Message::user("continue"),
+        ];
+        let lossy = prepare_summary_input(
+            &messages,
+            InputLadderStage::Lossy,
+            Some(400),
+            &TokenEstimator::default(),
+        );
+        let tool = lossy
+            .iter()
+            .find(|m| m.role == Role::Tool)
+            .and_then(|m| m.content.as_deref())
+            .unwrap_or("");
+        assert!(tool.contains("omitted for compaction"));
+    }
+
+    #[test]
+    fn fit_budget_keeps_system() {
         let mut messages = vec![Message::system("sys")];
         for i in 0..20 {
             messages.push(Message::user(format!("msg {i} {}", "x".repeat(80))));
         }
-        let lossy = prepare_summary_input(
+        let fitted = prepare_summary_input(
             &messages,
-            InputLadderStage::Lossy,
+            InputLadderStage::Fitted,
             Some(200),
             &TokenEstimator::default(),
         );
-        assert!(lossy.len() < messages.len());
-        assert_eq!(lossy[0].role, Role::System);
+        assert!(fitted.len() < messages.len());
+        assert_eq!(fitted[0].role, Role::System);
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -264,8 +264,10 @@ impl Agent {
 
     /// Manually compact the conversation (`/compact [hint]`).
     pub async fn compact_now(&mut self, user_hint: Option<&str>) -> Result<Option<CompactionResult>> {
+        self.sync_todos_to_session();
         let tools = self.tool_definitions_for_llm();
         let estimator = self.token_estimator();
+        let background_tasks = self.background.lock().list();
         let _ = save_checkpoint(&self.session, "pre_manual_compact");
         let result = compact_session_forced(
             &mut self.session,
@@ -277,16 +279,68 @@ impl Agent {
             &estimator,
             true,
             user_hint,
+            &background_tasks,
         )
-        .await?;
-        if let Some(result) = &result {
-            self.record_compaction(result)?;
-            let _ = save_checkpoint(&self.session, "post_manual_compact");
-            self.sync_context_water_from_estimate();
+        .await;
+        match result {
+            Ok(result) => {
+                self.context_water.clear_auto_compact_suppression();
+                if let Some(result) = &result {
+                    self.record_compaction(result)?;
+                    let _ = save_checkpoint(&self.session, "post_manual_compact");
+                    self.sync_context_water_from_estimate();
+                }
+                self.session.ensure_system_message(&self.system_prompt);
+                self.session.save()?;
+                Ok(result)
+            }
+            Err(err) => {
+                self.context_water.suppress_auto_compact();
+                Err(err)
+            }
         }
-        self.session.ensure_system_message(&self.system_prompt);
-        self.session.save()?;
-        Ok(result)
+    }
+
+    /// Human-readable context report for `/context` (grok-aligned).
+    pub fn context_report(&self) -> String {
+        let water = &self.context_water;
+        let cfg = &self.config.compaction;
+        let threshold_pct = ContextWaterLevel::auto_compact_threshold_percent(cfg);
+        let threshold_tokens = ContextWaterLevel::threshold_tokens(cfg);
+        let used = water.effective_tokens();
+        let window = water.context_window_tokens.max(1);
+        let mut lines = vec![
+            format!(
+                "context: {}% ({} / {} tokens)",
+                water.usage_percent(),
+                used,
+                window
+            ),
+            format!(
+                "auto-compact at {}% ({} tokens)",
+                threshold_pct, threshold_tokens
+            ),
+            format!(
+                "sources: usage={} estimate={}",
+                water
+                    .last_prompt_tokens
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "-".into()),
+                water
+                    .last_estimate_tokens
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "-".into())
+            ),
+            format!("messages: {}", self.session.messages.len()),
+            format!("model: {}", self.config.model),
+        ];
+        if water.auto_compact_suppressed {
+            lines.push(
+                "auto-compact: suppressed (last summarize failed; use /compact to retry)"
+                    .to_string(),
+            );
+        }
+        lines.join("\n")
     }
 
     /// Rewind to the latest compaction checkpoint (or a specific id).
@@ -536,6 +590,8 @@ impl Agent {
                 if let Some(tool_calls) = assistant_message.tool_calls.clone() {
                     self.session.push_message(assistant_message);
                     self.run_tools(&tool_calls, options, cancel).await?;
+                    // Prefight: tool results may have pushed us over the window.
+                    self.maybe_compact_before_llm().await?;
                     if self.inject_pending_steer(options)? {
                         continue;
                     }
@@ -631,23 +687,41 @@ impl Agent {
         );
         self.warn_if_near_context_limit(self.context_water.effective_tokens() as usize);
 
-        if self.context_water.should_compact(&self.config.compaction) {
+        let preflight = self.context_water.exceeds_window()
+            && !self.context_water.auto_compact_suppressed;
+        if self.context_water.should_compact(&self.config.compaction) || preflight {
+            self.sync_todos_to_session();
             let _ = save_checkpoint(&self.session, "pre_auto_compact");
             let estimator = self.token_estimator();
-            if let Some(result) = compact_session(
+            let background_tasks = self.background.lock().list();
+            let reason = if preflight {
+                "preflight_overflow"
+            } else {
+                "token_threshold"
+            };
+            match compact_session(
                 &mut self.session,
                 &self.client,
                 &self.config.model,
                 &self.config.compaction,
-                "token_threshold",
+                reason,
                 &tools,
                 &estimator,
+                &background_tasks,
             )
-            .await?
+            .await
             {
-                self.record_compaction(&result)?;
-                let _ = save_checkpoint(&self.session, "post_auto_compact");
-                self.sync_context_water_from_estimate();
+                Ok(Some(result)) => {
+                    self.context_water.clear_auto_compact_suppression();
+                    self.record_compaction(&result)?;
+                    let _ = save_checkpoint(&self.session, "post_auto_compact");
+                    self.sync_context_water_from_estimate();
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    warn!(error = %err, "auto-compact failed; suppressing until /compact");
+                    self.context_water.suppress_auto_compact();
+                }
             }
             self.session
                 .ensure_system_message(&self.system_prompt);
@@ -726,9 +800,11 @@ impl Agent {
                     }
                     if !overflow_summarized {
                         overflow_summarized = true;
+                        self.sync_todos_to_session();
                         let _ = save_checkpoint(&self.session, "pre_overflow_compact");
                         let estimator = self.token_estimator();
-                        if let Some(result) = compact_session(
+                        let background_tasks = self.background.lock().list();
+                        match compact_session(
                             &mut self.session,
                             &self.client,
                             &self.config.model,
@@ -736,12 +812,22 @@ impl Agent {
                             "context_overflow",
                             tools,
                             &estimator,
+                            &background_tasks,
                         )
-                        .await?
+                        .await
                         {
-                            self.record_compaction(&result)?;
-                            let _ = save_checkpoint(&self.session, "post_overflow_compact");
-                            self.sync_context_water_from_estimate();
+                            Ok(Some(result)) => {
+                                self.context_water.clear_auto_compact_suppression();
+                                self.record_compaction(&result)?;
+                                let _ = save_checkpoint(&self.session, "post_overflow_compact");
+                                self.sync_context_water_from_estimate();
+                            }
+                            Ok(None) => {}
+                            Err(compact_err) => {
+                                warn!(error = %compact_err, "overflow compact failed");
+                                self.context_water.suppress_auto_compact();
+                                return Err(compact_err);
+                            }
                         }
                         self.session
                             .ensure_system_message(&self.system_prompt);

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -4,6 +4,9 @@ mod http;
 mod manager;
 mod tool;
 mod transport;
+mod truncate;
+
+pub use truncate::{mcp_max_output_bytes, truncate_mcp_output, MCP_MAX_OUTPUT_BYTES};
 
 pub use client::mcp_tool_registry_name;
 pub use config::{

--- a/crates/mcp/src/tool.rs
+++ b/crates/mcp/src/tool.rs
@@ -51,10 +51,12 @@ impl Tool for McpTool {
         }
     }
 
-    async fn execute(&self, arguments: &str, _ctx: &ToolContext) -> Result<ToolResult> {
+    async fn execute(&self, arguments: &str, ctx: &ToolContext) -> Result<ToolResult> {
         let args: Value = serde_json::from_str(arguments).unwrap_or(json!({}));
         let mut client = self.client.lock().await;
         let (content, is_error) = client.call_tool(&self.tool_name, args).await?;
+        let content =
+            crate::truncate::truncate_mcp_output(content, ctx.sandbox.workdir(), &self.registry_name);
         Ok(ToolResult { content, is_error })
     }
 }

--- a/crates/mcp/src/truncate.rs
+++ b/crates/mcp/src/truncate.rs
@@ -1,0 +1,108 @@
+//! Bound MCP tool output so large payloads do not flood the context window.
+//!
+//! Aligned with grok-build's MCP truncate-to-disk: keep a short inline preview,
+//! spill the remainder under `.zene/tool-output/`, and steer the model to Read
+//! the saved file.
+
+use std::fs;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tracing::warn;
+
+/// Default inline cap for MCP tool output (bytes).
+pub const MCP_MAX_OUTPUT_BYTES: usize = 20_000;
+
+/// Env overrides (first wins): `ZENE_MAX_MCP_OUTPUT_BYTES`, `MAX_MCP_OUTPUT_BYTES`.
+pub fn mcp_max_output_bytes() -> usize {
+    for key in ["ZENE_MAX_MCP_OUTPUT_BYTES", "MAX_MCP_OUTPUT_BYTES"] {
+        if let Ok(raw) = std::env::var(key) {
+            if let Ok(n) = raw.trim().parse::<usize>() {
+                if n > 0 {
+                    return n;
+                }
+            }
+        }
+    }
+    MCP_MAX_OUTPUT_BYTES
+}
+
+/// Truncate `content` if over the byte cap; spill the full payload to disk.
+pub fn truncate_mcp_output(content: String, workdir: &Path, tool_name: &str) -> String {
+    let max = mcp_max_output_bytes();
+    if content.len() <= max {
+        return content;
+    }
+
+    let dump_dir = workdir.join(".zene").join("tool-output");
+    if let Err(err) = fs::create_dir_all(&dump_dir) {
+        warn!(error = %err, "failed to create MCP tool-output dir");
+        return truncate_inline(&content, max, None);
+    }
+
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let safe_name = tool_name
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '_' || c == '-' { c } else { '_' })
+        .collect::<String>();
+    let ext = if content.trim_start().starts_with('{') || content.trim_start().starts_with('[') {
+        "json"
+    } else {
+        "txt"
+    };
+    let path = dump_dir.join(format!("{safe_name}-{ts}.{ext}"));
+    if let Err(err) = fs::write(&path, &content) {
+        warn!(error = %err, "failed to spill MCP output");
+        return truncate_inline(&content, max, None);
+    }
+
+    truncate_inline(&content, max, Some(path.display().to_string()))
+}
+
+fn truncate_inline(content: &str, max: usize, saved_path: Option<String>) -> String {
+    let preview_budget = max.saturating_sub(200).max(256);
+    let preview = match content.char_indices().nth(preview_budget) {
+        Some((idx, _)) => &content[..idx],
+        None => content,
+    };
+    let omitted = content.len().saturating_sub(preview.len());
+    match saved_path {
+        Some(path) => format!(
+            "{preview}\n\n[truncated {omitted} bytes; full output saved to {path}. Use the Read tool on that path if you need more.]"
+        ),
+        None => format!(
+            "{preview}\n\n[truncated {omitted} bytes; full MCP output omitted to protect context]"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn leaves_small_output_alone() {
+        let dir = tempdir().unwrap();
+        let out = truncate_mcp_output("hello".into(), dir.path(), "mcp__s__t");
+        assert_eq!(out, "hello");
+    }
+
+    #[test]
+    fn spills_large_output() {
+        let dir = tempdir().unwrap();
+        std::env::set_var("ZENE_MAX_MCP_OUTPUT_BYTES", "500");
+        let big = "x".repeat(2000);
+        let out = truncate_mcp_output(big, dir.path(), "mcp__demo__tool");
+        std::env::remove_var("ZENE_MAX_MCP_OUTPUT_BYTES");
+        assert!(out.contains("truncated"));
+        assert!(out.contains(".zene/tool-output/"));
+        let entries: Vec<_> = fs::read_dir(dir.path().join(".zene/tool-output"))
+            .unwrap()
+            .collect();
+        assert_eq!(entries.len(), 1);
+    }
+}

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -76,15 +76,19 @@ Avoids paying for LLM summarize when truncation alone fixes the overflow.
 
 ### Usage-driven water level
 
-`ContextWaterLevel` (`context_water.rs`) tracks the last provider `prompt_tokens` and the heuristic estimate. Auto-compact triggers on `max(usage, estimate)` vs `context_window * trigger_ratio` (default 85%). Session persists `context_window_usage` / `context_tokens_used`; TUI status shows `ctx N%`.
+`ContextWaterLevel` (`context_water.rs`) tracks the last provider `prompt_tokens` and the heuristic estimate. Auto-compact triggers on `max(usage, estimate)` vs `context_window * trigger_ratio` (default 85%). After tool results, a preflight pass also compacts when the estimate exceeds the hard window. Failed summarize sets sticky suppression until a successful `/compact`. Session persists `context_window_usage` / `context_tokens_used`; TUI shows `ctx N%`; `/context` (alias `/tokens`) prints the report.
 
 ### Full-replace assemble + input ladder
 
 LLM summarize rebuilds history as:
 
-`system + last_user_query + recent_after_query + compaction_summary + optional <system-reminder> (todos)`
+`system + last_user_query + recent_after_query + compaction_summary + optional <system-reminder> (todos + running background tasks)`
 
-Summarizer input steps `verbatim → fitted → lossy` on overflow or degenerate (too-short) summaries (`input_ladder.rs`). Manual `/compact [hint]` forces summarize and writes compaction checkpoints.
+Tail selection snaps so assistant `tool_calls` are never split from their tool results. Summarizer input steps `verbatim → fitted → lossy` (`input_ladder.rs`): fitted shrinks bodies and drops oldest whole turns; lossy flattens tool results. Summaries shorter than **500** chars are rejected (retries, then hard fail — aligned with grok-build). Manual `/compact [hint]` forces summarize and writes compaction checkpoints.
+
+### MCP output bounding
+
+MCP tool results over `ZENE_MAX_MCP_OUTPUT_BYTES` / `MAX_MCP_OUTPUT_BYTES` (default 20_000) are truncated inline and spilled to `.zene/tool-output/` so large payloads do not force premature auto-compact.
 
 ## Permission modes (grok-aligned)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -409,11 +409,11 @@ TUI、record/replay、安装分发。
 
 | 阶段 | 状态 | 内容 |
 |------|------|------|
-| P1 采样/上下文 | [x] | usage 水位、full-replace、输入阶梯、LLM 错误分类、`/compact` |
+| P1 采样/上下文 | [x] | usage 水位、full-replace、输入阶梯、LLM 错误分类、`/compact`；续：硬拒绝短摘要、MCP 落盘截断、`/context`、tool-pair 安全切片、preflight、bg reminder、失败抑制 |
 | P2 权限 | [x] | default/accept_edits/dont_ask/bypass + allow/deny/ask 规则 |
 | P3 会话恢复 | [x] | compaction checkpoints、`/rewind`、`/fork`、`/session-info` |
 | P4 运行时 | [x] | 后台 Bash/Task + TaskOutput、`--worktree`、subagent 报告包装 |
 | P5 MCP/扩展 | [x] | stdio + HTTP MCP、`zene mcp doctor` |
 | P6 集成/产品化 | [x] | `zene -p` headless + `--output-format json`；`zene acp` 最小 ACP stdio |
 
-*最后更新：2026-07-18（P6：ACP stdio）*
+*最后更新：2026-07-18（P1 续：采样/上下文 grok 强对齐）*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
对照 `xai-org/grok-build` 的采样/上下文主路径，补齐此前未对齐的关键能力。

## 本次对齐
- 摘要最短 **500** 字符硬拒绝（阶梯重试后失败，不再接受退化摘要）
- 输入阶梯强化：fitted 整轮丢弃 + tool-pair 安全；lossy 扁平化 tool 结果
- Tail 选择 tool-pair snap；compact 后 reminder 注入 todos + 运行中 background tasks
- 工具后 preflight compact；summarize 失败 sticky 抑制 auto-compact
- MCP 输出默认 20KB 截断并落盘 `.zene/tool-output/`
- `/context`（`/tokens` 别名）展示水位、阈值、usage/estimate

## 仍未覆盖（下一波）
- Prefire / 后台 two-pass compact
- Inter / Intra（StepsOnly 等）多策略
- 精确 tokenizer、Memory flush、CompactionMode(transcript/segments)

## 验证
`cargo test -p zene-core -p zene-mcp`；`cargo test -p zene-cli acp::`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

