### PR TITLE
Pause Cloudflare Pages deploys until project is stable

### DIFF
--- a/.github/CLOUDFLARE_PAGES.md
+++ b/.github/CLOUDFLARE_PAGES.md
@@ -1,0 +1,18 @@
+# Cloudflare Pages (paused)
+
+The `zene-docs` site is connected via the **Cloudflare Workers and Pages** GitHub App (not a workflow under `.github/workflows/`). That is why PRs get `cloudflare-workers-and-pages` deploy comments even though `ci.yml` only runs `cargo test`.
+
+## Temporary pause (until project is stable)
+
+In the Cloudflare dashboard:
+
+1. Open **Workers & Pages** → project **zene-docs**
+2. **Settings** → **Builds** (branch control)
+3. Set **Preview branch** to **None** (disable automatic preview deployments)
+4. Turn off **Enable automatic production branch deployments**
+
+Direct uploads via `deploy-web.sh` option 3 stay blocked unless `ZENE_PAGES_DEPLOY=1`.
+
+## Re-enable later
+
+Restore preview/production automatic deployments in the same settings when ready, and remove the `ZENE_PAGES_DEPLOY` gate from `deploy-web.sh` if desired.

--- a/crates/core/src/hooks.rs
+++ b/crates/core/src/hooks.rs
@@ -98,11 +98,17 @@ impl HookRunner {
             .with_context(|| format!("spawn hook command: {}", hook.command))?;
 
         if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(input.as_bytes())
-                .await
-                .context("write hook stdin")?;
-            stdin.shutdown().await.context("close hook stdin")?;
+            // Hooks may exit before consuming stdin (e.g. immediate deny). Treat
+            // broken pipe as non-fatal so we can still read the exit status.
+            if let Err(err) = stdin.write_all(input.as_bytes()).await {
+                if err.kind() != std::io::ErrorKind::BrokenPipe {
+                    return Err(err).context("write hook stdin");
+                }
+            } else if let Err(err) = stdin.shutdown().await {
+                if err.kind() != std::io::ErrorKind::BrokenPipe {
+                    return Err(err).context("close hook stdin");
+                }
+            }
         }
 
         let output = child
@@ -164,7 +170,8 @@ mod tests {
     #[tokio::test]
     async fn pre_tool_use_blocks_on_non_zero_exit() {
         let _guard = TEST_LOCK.lock().expect("test lock");
-        let (_temp, runner) = sample_hook("PreToolUse", r#"echo "not allowed" >&2; exit 1"#);
+        let (_temp, runner) =
+            sample_hook("PreToolUse", r#"cat >/dev/null; echo "not allowed" >&2; exit 1"#);
         let block = runner
             .run_pre_tool_use("Write", r#"{"path":"foo.txt"}"#)
             .await
@@ -187,7 +194,8 @@ mod tests {
     #[tokio::test]
     async fn post_tool_use_does_not_block() {
         let _guard = TEST_LOCK.lock().expect("test lock");
-        let (_temp, runner) = sample_hook("PostToolUse", "echo blocked >&2; exit 1");
+        let (_temp, runner) =
+            sample_hook("PostToolUse", "cat >/dev/null; echo blocked >&2; exit 1");
         runner.run_post_tool_use("Read", "{}").await;
     }
 

--- a/deploy-web.sh
+++ b/deploy-web.sh
@@ -2,15 +2,24 @@
 set -euo pipefail
 
 # Zene Web deployment helper script.
-# This script makes it easy to preview locally and deploy/sync the website to zene.sh.
+# Cloudflare Pages auto-deploy (GitHub App → zene-docs) is PAUSED until the
+# project is stable. Re-enable in the Cloudflare dashboard:
+#   Workers & Pages → zene-docs → Settings → Builds
+#   - Preview branch: None
+#   - Disable automatic production branch deployments
+# Direct Wrangler deploy requires ZENE_PAGES_DEPLOY=1.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+pages_deploy_allowed() {
+  [[ "${ZENE_PAGES_DEPLOY:-0}" == "1" ]]
+}
+
 echo "=== Zene Web Deployment Helper ==="
 echo "1. Run local preview server (localhost:8000)"
-echo "2. Push changes to GitHub (Triggers CI/CD deployment on main)"
-echo "3. Direct deploy to Cloudflare Pages via Wrangler"
+echo "2. Push website changes to GitHub (Pages auto-deploy currently paused)"
+echo "3. Direct deploy to Cloudflare Pages via Wrangler (requires ZENE_PAGES_DEPLOY=1)"
 echo "4. Exit"
 echo
 
@@ -25,18 +34,23 @@ case "$OPTION" in
   2)
     echo "Staging files in web/..."
     git add web/
-    
+
     echo "Enter commit message (default: 'update website content'):"
     read -r MSG
     MSG=${MSG:-"update website content"}
-    
+
     git commit -m "$MSG"
-    
+
     echo "Pushing to main branch..."
     git push origin main
-    echo "Sync complete! CI/CD will build and deploy the changes to https://zene.sh/ shortly."
+    echo "Pushed. Note: Cloudflare Pages auto-deploy is paused until the project is stable."
     ;;
   3)
+    if ! pages_deploy_allowed; then
+      echo "Cloudflare Pages deploy is paused (project not stable yet)."
+      echo "Set ZENE_PAGES_DEPLOY=1 to override, or re-enable builds in the Cloudflare dashboard."
+      exit 1
+    fi
     echo "Checking if wrangler is installed..."
     if ! command -v npx &> /dev/null; then
       echo "Error: npx/npm is not installed on this machine."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR 评论里的 `cloudflare-workers-and-pages` 来自 Cloudflare GitHub App 直连的 Pages 项目 **zene-docs**，不是仓库里 `.github/workflows/ci.yml`（那里只有 `cargo test`）。

## 本 PR
- `deploy-web.sh`：Wrangler 直推需 `ZENE_PAGES_DEPLOY=1`，否则拒绝
- `.github/CLOUDFLARE_PAGES.md`：说明如何在 Dashboard 暂停自动构建
- 顺带修复 CI 偶发失败：`hooks::pre_tool_use_blocks_on_non_zero_exit` 在 hook 提前退出时写 stdin 触发 Broken pipe；现忽略该错误，测试改为先消费 stdin

## 需要你在 Cloudflare 控制台操作一次（仓库侧无法代关 Git App）
Workers & Pages → **zene-docs** → Settings → Builds：
- Preview branch → **None**
- 关闭 automatic production branch deployments

这样 PR/push 才不会再触发 Pages 预览部署；项目 stable 后再打开即可。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

