### PR TITLE
Script-aware tokens and Intra steps-first compact

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -87,6 +87,10 @@ pub struct CompactionConfig {
     pub context_window_tokens: u32,
     #[serde(default = "default_min_keep_messages")]
     pub min_keep_messages: usize,
+    /// Before full compact, aggressively truncate tool results in the current
+    /// turn's steps (after the last user message) — grok Intra Steps-first lite.
+    #[serde(default = "default_intra_steps_first")]
+    pub intra_steps_first: bool,
 }
 
 fn default_compaction_trigger_ratio() -> f32 {
@@ -105,6 +109,10 @@ fn default_min_keep_messages() -> usize {
     20
 }
 
+fn default_intra_steps_first() -> bool {
+    true
+}
+
 impl Default for CompactionConfig {
     fn default() -> Self {
         Self {
@@ -112,6 +120,7 @@ impl Default for CompactionConfig {
             keep_recent_ratio: default_keep_recent_ratio(),
             context_window_tokens: default_context_window_tokens(),
             min_keep_messages: default_min_keep_messages(),
+            intra_steps_first: default_intra_steps_first(),
         }
     }
 }

--- a/crates/core/src/compaction.rs
+++ b/crates/core/src/compaction.rs
@@ -720,7 +720,54 @@ pub fn subagent_compaction_config(parent: &CompactionConfig) -> CompactionConfig
         trigger_ratio: 0.5,
         keep_recent_ratio: parent.keep_recent_ratio.max(0.3),
         min_keep_messages: parent.min_keep_messages,
+        intra_steps_first: parent.intra_steps_first,
     }
+}
+
+/// Max chars for tool results in the current turn's steps during intra pass.
+const STEPS_TOOL_RESULT_MAX_CHARS: usize = 200;
+
+/// Intra Steps-first lite: aggressively truncate tool results after the last
+/// user message. Returns true if any body was truncated.
+pub fn apply_steps_truncate_pass(
+    session: &mut SessionRecord,
+    config: &CompactionConfig,
+) -> bool {
+    if !config.intra_steps_first {
+        return false;
+    }
+    let Some(user_idx) = last_user_query_index(&session.messages) else {
+        return false;
+    };
+    let mut changed = 0usize;
+    for message in session.messages.iter_mut().skip(user_idx + 1) {
+        if message.role != Role::Tool {
+            continue;
+        }
+        let Some(content) = message.content.as_ref() else {
+            continue;
+        };
+        let count = content.chars().count();
+        if count <= STEPS_TOOL_RESULT_MAX_CHARS {
+            continue;
+        }
+        let kept: String = content.chars().take(STEPS_TOOL_RESULT_MAX_CHARS).collect();
+        message.content = Some(format!(
+            "{kept}…[steps-truncated {count} chars]"
+        ));
+        changed += 1;
+    }
+    if changed > 0 {
+        info!(changed, "intra steps-first truncated tool results");
+        let _ = session.record_compaction_event(
+            "steps_truncate",
+            changed,
+            None,
+            None,
+            None,
+        );
+    }
+    changed > 0
 }
 
 pub fn apply_compaction_to_messages(
@@ -1173,6 +1220,7 @@ mod tests {
             keep_recent_ratio: 0.25,
             context_window_tokens: 1000,
             min_keep_messages: 4,
+                    intra_steps_first: true,
         };
         assert!(!should_compact(499, &config));
         assert!(should_compact(500, &config));
@@ -1186,6 +1234,7 @@ mod tests {
             keep_recent_ratio: 0.25,
             context_window_tokens: 200,
             min_keep_messages: 2,
+                    intra_steps_first: true,
         };
         let messages: Vec<Message> = (0..30)
             .map(|i| user_msg(&format!("message {i}: {}", "x".repeat(200))))
@@ -1237,6 +1286,7 @@ mod tests {
             keep_recent_ratio: 0.5,
             context_window_tokens: 100,
             min_keep_messages: 2,
+                    intra_steps_first: true,
         };
         let plan = plan_compaction(&messages, &config, &estimator()).expect("plan");
         assert!(plan.compacted_count >= 1);
@@ -1313,11 +1363,35 @@ mod tests {
             keep_recent_ratio: 0.25,
             context_window_tokens: 128_000,
             min_keep_messages: 20,
+                    intra_steps_first: true,
         };
         let sub = subagent_compaction_config(&parent);
         assert_eq!(sub.context_window_tokens, 16_000);
         assert_eq!(sub.trigger_ratio, 0.5);
         assert_eq!(sub.min_keep_messages, 20);
+    }
+
+    #[test]
+    fn steps_truncate_only_touches_post_user_tools() {
+        let mut session = SessionRecord::new(std::path::Path::new("/tmp"));
+        session.messages = vec![
+            Message::system("sys"),
+            Message::tool_result("0", "Read", "x".repeat(1000)),
+            Message::user("do it"),
+            Message::tool_result("1", "Bash", "y".repeat(1000)),
+        ];
+        let cfg = CompactionConfig::default();
+        assert!(apply_steps_truncate_pass(&mut session, &cfg));
+        assert!(!session.messages[1]
+            .content
+            .as_deref()
+            .unwrap()
+            .contains("steps-truncated"));
+        assert!(session.messages[3]
+            .content
+            .as_deref()
+            .unwrap()
+            .contains("steps-truncated"));
     }
 
     #[test]

--- a/crates/core/src/context_water.rs
+++ b/crates/core/src/context_water.rs
@@ -127,6 +127,7 @@ mod tests {
             keep_recent_ratio: 0.25,
             context_window_tokens: 1000,
             min_keep_messages: 4,
+                    intra_steps_first: true,
         }));
     }
 
@@ -140,6 +141,7 @@ mod tests {
             keep_recent_ratio: 0.25,
             context_window_tokens: 1000,
             min_keep_messages: 4,
+                    intra_steps_first: true,
         }));
         water.clear_auto_compact_suppression();
         assert!(water.should_compact(&CompactionConfig {
@@ -147,6 +149,7 @@ mod tests {
             keep_recent_ratio: 0.25,
             context_window_tokens: 1000,
             min_keep_messages: 4,
+                    intra_steps_first: true,
         }));
     }
 
@@ -157,6 +160,7 @@ mod tests {
             keep_recent_ratio: 0.25,
             context_window_tokens: 1000,
             min_keep_messages: 4,
+                    intra_steps_first: true,
         };
         let mut water = ContextWaterLevel::new(1000);
         water.record_estimate(760); // 76% — lead 10pp below 85%

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -42,7 +42,8 @@ mod two_pass;
 mod worktree;
 
 use compaction::{
-    apply_overflow_truncate_pass, compact_session, compact_session_forced, is_context_overflow_error,
+    apply_overflow_truncate_pass, apply_steps_truncate_pass, compact_session,
+    compact_session_forced, is_context_overflow_error,
 };
 pub use compaction::CompactionResult;
 mod workspace;
@@ -722,6 +723,16 @@ impl Agent {
         let preflight = self.context_water.exceeds_window()
             && !self.context_water.auto_compact_suppressed;
         if self.context_water.should_compact(&self.config.compaction) || preflight {
+            // Intra Steps-first: shrink current-turn tool bodies before full compact.
+            if apply_steps_truncate_pass(&mut self.session, &self.config.compaction) {
+                self.sync_context_water_from_estimate();
+                if !self.context_water.should_compact(&self.config.compaction)
+                    && !self.context_water.exceeds_window()
+                {
+                    info!("intra steps-first truncate relieved pressure; skipping full compact");
+                    return Ok(());
+                }
+            }
             self.sync_todos_to_session();
             self.prefire.await_in_flight().await;
             let prefire_cache = self.prefire_cache_for_current_prefix();

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -94,6 +94,26 @@ pub fn process_flush_response(response: &str) -> Result<Option<String>, FlushRes
     Ok(Some(content))
 }
 
+fn content_fingerprint(content: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    content.trim().hash(&mut h);
+    h.finish()
+}
+
+fn last_flush_hash_path(workdir: &Path) -> PathBuf {
+    memory_root(workdir).join(".last_flush_hash")
+}
+
+/// Returns true when `content` matches the previous accepted flush (exact text).
+pub fn is_duplicate_flush(workdir: &Path, content: &str) -> bool {
+    let path = last_flush_hash_path(workdir);
+    let Ok(prev) = fs::read_to_string(path) else {
+        return false;
+    };
+    prev.trim() == content_fingerprint(content).to_string()
+}
+
 pub fn append_daily_log(workdir: &Path, content: &str) -> Result<PathBuf> {
     let path = daily_log_path(workdir);
     if let Some(parent) = path.parent() {
@@ -115,6 +135,10 @@ pub fn append_daily_log(workdir: &Path, content: &str) -> Result<PathBuf> {
         .context("open daily memory log")?;
     file.write_all(block.as_bytes())
         .context("write daily memory log")?;
+    let _ = fs::write(
+        last_flush_hash_path(workdir),
+        content_fingerprint(content).to_string(),
+    );
     Ok(path)
 }
 
@@ -252,6 +276,10 @@ pub async fn run_memory_flush(
 
     match process_flush_response(&text) {
         Ok(Some(content)) => {
+            if is_duplicate_flush(workdir, &content) {
+                info!("memory flush: duplicate of last flush; skipped");
+                return Ok(FlushResult::NothingToStore);
+            }
             let path = append_daily_log(workdir, &content)?;
             info!(path = %path.display(), chars = content.len(), "memory flush wrote daily log");
             Ok(FlushResult::Accepted)

--- a/crates/core/src/tokens.rs
+++ b/crates/core/src/tokens.rs
@@ -3,16 +3,28 @@ use zene_llm::{Message, MessageKind, Role, ToolDefinition};
 /// Per tool-call JSON/API framing beyond argument string length.
 const TOOL_CALL_FRAME_TOKENS: u32 = 12;
 
+/// How text is converted to token estimates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EstimateMode {
+    /// Latin ~`chars_per_token`; CJK ~1 token/char (closer to real BPE for mixed text).
+    #[default]
+    ScriptAware,
+    /// Legacy uniform chars/token ceiling division.
+    Uniform,
+}
+
 /// Heuristic token estimator with configurable chars-per-token ratio.
 #[derive(Debug, Clone, Copy)]
 pub struct TokenEstimator {
     pub chars_per_token: f32,
+    pub mode: EstimateMode,
 }
 
 impl Default for TokenEstimator {
     fn default() -> Self {
         Self {
             chars_per_token: 4.0,
+            mode: EstimateMode::ScriptAware,
         }
     }
 }
@@ -21,14 +33,25 @@ impl TokenEstimator {
     pub fn new(chars_per_token: f32) -> Self {
         Self {
             chars_per_token: chars_per_token.max(1.0),
+            mode: EstimateMode::ScriptAware,
         }
+    }
+
+    pub fn with_mode(mut self, mode: EstimateMode) -> Self {
+        self.mode = mode;
+        self
     }
 
     pub fn estimate_chars_as_tokens(&self, text: &str) -> u32 {
         if text.is_empty() {
             return 0;
         }
-        (text.chars().count() as f32 / self.chars_per_token).ceil() as u32
+        match self.mode {
+            EstimateMode::Uniform => {
+                (text.chars().count() as f32 / self.chars_per_token).ceil() as u32
+            }
+            EstimateMode::ScriptAware => estimate_script_aware(text, self.chars_per_token),
+        }
     }
 
     /// Role-specific framing overhead (JSON keys, role labels, separators).
@@ -107,6 +130,44 @@ impl TokenEstimator {
     }
 }
 
+fn is_cjk(ch: char) -> bool {
+    matches!(ch,
+        '\u{4E00}'..='\u{9FFF}' | // CJK Unified
+        '\u{3400}'..='\u{4DBF}' | // Extension A
+        '\u{F900}'..='\u{FAFF}' | // Compatibility
+        '\u{3040}'..='\u{30FF}' | // Hiragana/Katakana
+        '\u{AC00}'..='\u{D7AF}'   // Hangul
+    )
+}
+
+/// Mixed-script estimate: CJK ≈ 1 tok/char; Latin runs use chars_per_token.
+fn estimate_script_aware(text: &str, chars_per_token: f32) -> u32 {
+    let cpt = chars_per_token.max(1.0);
+    let mut tokens = 0.0f32;
+    let mut latin_run = 0usize;
+    for ch in text.chars() {
+        if is_cjk(ch) {
+            if latin_run > 0 {
+                tokens += (latin_run as f32 / cpt).ceil();
+                latin_run = 0;
+            }
+            tokens += 1.0;
+        } else if ch.is_whitespace() {
+            if latin_run > 0 {
+                tokens += (latin_run as f32 / cpt).ceil();
+                latin_run = 0;
+            }
+            tokens += 0.25;
+        } else {
+            latin_run += 1;
+        }
+    }
+    if latin_run > 0 {
+        tokens += (latin_run as f32 / cpt).ceil();
+    }
+    tokens.ceil().max(1.0) as u32
+}
+
 /// Total estimated context size (messages + tool definitions) for compaction checks.
 pub fn estimate_context(
     messages: &[Message],
@@ -148,16 +209,26 @@ mod tests {
     use zene_llm::ToolCall;
 
     #[test]
-    fn chars_heuristic_uses_ceiling_division() {
-        assert_eq!(estimate_chars_as_tokens(""), 0);
-        assert_eq!(estimate_chars_as_tokens("abcd"), 1);
-        assert_eq!(estimate_chars_as_tokens("abcde"), 2);
+    fn uniform_chars_heuristic_uses_ceiling_division() {
+        let est = TokenEstimator::default().with_mode(EstimateMode::Uniform);
+        assert_eq!(est.estimate_chars_as_tokens(""), 0);
+        assert_eq!(est.estimate_chars_as_tokens("abcd"), 1);
+        assert_eq!(est.estimate_chars_as_tokens("abcde"), 2);
+    }
+
+    #[test]
+    fn script_aware_counts_cjk_higher() {
+        let est = TokenEstimator::default();
+        let latin = est.estimate_chars_as_tokens("abcd"); // ~1
+        let cjk = est.estimate_chars_as_tokens("中文测试"); // ~4
+        assert!(cjk > latin);
+        assert_eq!(cjk, 4);
     }
 
     #[test]
     fn custom_ratio_increases_token_count() {
-        let loose = TokenEstimator::new(8.0);
-        let tight = TokenEstimator::new(2.0);
+        let loose = TokenEstimator::new(8.0).with_mode(EstimateMode::Uniform);
+        let tight = TokenEstimator::new(2.0).with_mode(EstimateMode::Uniform);
         let text = "abcdefgh";
         assert!(loose.estimate_chars_as_tokens(text) < tight.estimate_chars_as_tokens(text));
     }

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -12,7 +12,7 @@ Core agent loop lives in `crates/core`. This document tracks engine-level behavi
 
 ## Token estimation (v2 heuristic)
 
-Implemented in `tokens.rs` as `TokenEstimator` — no external tokenizer dependency (Option B). Uses configurable `chars_per_token` (default 4) from global config or per-model `model_chars_per_token`.
+Implemented in `tokens.rs` as `TokenEstimator` — no external tokenizer dependency (Option B). Default **script-aware** mode: Latin/code runs use configurable `chars_per_token` (default 4); CJK characters count ≈1 token each (closer to real BPE on mixed text). Uniform legacy mode remains available via `EstimateMode::Uniform`.
 
 **Per-message estimate** (`estimate_message_tokens` / `TokenEstimator::estimate_message_tokens`):
 
@@ -101,6 +101,10 @@ Near compact time, zene may run a no-tools flush turn that extracts durable less
 ### Intra-lite tool bounding
 
 Non-MCP tool results over `ZENE_MAX_TOOL_OUTPUT_BYTES` (default 30_000) are truncated into session history and spilled to `.zene/tool-output/` (MCP uses its own 20KB path).
+
+### Intra Steps-first
+
+When auto-compact is about to fire, zene first runs a Steps-first pass (`compaction.intra_steps_first`, default true): tool results after the last user message are truncated to ~200 chars. If that alone brings usage under the threshold, full summarize is skipped (grok Intra `StepsOnly` / HistoryThenSteps lite).
 
 ## Permission modes (grok-aligned)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -409,11 +409,11 @@ TUI、record/replay、安装分发。
 
 | 阶段 | 状态 | 内容 |
 |------|------|------|
-| P1 采样/上下文 | [x] | 水位/full-replace/阶梯；续1 截断/context/tool-pair；续2 prefire two-pass/segments；续3 memory flush/注入 + 工具结果 intra 边界 |
+| P1 采样/上下文 | [x] | …续3 memory；续4 script-aware token 估计、Intra steps-first、memory 指纹去重 |
 | P2 权限 | [x] | default/accept_edits/dont_ask/bypass + allow/deny/ask 规则 |
 | P3 会话恢复 | [x] | compaction checkpoints、`/rewind`、`/fork`、`/session-info` |
 | P4 运行时 | [x] | 后台 Bash/Task + TaskOutput、`--worktree`、subagent 报告包装 |
 | P5 MCP/扩展 | [x] | stdio + HTTP MCP、`zene mcp doctor` |
 | P6 集成/产品化 | [x] | `zene -p` headless + `--output-format json`；`zene acp` 最小 ACP stdio |
 
-*最后更新：2026-07-18（P1 续3：memory flush + tool bound）*
+*最后更新：2026-07-18（P1 续4：script-aware tokens + steps-first）*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR 9 合入后的采样/上下文续作。

## 变更
- 默认 token 估计改为 **script-aware**（拉丁/代码按 `chars_per_token`，CJK ≈1 tok/字）
- Auto-compact 前先跑 Intra **Steps-first**：截断上一轮用户消息之后的 tool 结果；若已低于阈值则跳过全文 summarize（`compaction.intra_steps_first`，默认 true）
- Memory flush 对上次内容做指纹去重，避免重复写入 daily log

## 仍未覆盖
tiktoken 级精确分词、完整 Inter/Intra 多模式枚举、embedding 语义去重

## 验证
`cargo test -p zene-core -p zene-config`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

