### PR TITLE
Memory flush/injection and intra tool output bounds

### DIFF
--- a/crates/core/src/compaction.rs
+++ b/crates/core/src/compaction.rs
@@ -145,10 +145,11 @@ pub fn assemble_full_replace_history(
     out
 }
 
-/// Post-compaction `<system-reminder>`: actionable todos + running background tasks.
+/// Post-compaction `<system-reminder>`: todos, background tasks, memory.
 pub fn build_compaction_reminder(
     session: &SessionRecord,
     background_tasks: &[BackgroundTask],
+    memory_block: Option<&str>,
 ) -> Option<String> {
     let mut sections = Vec::new();
 
@@ -186,6 +187,12 @@ pub fn build_compaction_reminder(
             lines.push(format!("- {} ({kind}): {}", task.id, task.label));
         }
         sections.push(lines.join("\n"));
+    }
+
+    if let Some(memory) = memory_block {
+        if !memory.trim().is_empty() {
+            sections.push(memory.trim().to_string());
+        }
     }
 
     if sections.is_empty() {
@@ -934,6 +941,7 @@ pub async fn compact_session(
     estimator: &TokenEstimator,
     background_tasks: &[BackgroundTask],
     prefire: Option<&PrefireCache>,
+    memory_block: Option<&str>,
 ) -> Result<Option<CompactionResult>> {
     if let Some(result) = try_truncate_only_compaction(session, config, tools, estimator) {
         return Ok(Some(result));
@@ -983,6 +991,7 @@ pub async fn compact_session(
         reason,
         tokens_before,
         background_tasks,
+        memory_block,
     );
 
     let tokens_after = estimate_session_tokens(session, tools, estimator);
@@ -1014,6 +1023,7 @@ pub async fn compact_session_forced(
     user_hint: Option<&str>,
     background_tasks: &[BackgroundTask],
     prefire: Option<&PrefireCache>,
+    memory_block: Option<&str>,
 ) -> Result<Option<CompactionResult>> {
     if !force_summarize {
         return compact_session(
@@ -1026,6 +1036,7 @@ pub async fn compact_session_forced(
             estimator,
             background_tasks,
             prefire,
+            memory_block,
         )
         .await;
     }
@@ -1075,6 +1086,7 @@ pub async fn compact_session_forced(
         reason,
         tokens_before,
         background_tasks,
+        memory_block,
     );
 
     let tokens_after = estimate_session_tokens(session, tools, estimator);
@@ -1100,6 +1112,7 @@ fn apply_full_replace_to_session(
     reason: &str,
     tokens_before: u32,
     background_tasks: &[BackgroundTask],
+    memory_block: Option<&str>,
 ) {
     let system = session
         .messages
@@ -1119,7 +1132,7 @@ fn apply_full_replace_to_session(
         }
         None => (None, session.messages[tail_start..].to_vec()),
     };
-    let reminder = build_compaction_reminder(session, background_tasks);
+    let reminder = build_compaction_reminder(session, background_tasks, memory_block);
     session.messages =
         assemble_full_replace_history(system, last_user, recent, summary.clone(), reminder);
     session.record_compaction_event(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -27,12 +27,14 @@ mod context_water;
 mod events;
 mod hooks;
 mod input_ladder;
+mod memory;
 mod permission;
 mod plan_mode;
 mod prefire;
 mod skills;
 mod subagent;
 mod tokens;
+mod tool_bound;
 mod tool_dedup;
 pub mod tool_scheduler;
 mod turn;
@@ -87,6 +89,8 @@ pub struct Agent {
     mcp: Option<McpManager>,
     background: SharedBackgroundTasks,
     prefire: prefire::PrefireState,
+    /// Compaction cycle index of the last successful memory flush.
+    last_memory_flush_compaction: u64,
 }
 
 pub struct PromptOptions {
@@ -119,6 +123,7 @@ impl Agent {
         let system_prompt =
             workspace::build_system_prompt(&config.system_prompt, &workdir, config.include_workspace_context);
         session.ensure_system_message(&system_prompt);
+        memory::ensure_memory_in_system(&mut session.messages, &workdir);
         let client = ChatClient::from_config(&config).await?;
         let record_writer = AgentRecordWriter::for_session(&session.meta.id)?;
 
@@ -167,6 +172,7 @@ impl Agent {
             mcp,
             background: shared_background_tasks(),
             prefire: prefire::PrefireState::new(),
+            last_memory_flush_compaction: 0,
         })
     }
 
@@ -274,6 +280,8 @@ impl Agent {
         let background_tasks = self.background.lock().list();
         self.prefire.await_in_flight().await;
         let prefire_cache = self.prefire_cache_for_current_prefix();
+        let _ = self.maybe_flush_memory().await;
+        let memory_block = memory::memory_reminder(self.sandbox.workdir());
         let _ = save_checkpoint(&self.session, "pre_manual_compact");
         let result = compact_session_forced(
             &mut self.session,
@@ -287,6 +295,7 @@ impl Agent {
             user_hint,
             &background_tasks,
             prefire_cache.as_ref(),
+            memory_block.as_deref(),
         )
         .await;
         self.prefire.clear();
@@ -352,6 +361,12 @@ impl Agent {
             lines.push("prefire: NOTE₁ cached (two-pass ready)".to_string());
         } else if self.prefire.is_in_flight() {
             lines.push("prefire: pass1 in flight".to_string());
+        }
+        if memory::memory_enabled() {
+            let root = memory::memory_root(self.sandbox.workdir());
+            lines.push(format!("memory: {} (ZENE_MEMORY)", root.display()));
+        } else {
+            lines.push("memory: disabled".to_string());
         }
         lines.join("\n")
     }
@@ -710,6 +725,8 @@ impl Agent {
             self.sync_todos_to_session();
             self.prefire.await_in_flight().await;
             let prefire_cache = self.prefire_cache_for_current_prefix();
+            let _ = self.maybe_flush_memory().await;
+            let memory_block = memory::memory_reminder(self.sandbox.workdir());
             let _ = save_checkpoint(&self.session, "pre_auto_compact");
             let estimator = self.token_estimator();
             let background_tasks = self.background.lock().list();
@@ -728,6 +745,7 @@ impl Agent {
                 &estimator,
                 &background_tasks,
                 prefire_cache.as_ref(),
+                memory_block.as_deref(),
             )
             .await
             {
@@ -926,6 +944,8 @@ impl Agent {
                         self.sync_todos_to_session();
                         self.prefire.await_in_flight().await;
                         let prefire_cache = self.prefire_cache_for_current_prefix();
+                        let _ = self.maybe_flush_memory().await;
+                        let memory_block = memory::memory_reminder(self.sandbox.workdir());
                         let _ = save_checkpoint(&self.session, "pre_overflow_compact");
                         let estimator = self.token_estimator();
                         let background_tasks = self.background.lock().list();
@@ -939,6 +959,7 @@ impl Agent {
                             &estimator,
                             &background_tasks,
                             prefire_cache.as_ref(),
+                            memory_block.as_deref(),
                         )
                         .await
                         {
@@ -1282,7 +1303,7 @@ impl Agent {
                     "(tool returned no output)".to_string()
                 }
             } else {
-                result.content
+                tool_bound::bound_tool_result(result.content, &workdir, &call.name)
             };
 
             if let Some(reminder) = self.tool_dedup.on_call(&call.name, &call.arguments) {
@@ -1318,6 +1339,35 @@ impl Agent {
             tokens_after: Some(result.stats.tokens_after),
             ts: chrono::Utc::now(),
         })
+    }
+
+    async fn maybe_flush_memory(&mut self) -> Result<()> {
+        let cycle = self.session.compactions.len() as u64;
+        let marker = cycle.saturating_add(1);
+        let threshold = ContextWaterLevel::auto_compact_threshold_percent(&self.config.compaction);
+        if !memory::should_flush(
+            self.context_water.usage_percent(),
+            threshold,
+            self.last_memory_flush_compaction == marker,
+        ) {
+            return Ok(());
+        }
+        match memory::run_memory_flush(
+            &self.client,
+            &self.config.model,
+            &self.session.messages,
+            self.sandbox.workdir(),
+        )
+        .await?
+        {
+            memory::FlushResult::Accepted => {
+                self.last_memory_flush_compaction = marker;
+            }
+            other => {
+                debug!(?other, "memory flush finished without write");
+            }
+        }
+        Ok(())
     }
 }
 

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -1,0 +1,325 @@
+//! Session memory flush + post-compact injection (grok-aligned subset).
+//!
+//! Before compaction, optionally ask the model to extract durable lessons into
+//! `{workdir}/.zene/memory/daily/YYYY-MM-DD.md`. After compaction (and at
+//! session start), recent memory is re-injected as a stable `<memory-context>`
+//! block so work survives history loss without reshuffling the system prefix
+//! every turn.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tracing::{info, warn};
+use zene_llm::{ChatClient, ChatRequest, Message, ToolDefinition};
+
+pub const MEMORY_CONTEXT_OPEN: &str = "<memory-context>";
+pub const MEMORY_CONTEXT_CLOSE: &str = "</memory-context>";
+
+const FLUSH_SYSTEM_PROMPT: &str = "\
+You are a memory assistant. Extract ALL useful information from this conversation \
+that would help you be more effective in future sessions with this user. \
+Write a concise markdown summary with ## headers covering:
+
+- **Decisions & rationale** — what was chosen and why
+- **Technical context** — architecture, APIs, patterns, tools, file paths discussed
+- **Problems & solutions** — bugs found, how they were fixed, workarounds
+
+Omit any section where there is nothing substantive to report. \
+Do NOT include ephemeral progress or routine Q&A.
+
+Respond with NO_REPLY if nothing genuinely useful was learned.";
+
+const MAX_FLUSH_CHARS: usize = 4_000;
+const MAX_INJECT_CHARS: usize = 3_000;
+const FLUSH_INPUT_MSG_CAP: usize = 40;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlushResult {
+    NothingToStore,
+    Accepted,
+    Rejected,
+}
+
+pub fn memory_enabled() -> bool {
+    match std::env::var("ZENE_MEMORY") {
+        Ok(v) => {
+            let v = v.trim().to_lowercase();
+            !(v == "0" || v == "false" || v == "off" || v == "no")
+        }
+        Err(_) => true,
+    }
+}
+
+pub fn memory_root(workdir: &Path) -> PathBuf {
+    workdir.join(".zene").join("memory")
+}
+
+pub fn daily_log_path(workdir: &Path) -> PathBuf {
+    let day = chrono::Utc::now().format("%Y-%m-%d");
+    memory_root(workdir).join("daily").join(format!("{day}.md"))
+}
+
+pub fn conversation_has_memory_context(messages: &[Message]) -> bool {
+    messages.first().is_some_and(|m| {
+        m.role == zene_llm::Role::System
+            && m.content
+                .as_ref()
+                .is_some_and(|c| c.contains(MEMORY_CONTEXT_OPEN))
+    })
+}
+
+fn is_no_reply(text: &str) -> bool {
+    let t = text.trim().to_uppercase();
+    t == "NO_REPLY" || t == "NO REPLY" || t.starts_with("NO_REPLY\n")
+}
+
+fn has_markdown_headers(text: &str) -> bool {
+    text.lines().any(|l| l.trim_start().starts_with("## "))
+}
+
+pub fn process_flush_response(response: &str) -> Result<Option<String>, FlushResult> {
+    let trimmed = response.trim();
+    if trimmed.is_empty() || is_no_reply(trimmed) {
+        return Err(FlushResult::NothingToStore);
+    }
+    let content: String = if trimmed.chars().count() > MAX_FLUSH_CHARS {
+        trimmed.chars().take(MAX_FLUSH_CHARS).collect()
+    } else {
+        trimmed.to_string()
+    };
+    if !has_markdown_headers(&content) {
+        return Err(FlushResult::Rejected);
+    }
+    Ok(Some(content))
+}
+
+pub fn append_daily_log(workdir: &Path, content: &str) -> Result<PathBuf> {
+    let path = daily_log_path(workdir);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).context("create memory daily dir")?;
+    }
+    let mut block = String::new();
+    if path.exists() {
+        block.push_str("\n\n---\n\n");
+    }
+    block.push_str(&format!(
+        "## Flush {}\n\n{content}\n",
+        chrono::Utc::now().format("%H:%M:%SZ")
+    ));
+    use std::io::Write;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .context("open daily memory log")?;
+    file.write_all(block.as_bytes())
+        .context("write daily memory log")?;
+    Ok(path)
+}
+
+/// Load recent memory text for injection (MEMORY.md + recent daily logs).
+pub fn load_recent_memory(workdir: &Path) -> Option<String> {
+    let root = memory_root(workdir);
+    let mut chunks = Vec::new();
+
+    let memory_md = root.join("MEMORY.md");
+    if let Ok(text) = fs::read_to_string(&memory_md) {
+        if !text.trim().is_empty() {
+            chunks.push(text);
+        }
+    }
+
+    let daily_dir = root.join("daily");
+    if let Ok(mut entries) = fs::read_dir(&daily_dir) {
+        let mut files: Vec<PathBuf> = entries
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("md"))
+            .collect();
+        files.sort();
+        for path in files.iter().rev().take(3) {
+            if let Ok(text) = fs::read_to_string(path) {
+                if !text.trim().is_empty() {
+                    chunks.push(text);
+                }
+            }
+        }
+    }
+
+    if chunks.is_empty() {
+        return None;
+    }
+    let mut combined = chunks.join("\n\n");
+    if combined.chars().count() > MAX_INJECT_CHARS {
+        // Keep the newest tail.
+        let owned: String = combined
+            .chars()
+            .rev()
+            .take(MAX_INJECT_CHARS)
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect();
+        combined = format!("…\n{owned}");
+    }
+    Some(combined)
+}
+
+pub fn format_memory_context_block(body: &str) -> String {
+    format!(
+        "{MEMORY_CONTEXT_OPEN}\n## Relevant Memory from Past Sessions\n\n{body}\n{MEMORY_CONTEXT_CLOSE}"
+    )
+}
+
+/// Append memory context to the system message once (KV-stable for the session).
+pub fn ensure_memory_in_system(messages: &mut [Message], workdir: &Path) {
+    if !memory_enabled() || conversation_has_memory_context(messages) {
+        return;
+    }
+    let Some(body) = load_recent_memory(workdir) else {
+        return;
+    };
+    let block = format_memory_context_block(&body);
+    if let Some(system) = messages.first_mut() {
+        if system.role == zene_llm::Role::System {
+            let existing = system.content.clone().unwrap_or_default();
+            system.content = Some(format!("{existing}\n\n{block}"));
+        }
+    }
+}
+
+/// Reminder fragment for post-compaction reinjection.
+pub fn memory_reminder(workdir: &Path) -> Option<String> {
+    if !memory_enabled() {
+        return None;
+    }
+    let body = load_recent_memory(workdir)?;
+    Some(format_memory_context_block(&body))
+}
+
+fn format_flush_input(messages: &[Message]) -> String {
+    let start = messages.len().saturating_sub(FLUSH_INPUT_MSG_CAP);
+    let mut out = String::new();
+    for message in &messages[start..] {
+        let role = match message.role {
+            zene_llm::Role::System => continue,
+            zene_llm::Role::User => "user",
+            zene_llm::Role::Assistant => "assistant",
+            zene_llm::Role::Tool => "tool",
+        };
+        out.push_str(&format!("[{role}] "));
+        if let Some(content) = &message.content {
+            let clipped: String = content.chars().take(800).collect();
+            out.push_str(&clipped);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+/// Run a flush LLM call and append to the daily log when accepted.
+pub async fn run_memory_flush(
+    client: &ChatClient,
+    model: &str,
+    messages: &[Message],
+    workdir: &Path,
+) -> Result<FlushResult> {
+    if !memory_enabled() {
+        return Ok(FlushResult::NothingToStore);
+    }
+    let conversation = format_flush_input(messages);
+    if conversation.trim().is_empty() {
+        return Ok(FlushResult::NothingToStore);
+    }
+
+    let request = ChatRequest {
+        model: model.to_string(),
+        messages: vec![
+            Message::system(FLUSH_SYSTEM_PROMPT),
+            Message::user(format!(
+                "Conversation to extract memory from:\n\n{conversation}"
+            )),
+        ],
+        tools: Vec::<ToolDefinition>::new(),
+        stream: false,
+    };
+
+    let response = client.chat(request).await.context("memory flush chat")?;
+    let text = response
+        .message
+        .content
+        .unwrap_or_default();
+
+    match process_flush_response(&text) {
+        Ok(Some(content)) => {
+            let path = append_daily_log(workdir, &content)?;
+            info!(path = %path.display(), chars = content.len(), "memory flush wrote daily log");
+            Ok(FlushResult::Accepted)
+        }
+        Err(FlushResult::NothingToStore) => {
+            info!("memory flush: nothing to store");
+            Ok(FlushResult::NothingToStore)
+        }
+        Err(FlushResult::Rejected) => {
+            warn!("memory flush: rejected (missing ## headers)");
+            Ok(FlushResult::Rejected)
+        }
+        Err(FlushResult::Accepted) | Ok(None) => Ok(FlushResult::NothingToStore),
+    }
+}
+
+/// Soft threshold: flush when usage is within `lead` pp of auto-compact.
+pub fn should_flush(
+    usage_percent: u8,
+    compact_threshold_percent: u8,
+    already_flushed_this_cycle: bool,
+) -> bool {
+    if !memory_enabled() || already_flushed_this_cycle {
+        return false;
+    }
+    let lead = std::env::var("ZENE_MEMORY_FLUSH_LEAD_PERCENT")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(5u8);
+    let start = compact_threshold_percent.saturating_sub(lead);
+    usage_percent >= start
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn rejects_no_reply_and_unstructured() {
+        assert!(matches!(
+            process_flush_response("NO_REPLY"),
+            Err(FlushResult::NothingToStore)
+        ));
+        assert!(matches!(
+            process_flush_response("just some prose without headers"),
+            Err(FlushResult::Rejected)
+        ));
+        assert!(matches!(
+            process_flush_response("## Decisions\n\nUse Axum.\n"),
+            Ok(Some(_))
+        ));
+    }
+
+    #[test]
+    fn append_and_load_daily() {
+        let dir = tempdir().unwrap();
+        append_daily_log(dir.path(), "## Decisions\n\nShip it.\n").unwrap();
+        let loaded = load_recent_memory(dir.path()).unwrap();
+        assert!(loaded.contains("Ship it"));
+        let block = format_memory_context_block(&loaded);
+        assert!(block.contains(MEMORY_CONTEXT_OPEN));
+    }
+
+    #[test]
+    fn should_flush_respects_cycle() {
+        assert!(should_flush(82, 85, false));
+        assert!(!should_flush(82, 85, true));
+        assert!(!should_flush(10, 85, false));
+    }
+}

--- a/crates/core/src/tool_bound.rs
+++ b/crates/core/src/tool_bound.rs
@@ -1,0 +1,108 @@
+//! Bound large tool results before they enter session history (intra-lite).
+//!
+//! MCP already spills via `zene_mcp::truncate_mcp_output`. This covers Bash and
+//! other verbose tools so they do not force premature auto-compact.
+
+use std::fs;
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tracing::warn;
+
+/// Default inline cap for non-MCP tool output in session history (bytes).
+pub const TOOL_MAX_OUTPUT_BYTES: usize = 30_000;
+
+pub fn tool_max_output_bytes() -> usize {
+    for key in ["ZENE_MAX_TOOL_OUTPUT_BYTES", "MAX_TOOL_OUTPUT_BYTES"] {
+        if let Ok(raw) = std::env::var(key) {
+            if let Ok(n) = raw.trim().parse::<usize>() {
+                if n > 0 {
+                    return n;
+                }
+            }
+        }
+    }
+    TOOL_MAX_OUTPUT_BYTES
+}
+
+/// Truncate oversized tool output; spill full payload under `.zene/tool-output/`.
+/// Skips MCP tools (handled by the MCP layer) and tiny results.
+pub fn bound_tool_result(content: String, workdir: &Path, tool_name: &str) -> String {
+    if tool_name.starts_with("mcp__") {
+        return content;
+    }
+    let max = tool_max_output_bytes();
+    if content.len() <= max {
+        return content;
+    }
+
+    let dump_dir = workdir.join(".zene").join("tool-output");
+    if let Err(err) = fs::create_dir_all(&dump_dir) {
+        warn!(error = %err, "failed to create tool-output dir");
+        return truncate_inline(&content, max, None);
+    }
+
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    let safe: String = tool_name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let path = dump_dir.join(format!("{safe}-{ts}.txt"));
+    if let Err(err) = fs::write(&path, &content) {
+        warn!(error = %err, "failed to spill tool output");
+        return truncate_inline(&content, max, None);
+    }
+    truncate_inline(&content, max, Some(path.display().to_string()))
+}
+
+fn truncate_inline(content: &str, max: usize, saved_path: Option<String>) -> String {
+    let preview_budget = max.saturating_sub(220).max(256);
+    let preview = match content.char_indices().nth(preview_budget) {
+        Some((idx, _)) => &content[..idx],
+        None => content,
+    };
+    let omitted = content.len().saturating_sub(preview.len());
+    match saved_path {
+        Some(path) => format!(
+            "{preview}\n\n[truncated {omitted} bytes; full output saved to {path}. Use Read if needed.]"
+        ),
+        None => format!("{preview}\n\n[truncated {omitted} bytes]"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn skips_small_and_mcp() {
+        let dir = tempdir().unwrap();
+        assert_eq!(
+            bound_tool_result("hi".into(), dir.path(), "Bash"),
+            "hi"
+        );
+        let big = "x".repeat(40_000);
+        let mcp = bound_tool_result(big.clone(), dir.path(), "mcp__s__t");
+        assert_eq!(mcp.len(), big.len());
+    }
+
+    #[test]
+    fn spills_bash() {
+        let dir = tempdir().unwrap();
+        std::env::set_var("ZENE_MAX_TOOL_OUTPUT_BYTES", "400");
+        let out = bound_tool_result("y".repeat(2000), dir.path(), "Bash");
+        std::env::remove_var("ZENE_MAX_TOOL_OUTPUT_BYTES");
+        assert!(out.contains("truncated"));
+        assert!(out.contains(".zene/tool-output/"));
+    }
+}

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -94,6 +94,14 @@ MCP tool results over `ZENE_MAX_MCP_OUTPUT_BYTES` / `MAX_MCP_OUTPUT_BYTES` (defa
 
 When usage reaches auto-compact threshold minus `ZENE_PREFIRE_LEAD_PERCENT` (default 10pp), a background pass1 summarizes ~95% of history into NOTE₁. At compact time, pass2 merges NOTE₁ with the recent tail (prefire hit). Without a valid cache, large prefixes still use synchronous two-pass. Compacted prefixes are also written under `~/.zene/sessions/<id>/compaction_segments/` for recovery.
 
+### Memory flush + injection
+
+Near compact time, zene may run a no-tools flush turn that extracts durable lessons into `{workdir}/.zene/memory/daily/YYYY-MM-DD.md` (disable with `ZENE_MEMORY=0`). Session start injects recent memory into the system prompt once inside `<memory-context>` (kept stable for KV-friendly prefixes). Post-compact reminders also re-inject memory alongside todos/background tasks. Optional curated notes can live in `{workdir}/.zene/memory/MEMORY.md`.
+
+### Intra-lite tool bounding
+
+Non-MCP tool results over `ZENE_MAX_TOOL_OUTPUT_BYTES` (default 30_000) are truncated into session history and spilled to `.zene/tool-output/` (MCP uses its own 20KB path).
+
 ## Permission modes (grok-aligned)
 
 | Mode | Behavior |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -409,11 +409,11 @@ TUI、record/replay、安装分发。
 
 | 阶段 | 状态 | 内容 |
 |------|------|------|
-| P1 采样/上下文 | [x] | 水位/full-replace/阶梯/错误分类；续1：硬拒绝短摘要、MCP 落盘、`/context`、tool-pair、preflight、reminder、抑制；续2：prefire two-pass、sync two-pass、compaction segments |
+| P1 采样/上下文 | [x] | 水位/full-replace/阶梯；续1 截断/context/tool-pair；续2 prefire two-pass/segments；续3 memory flush/注入 + 工具结果 intra 边界 |
 | P2 权限 | [x] | default/accept_edits/dont_ask/bypass + allow/deny/ask 规则 |
 | P3 会话恢复 | [x] | compaction checkpoints、`/rewind`、`/fork`、`/session-info` |
 | P4 运行时 | [x] | 后台 Bash/Task + TaskOutput、`--worktree`、subagent 报告包装 |
 | P5 MCP/扩展 | [x] | stdio + HTTP MCP、`zene mcp doctor` |
 | P6 集成/产品化 | [x] | `zene -p` headless + `--output-format json`；`zene acp` 最小 ACP stdio |
 
-*最后更新：2026-07-18（P1 续2：prefire two-pass / segments）*
+*最后更新：2026-07-18（P1 续3：memory flush + tool bound）*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR 8 合入后的采样/上下文续作：对齐 grok-build 的 memory flush / 注入，并补上非 MCP 工具结果的 intra 边界。

## 变更
- compact 前可选 memory flush → `{workdir}/.zene/memory/daily/YYYY-MM-DD.md`（`ZENE_MEMORY=0` 关闭）
- 会话启动把近期 memory 注入 system 的稳定 `<memory-context>`；compact 后 reminder 再注入
- 支持手写 `{workdir}/.zene/memory/MEMORY.md`
- Bash 等非 MCP 大输出按 `ZENE_MAX_TOOL_OUTPUT_BYTES`（默认 30KB）截断并落盘 `.zene/tool-output/`
- `/context` 显示 memory 路径状态

## 仍未覆盖
完整 embedding 去重 memory、Inter/Intra 多模式策略、精确 tokenizer

## 验证
`cargo test -p zene-core`（87 unit + integration）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

