### PR TITLE
Prefire two-pass compaction and segment persistence

### DIFF
--- a/crates/core/src/compaction.rs
+++ b/crates/core/src/compaction.rs
@@ -1,12 +1,19 @@
+use std::fs;
+use std::path::PathBuf;
+
 use anyhow::{bail, Context, Result};
 use tracing::info;
 use zene_config::CompactionConfig;
 use zene_llm::{ChatClient, ChatRequest, ChatResponse, Message, MessageKind, Role, ToolDefinition};
-use zene_session::SessionRecord;
+use zene_session::{session_record_dir, SessionRecord};
 use zene_tools::{BackgroundTask, BackgroundTaskStatus};
 
 use crate::input_ladder::{prepare_summary_input, InputLadderStage};
+use crate::prefire::PrefireCache;
 use crate::tokens::{self, TokenEstimator};
+use crate::two_pass::{
+    note_for_pass2, pass2_user_prompt, split_messages_for_two_pass, TWO_PASS_DEFAULT_SPLIT_FRACTION,
+};
 
 const SUMMARY_SYSTEM_PROMPT: &str = "You summarize coding agent conversations. Preserve key user requests, files discussed or modified, tool outcomes, errors and fixes, and current task state. Prefer tight prose over verbatim dumps. Aim for a few hundred to a few thousand words.";
 
@@ -234,6 +241,25 @@ pub async fn summarize_messages_with_ladder(
     context_window: Option<u32>,
     estimator: &TokenEstimator,
 ) -> Result<String> {
+    summarize_prepared_input(
+        client,
+        model,
+        messages,
+        context_window,
+        estimator,
+        "Summarize this conversation for a coding agent to continue work",
+    )
+    .await
+}
+
+async fn summarize_prepared_input(
+    client: &ChatClient,
+    model: &str,
+    messages: &[Message],
+    context_window: Option<u32>,
+    estimator: &TokenEstimator,
+    user_lead: &str,
+) -> Result<String> {
     let mut stage = InputLadderStage::Verbatim;
     let budget = context_window.map(|w| (w as f32 * 0.7).floor() as u32);
 
@@ -244,9 +270,7 @@ pub async fn summarize_messages_with_ladder(
             model: model.to_string(),
             messages: vec![
                 Message::system(SUMMARY_SYSTEM_PROMPT),
-                Message::user(format!(
-                    "Summarize this conversation for a coding agent to continue work:\n\n{conversation}"
-                )),
+                Message::user(format!("{user_lead}:\n\n{conversation}")),
             ],
             tools: Vec::<ToolDefinition>::new(),
             stream: false,
@@ -289,6 +313,134 @@ pub async fn summarize_messages_with_ladder(
             Err(err) => return Err(err).context("compaction summary"),
         }
     }
+}
+
+/// Pass2 of two-pass compaction: merge NOTE₁ with recent tail messages.
+pub async fn summarize_pass2(
+    client: &ChatClient,
+    model: &str,
+    system: Option<&Message>,
+    note1: &str,
+    tail: &[Message],
+    context_window: Option<u32>,
+    estimator: &TokenEstimator,
+    hint: Option<&str>,
+) -> Result<String> {
+    let mut msgs = Vec::new();
+    if let Some(system) = system {
+        msgs.push(system.clone());
+    }
+    msgs.push(Message::user(format!(
+        "Your conversation was summarized due to context constraints. \
+         Here is the summary of the conversation so far:\n\n\
+         <summary_content>\n{}\n</summary_content>",
+        note_for_pass2(note1)
+    )));
+    msgs.extend(tail.iter().cloned());
+    msgs.push(Message::user(pass2_user_prompt(note1, hint)));
+    summarize_prepared_input(
+        client,
+        model,
+        &msgs,
+        context_window,
+        estimator,
+        "Produce the final compaction summary",
+    )
+    .await
+}
+
+/// Summarize a compactable prefix, using prefire NOTE₁ when valid, else sync two-pass
+/// for large prefixes, else single-pass ladder.
+pub async fn summarize_prefix(
+    client: &ChatClient,
+    model: &str,
+    prefix: &[Message],
+    context_window: Option<u32>,
+    estimator: &TokenEstimator,
+    prefire: Option<&PrefireCache>,
+    hint: Option<&str>,
+) -> Result<String> {
+    let system = prefix.first().filter(|m| m.role == Role::System);
+    let body_start = if system.is_some() { 1 } else { 0 };
+    let body = &prefix[body_start..];
+
+    if let Some(cache) = prefire {
+        if cache.split_idx > 0 && cache.split_idx < body.len() {
+            let pass1_prefix = &body[..cache.split_idx];
+            let tail = &body[cache.split_idx..];
+            info!(
+                split_idx = cache.split_idx,
+                note1_chars = cache.note1.len(),
+                "compaction using prefire NOTE₁ (two-pass pass2)"
+            );
+            return summarize_pass2(
+                client,
+                model,
+                system,
+                &cache.note1,
+                tail,
+                context_window,
+                estimator,
+                hint,
+            )
+            .await;
+        }
+    }
+
+    let body_tokens = estimator.estimate_messages_tokens(body);
+    let two_pass_min = context_window
+        .map(|w| (w as f32 * 0.35).floor() as u32)
+        .unwrap_or(8_000);
+    if body.len() >= 8 && body_tokens >= two_pass_min {
+        let split = split_messages_for_two_pass(body, estimator, TWO_PASS_DEFAULT_SPLIT_FRACTION);
+        if split.split_idx > 0 && split.split_idx < body.len() {
+            info!(
+                split_idx = split.split_idx,
+                body_tokens, "compaction sync two-pass (no prefire cache)"
+            );
+            let note1 = summarize_messages_with_ladder(
+                client,
+                model,
+                &body[..split.split_idx],
+                context_window,
+                estimator,
+            )
+            .await?;
+            return summarize_pass2(
+                client,
+                model,
+                system,
+                &note1,
+                &body[split.split_idx..],
+                context_window,
+                estimator,
+                hint,
+            )
+            .await;
+        }
+    }
+
+    summarize_messages_with_ladder(client, model, prefix, context_window, estimator).await
+}
+
+/// Persist compacted prefix for recovery (grok CompactionMode::Segments lite).
+pub fn persist_compaction_segment(
+    session_id: &str,
+    prefix: &[Message],
+    summary: &str,
+) -> Result<PathBuf> {
+    let dir = session_record_dir(session_id).join("compaction_segments");
+    fs::create_dir_all(&dir).context("create compaction_segments dir")?;
+    let ts = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
+    let path = dir.join(format!("{ts}.md"));
+    let mut body = String::new();
+    body.push_str("# Compaction segment\n\n");
+    body.push_str("## Final summary\n\n");
+    body.push_str(summary);
+    body.push_str("\n\n## Compacted prefix\n\n");
+    body.push_str(&format_messages_for_summary(prefix));
+    fs::write(&path, body).context("write compaction segment")?;
+    Ok(path)
 }
 
 pub struct CompactionPlan {
@@ -781,6 +933,7 @@ pub async fn compact_session(
     tools: &[ToolDefinition],
     estimator: &TokenEstimator,
     background_tasks: &[BackgroundTask],
+    prefire: Option<&PrefireCache>,
 ) -> Result<Option<CompactionResult>> {
     if let Some(result) = try_truncate_only_compaction(session, config, tools, estimator) {
         return Ok(Some(result));
@@ -798,14 +951,20 @@ pub async fn compact_session(
 
     let prefix_start = system_prefix_start(&session.messages);
     let prefix = session.messages[prefix_start..plan.tail_start].to_vec();
-    let summary = summarize_messages_with_ladder(
+    let summary = summarize_prefix(
         client,
         model,
         &prefix,
         Some(config.context_window_tokens),
         estimator,
+        prefire,
+        None,
     )
     .await?;
+
+    if let Ok(path) = persist_compaction_segment(&session.meta.id, &prefix, &summary) {
+        info!(path = %path.display(), "wrote compaction segment");
+    }
 
     info!(
         reason = reason,
@@ -854,6 +1013,7 @@ pub async fn compact_session_forced(
     force_summarize: bool,
     user_hint: Option<&str>,
     background_tasks: &[BackgroundTask],
+    prefire: Option<&PrefireCache>,
 ) -> Result<Option<CompactionResult>> {
     if !force_summarize {
         return compact_session(
@@ -865,6 +1025,7 @@ pub async fn compact_session_forced(
             tools,
             estimator,
             background_tasks,
+            prefire,
         )
         .await;
     }
@@ -890,23 +1051,21 @@ pub async fn compact_session_forced(
     };
 
     let prefix_start = system_prefix_start(&session.messages);
-    let mut prefix = session.messages[prefix_start..plan.tail_start].to_vec();
-    if let Some(hint) = user_hint {
-        if !hint.trim().is_empty() {
-            prefix.push(Message::user(format!(
-                "Additional compaction guidance from the user: {hint}"
-            )));
-        }
-    }
-
-    let summary = summarize_messages_with_ladder(
+    let prefix = session.messages[prefix_start..plan.tail_start].to_vec();
+    let summary = summarize_prefix(
         client,
         model,
         &prefix,
         Some(config.context_window_tokens),
         estimator,
+        prefire,
+        user_hint,
     )
     .await?;
+
+    if let Ok(path) = persist_compaction_segment(&session.meta.id, &prefix, &summary) {
+        info!(path = %path.display(), "wrote compaction segment");
+    }
 
     apply_full_replace_to_session(
         session,

--- a/crates/core/src/context_water.rs
+++ b/crates/core/src/context_water.rs
@@ -82,6 +82,16 @@ impl ContextWaterLevel {
         self.effective_tokens() >= Self::threshold_tokens(config)
     }
 
+    /// Start background prefire when usage reaches `threshold% - lead`.
+    pub fn should_prefire(&self, config: &CompactionConfig, lead_percent: u8) -> bool {
+        if self.auto_compact_suppressed || self.should_compact(config) {
+            return false;
+        }
+        let threshold_pct = Self::auto_compact_threshold_percent(config);
+        let start = threshold_pct.saturating_sub(lead_percent);
+        self.usage_percent() >= start
+    }
+
     pub fn suppress_auto_compact(&mut self) {
         self.auto_compact_suppressed = true;
     }
@@ -138,5 +148,21 @@ mod tests {
             context_window_tokens: 1000,
             min_keep_messages: 4,
         }));
+    }
+
+    #[test]
+    fn prefire_starts_before_threshold() {
+        let cfg = CompactionConfig {
+            trigger_ratio: 0.85,
+            keep_recent_ratio: 0.25,
+            context_window_tokens: 1000,
+            min_keep_messages: 4,
+        };
+        let mut water = ContextWaterLevel::new(1000);
+        water.record_estimate(760); // 76% — lead 10pp below 85%
+        assert!(water.should_prefire(&cfg, 10));
+        assert!(!water.should_compact(&cfg));
+        water.record_estimate(900);
+        assert!(!water.should_prefire(&cfg, 10)); // already at compact
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -29,12 +29,14 @@ mod hooks;
 mod input_ladder;
 mod permission;
 mod plan_mode;
+mod prefire;
 mod skills;
 mod subagent;
 mod tokens;
 mod tool_dedup;
 pub mod tool_scheduler;
 mod turn;
+mod two_pass;
 mod worktree;
 
 use compaction::{
@@ -84,6 +86,7 @@ pub struct Agent {
     record_writer: AgentRecordWriter,
     mcp: Option<McpManager>,
     background: SharedBackgroundTasks,
+    prefire: prefire::PrefireState,
 }
 
 pub struct PromptOptions {
@@ -163,6 +166,7 @@ impl Agent {
             record_writer,
             mcp,
             background: shared_background_tasks(),
+            prefire: prefire::PrefireState::new(),
         })
     }
 
@@ -268,6 +272,8 @@ impl Agent {
         let tools = self.tool_definitions_for_llm();
         let estimator = self.token_estimator();
         let background_tasks = self.background.lock().list();
+        self.prefire.await_in_flight().await;
+        let prefire_cache = self.prefire_cache_for_current_prefix();
         let _ = save_checkpoint(&self.session, "pre_manual_compact");
         let result = compact_session_forced(
             &mut self.session,
@@ -280,8 +286,10 @@ impl Agent {
             true,
             user_hint,
             &background_tasks,
+            prefire_cache.as_ref(),
         )
         .await;
+        self.prefire.clear();
         match result {
             Ok(result) => {
                 self.context_water.clear_auto_compact_suppression();
@@ -340,6 +348,11 @@ impl Agent {
                     .to_string(),
             );
         }
+        if self.prefire.has_cache() {
+            lines.push("prefire: NOTE₁ cached (two-pass ready)".to_string());
+        } else if self.prefire.is_in_flight() {
+            lines.push("prefire: pass1 in flight".to_string());
+        }
         lines.join("\n")
     }
 
@@ -357,6 +370,7 @@ impl Agent {
             self.context_water.last_prompt_tokens = Some(tokens);
             self.context_water.last_estimate_tokens = Some(tokens);
         }
+        self.prefire.clear();
         self.session.save()?;
         Ok(id)
     }
@@ -371,6 +385,7 @@ impl Agent {
         self.session = forked;
         self.record_writer = AgentRecordWriter::for_session(&id)?;
         self.todos = shared_todo_store_from(self.session.todos.clone());
+        self.prefire.clear();
         Ok(id)
     }
 
@@ -687,10 +702,14 @@ impl Agent {
         );
         self.warn_if_near_context_limit(self.context_water.effective_tokens() as usize);
 
+        self.maybe_start_prefire();
+
         let preflight = self.context_water.exceeds_window()
             && !self.context_water.auto_compact_suppressed;
         if self.context_water.should_compact(&self.config.compaction) || preflight {
             self.sync_todos_to_session();
+            self.prefire.await_in_flight().await;
+            let prefire_cache = self.prefire_cache_for_current_prefix();
             let _ = save_checkpoint(&self.session, "pre_auto_compact");
             let estimator = self.token_estimator();
             let background_tasks = self.background.lock().list();
@@ -708,10 +727,12 @@ impl Agent {
                 &tools,
                 &estimator,
                 &background_tasks,
+                prefire_cache.as_ref(),
             )
             .await
             {
                 Ok(Some(result)) => {
+                    self.prefire.clear();
                     self.context_water.clear_auto_compact_suppression();
                     self.record_compaction(&result)?;
                     let _ = save_checkpoint(&self.session, "post_auto_compact");
@@ -727,6 +748,108 @@ impl Agent {
                 .ensure_system_message(&self.system_prompt);
         }
         Ok(())
+    }
+
+    fn prefire_cache_for_current_prefix(&self) -> Option<prefire::PrefireCache> {
+        let prefix_start = if self
+            .session
+            .messages
+            .first()
+            .is_some_and(|m| m.role == zene_llm::Role::System)
+        {
+            1
+        } else {
+            0
+        };
+        let body = &self.session.messages[prefix_start..];
+        self.prefire.valid_cache_for(body)
+    }
+
+    fn maybe_start_prefire(&self) {
+        let lead = prefire::prefire_lead_percent();
+        if !self
+            .context_water
+            .should_prefire(&self.config.compaction, lead)
+        {
+            return;
+        }
+        if self.prefire.is_in_flight() || self.prefire.has_cache() {
+            return;
+        }
+
+        let estimator = self.token_estimator();
+        let messages = self.session.messages.clone();
+        let prefix_start = if messages
+            .first()
+            .is_some_and(|m| m.role == zene_llm::Role::System)
+        {
+            1
+        } else {
+            0
+        };
+        if messages.len().saturating_sub(prefix_start) < 8 {
+            return;
+        }
+        let body = messages[prefix_start..].to_vec();
+        let split = two_pass::split_messages_for_two_pass(
+            &body,
+            &estimator,
+            two_pass::TWO_PASS_DEFAULT_SPLIT_FRACTION,
+        );
+        if split.split_idx == 0 || split.split_idx >= body.len() {
+            return;
+        }
+        let pass1_prefix = body[..split.split_idx].to_vec();
+        let fingerprint = two_pass::fingerprint_messages(&pass1_prefix);
+        if self.prefire.already_launched_for(fingerprint) {
+            return;
+        }
+
+        let config = self.config.clone();
+        let model = self.config.model.clone();
+        let window = self.config.compaction.context_window_tokens;
+        let split_idx = split.split_idx;
+        info!(
+            split_idx,
+            usage_percent = self.context_water.usage_percent(),
+            "starting prefire pass1"
+        );
+        let handle = tokio::spawn(async move {
+            let client = match ChatClient::from_config(&config).await {
+                Ok(c) => c,
+                Err(err) => {
+                    warn!(error = %err, "prefire: failed to create client");
+                    return None;
+                }
+            };
+            match compaction::summarize_messages_with_ladder(
+                &client,
+                &model,
+                &pass1_prefix,
+                Some(window),
+                &estimator,
+            )
+            .await
+            {
+                Ok(note1) => {
+                    if note1.trim().is_empty() {
+                        return None;
+                    }
+                    info!(note1_chars = note1.len(), "prefire pass1 cached NOTE₁");
+                    Some(prefire::PrefireCache {
+                        note1,
+                        fingerprint,
+                        split_idx,
+                        prefix_end: prefix_start + split_idx,
+                    })
+                }
+                Err(err) => {
+                    warn!(error = %err, "prefire pass1 failed");
+                    None
+                }
+            }
+        });
+        self.prefire.set_handle(fingerprint, handle);
     }
 
     fn sync_context_water_from_estimate(&mut self) {
@@ -801,6 +924,8 @@ impl Agent {
                     if !overflow_summarized {
                         overflow_summarized = true;
                         self.sync_todos_to_session();
+                        self.prefire.await_in_flight().await;
+                        let prefire_cache = self.prefire_cache_for_current_prefix();
                         let _ = save_checkpoint(&self.session, "pre_overflow_compact");
                         let estimator = self.token_estimator();
                         let background_tasks = self.background.lock().list();
@@ -813,10 +938,12 @@ impl Agent {
                             tools,
                             &estimator,
                             &background_tasks,
+                            prefire_cache.as_ref(),
                         )
                         .await
                         {
                             Ok(Some(result)) => {
+                                self.prefire.clear();
                                 self.context_water.clear_auto_compact_suppression();
                                 self.record_compaction(&result)?;
                                 let _ = save_checkpoint(&self.session, "post_overflow_compact");

--- a/crates/core/src/prefire.rs
+++ b/crates/core/src/prefire.rs
@@ -1,0 +1,128 @@
+//! Background prefire state for two-pass compaction.
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tokio::task::JoinHandle;
+
+use crate::two_pass::fingerprint_messages;
+use zene_llm::Message;
+
+/// Cached NOTE₁ from a completed prefire pass1.
+#[derive(Debug, Clone)]
+pub struct PrefireCache {
+    pub note1: String,
+    pub fingerprint: u64,
+    pub split_idx: usize,
+    /// Absolute index into session.messages where the pass1 prefix ended
+    /// (including any leading system message offset handled by caller).
+    pub prefix_end: usize,
+}
+
+pub struct PrefireState {
+    inner: Arc<Mutex<PrefireInner>>,
+}
+
+#[derive(Default)]
+struct PrefireInner {
+    cache: Option<PrefireCache>,
+    handle: Option<JoinHandle<Option<PrefireCache>>>,
+    /// Fingerprint we already launched a job for (avoid duplicate spawns).
+    launched_for: Option<u64>,
+}
+
+impl Default for PrefireState {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(PrefireInner::default())),
+        }
+    }
+}
+
+impl PrefireState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn clear(&self) {
+        let mut g = self.inner.lock();
+        if let Some(handle) = g.handle.take() {
+            handle.abort();
+        }
+        g.cache = None;
+        g.launched_for = None;
+    }
+
+    pub fn is_in_flight(&self) -> bool {
+        self.inner.lock().handle.is_some()
+    }
+
+    pub fn has_cache(&self) -> bool {
+        self.inner.lock().cache.is_some()
+    }
+
+    pub fn store(&self, cache: PrefireCache) {
+        let mut g = self.inner.lock();
+        g.cache = Some(cache);
+        g.handle = None;
+    }
+
+    pub fn take_cache(&self) -> Option<PrefireCache> {
+        self.inner.lock().cache.take()
+    }
+
+    pub fn peek_cache(&self) -> Option<PrefireCache> {
+        self.inner.lock().cache.clone()
+    }
+
+    /// Return cached NOTE₁ if fingerprint still matches the pass1 slice of `body`.
+    pub fn valid_cache_for(&self, body: &[Message]) -> Option<PrefireCache> {
+        let cache = self.peek_cache()?;
+        if cache.split_idx == 0 || cache.split_idx > body.len() {
+            return None;
+        }
+        let fp = fingerprint_messages(&body[..cache.split_idx]);
+        if cache.fingerprint == fp {
+            Some(cache)
+        } else {
+            None
+        }
+    }
+
+    pub fn already_launched_for(&self, fingerprint: u64) -> bool {
+        self.inner.lock().launched_for == Some(fingerprint)
+    }
+
+    pub fn set_handle(&self, fingerprint: u64, handle: JoinHandle<Option<PrefireCache>>) {
+        let mut g = self.inner.lock();
+        if let Some(old) = g.handle.take() {
+            old.abort();
+        }
+        g.launched_for = Some(fingerprint);
+        g.handle = Some(handle);
+    }
+
+    /// Wait for in-flight prefire (if any) and store the result.
+    pub async fn await_in_flight(&self) {
+        let handle = { self.inner.lock().handle.take() };
+        if let Some(handle) = handle {
+            match handle.await {
+                Ok(Some(cache)) => self.store(cache),
+                Ok(None) => {
+                    self.inner.lock().launched_for = None;
+                }
+                Err(_) => {
+                    self.inner.lock().launched_for = None;
+                }
+            }
+        }
+    }
+}
+
+/// Default percentage points below auto-compact threshold to start prefire.
+pub fn prefire_lead_percent() -> u8 {
+    std::env::var("ZENE_PREFIRE_LEAD_PERCENT")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(10)
+}

--- a/crates/core/src/two_pass.rs
+++ b/crates/core/src/two_pass.rs
@@ -1,0 +1,174 @@
+//! Prefire / two-pass compaction helpers (grok-build aligned).
+//!
+//! Pass1 summarizes ~95% of the compactable prefix → NOTE₁.
+//! Pass2 merges NOTE₁ with the remaining ~5% tail into the final summary.
+
+use std::hash::{Hash, Hasher};
+
+use zene_llm::{Message, Role};
+
+use crate::tokens::TokenEstimator;
+
+/// Default history fraction covered by pass1.
+pub const TWO_PASS_DEFAULT_SPLIT_FRACTION: f64 = 0.95;
+const TWO_PASS_MAX_NOTE1_CHARS: usize = 12_000;
+
+#[derive(Debug, Clone, Copy)]
+pub struct TwoPassSplit {
+    pub split_idx: usize,
+}
+
+/// Cheap fingerprint of a message prefix for prefire NOTE₁ validity.
+pub fn fingerprint_messages(messages: &[Message]) -> u64 {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    messages.len().hash(&mut h);
+    for m in messages {
+        let tag: u8 = match m.role {
+            Role::System => 0,
+            Role::User => 1,
+            Role::Assistant => 2,
+            Role::Tool => 3,
+        };
+        tag.hash(&mut h);
+        if let Some(content) = &m.content {
+            content.hash(&mut h);
+        }
+        if let Some(calls) = &m.tool_calls {
+            for c in calls {
+                c.id.hash(&mut h);
+                c.name.hash(&mut h);
+                c.arguments.hash(&mut h);
+            }
+        }
+        if let Some(name) = &m.name {
+            name.hash(&mut h);
+        }
+    }
+    h.finish()
+}
+
+fn split_index_by_token_fraction(weights: &[u32], fraction: f64) -> usize {
+    if weights.is_empty() {
+        return 0;
+    }
+    let frac = fraction.clamp(0.05, 0.95);
+    let total = weights.iter().copied().sum::<u32>().max(1);
+    let target = frac * f64::from(total);
+    let mut acc = 0u32;
+    let mut split_idx = weights.len().saturating_sub(1).max(1);
+    for (i, w) in weights.iter().enumerate() {
+        acc = acc.saturating_add(*w);
+        if f64::from(acc) >= target {
+            split_idx = (i + 1).max(1);
+            break;
+        }
+    }
+    if split_idx >= weights.len() && weights.len() > 1 {
+        split_idx = weights.len() - 1;
+    }
+    split_idx
+}
+
+fn snap_split_idx_to_tool_boundaries(messages: &[Message], mut split_idx: usize) -> usize {
+    let n = messages.len();
+    if n == 0 {
+        return 0;
+    }
+    split_idx = split_idx.min(n);
+    while split_idx < n && messages[split_idx].role == Role::Tool {
+        split_idx += 1;
+    }
+    if split_idx < n
+        && messages[split_idx].role == Role::Assistant
+        && messages[split_idx]
+            .tool_calls
+            .as_ref()
+            .is_some_and(|c| !c.is_empty())
+    {
+        split_idx += 1;
+        while split_idx < n && messages[split_idx].role == Role::Tool {
+            split_idx += 1;
+        }
+    }
+    if split_idx >= n && n > 1 {
+        split_idx = n - 1;
+        while split_idx > 1 && messages[split_idx].role == Role::Tool {
+            split_idx -= 1;
+        }
+    }
+    split_idx.min(n)
+}
+
+/// Split compactable messages into pass1 prefix / pass2 tail.
+pub fn split_messages_for_two_pass(
+    messages: &[Message],
+    estimator: &TokenEstimator,
+    split_fraction: f64,
+) -> TwoPassSplit {
+    let weights: Vec<u32> = messages
+        .iter()
+        .map(|m| estimator.estimate_message_tokens(m))
+        .collect();
+    let mut split_idx = split_index_by_token_fraction(&weights, split_fraction);
+    split_idx = snap_split_idx_to_tool_boundaries(messages, split_idx);
+    TwoPassSplit {
+        split_idx: split_idx.min(messages.len()),
+    }
+}
+
+/// Cap NOTE₁ embedded into pass2.
+pub fn note_for_pass2(pass1_raw: &str) -> String {
+    let mut note = pass1_raw.trim().to_string();
+    let n = note.chars().count();
+    if n > TWO_PASS_MAX_NOTE1_CHARS {
+        note = note.chars().take(TWO_PASS_MAX_NOTE1_CHARS).collect();
+        note.push_str("\n\n[… NOTE₁ truncated for pass2 input budget …]");
+    }
+    note
+}
+
+pub fn pass2_user_prompt(note1: &str, hint: Option<&str>) -> String {
+    let note1 = note_for_pass2(note1);
+    let guidance = hint.unwrap_or("Merge prior summary with recent turns into one self-contained note.");
+    format!(
+        "This is a two-pass / hierarchical compaction.\n\
+         You are writing the *final* compaction note a successor assistant will rely on.\n\n\
+         Critical requirements:\n\
+         - Incorporate the **entire** prior summary below — do not omit sections.\n\
+         - Merge that prior summary with the more recent conversation turns above into \
+         one coherent, faithful, self-contained summary.\n\
+         - Preserve concrete values, file paths, errors/blockers, and pending tasks.\n\n\
+         Prior summary to incorporate in full:\n\n\
+         <summary_content>\n{note1}\n</summary_content>\n\n\
+         Compaction guidance:\n{guidance}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zene_llm::Message;
+
+    #[test]
+    fn split_leaves_tail() {
+        let messages: Vec<_> = (0..10).map(|i| Message::user(format!("m{i}"))).collect();
+        let split = split_messages_for_two_pass(&messages, &TokenEstimator::default(), 0.9);
+        assert!(split.split_idx < messages.len());
+        assert!(split.split_idx >= 1);
+    }
+
+    #[test]
+    fn fingerprint_changes_with_content() {
+        let a = vec![Message::user("hello")];
+        let b = vec![Message::user("HELLO")];
+        assert_ne!(fingerprint_messages(&a), fingerprint_messages(&b));
+    }
+
+    #[test]
+    fn note_caps_length() {
+        let huge = "x".repeat(20_000);
+        let note = note_for_pass2(&huge);
+        assert!(note.chars().count() < 13_000);
+        assert!(note.contains("truncated"));
+    }
+}

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -90,6 +90,10 @@ Tail selection snaps so assistant `tool_calls` are never split from their tool r
 
 MCP tool results over `ZENE_MAX_MCP_OUTPUT_BYTES` / `MAX_MCP_OUTPUT_BYTES` (default 20_000) are truncated inline and spilled to `.zene/tool-output/` so large payloads do not force premature auto-compact.
 
+### Prefire two-pass + segments
+
+When usage reaches auto-compact threshold minus `ZENE_PREFIRE_LEAD_PERCENT` (default 10pp), a background pass1 summarizes ~95% of history into NOTE₁. At compact time, pass2 merges NOTE₁ with the recent tail (prefire hit). Without a valid cache, large prefixes still use synchronous two-pass. Compacted prefixes are also written under `~/.zene/sessions/<id>/compaction_segments/` for recovery.
+
 ## Permission modes (grok-aligned)
 
 | Mode | Behavior |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -409,11 +409,11 @@ TUI、record/replay、安装分发。
 
 | 阶段 | 状态 | 内容 |
 |------|------|------|
-| P1 采样/上下文 | [x] | usage 水位、full-replace、输入阶梯、LLM 错误分类、`/compact`；续：硬拒绝短摘要、MCP 落盘截断、`/context`、tool-pair 安全切片、preflight、bg reminder、失败抑制 |
+| P1 采样/上下文 | [x] | 水位/full-replace/阶梯/错误分类；续1：硬拒绝短摘要、MCP 落盘、`/context`、tool-pair、preflight、reminder、抑制；续2：prefire two-pass、sync two-pass、compaction segments |
 | P2 权限 | [x] | default/accept_edits/dont_ask/bypass + allow/deny/ask 规则 |
 | P3 会话恢复 | [x] | compaction checkpoints、`/rewind`、`/fork`、`/session-info` |
 | P4 运行时 | [x] | 后台 Bash/Task + TaskOutput、`--worktree`、subagent 报告包装 |
 | P5 MCP/扩展 | [x] | stdio + HTTP MCP、`zene mcp doctor` |
 | P6 集成/产品化 | [x] | `zene -p` headless + `--output-format json`；`zene acp` 最小 ACP stdio |
 
-*最后更新：2026-07-18（P1 续：采样/上下文 grok 强对齐）*
+*最后更新：2026-07-18（P1 续2：prefire two-pass / segments）*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR 7 合入后的采样/上下文续作，继续对齐 grok-build 的 prefire / two-pass 路径。

## 变更
- 水位到阈值 − `ZENE_PREFIRE_LEAD_PERCENT`（默认 10pp）时后台跑 pass1，缓存 NOTE₁
- compact 时若 fingerprint 仍有效则走 pass2；否则大前缀同步 two-pass；小前缀保持单次阶梯摘要
- 压缩前缀落盘 `~/.zene/sessions/<id>/compaction_segments/`
- `/context` 显示 prefire 状态；rewind/fork 清缓存

## 仍未覆盖
Inter/Intra 多模式策略、精确 tokenizer、完整 Memory flush

## 验证
`cargo test -p zene-core`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

