### PR TITLE
Release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.1.7 (2026-07-18)
+
+This release finishes the **grok-build long-context / sampling alignment** pass after v0.1.6: cheaper compaction paths, better token accounting, memory hygiene, and OpenAI-accurate BPE counts.
+
+### Added
+- Prefire two-pass compaction with `compaction_segments` persistence (NOTE₁ cache + sync merge).
+- Memory flush / injection into context, with content-fingerprint dedup across turns.
+- Intra **steps-first** pass: truncate current-turn tool results before full summarize when that alone frees enough budget.
+- Intra-lite tool output bounds for non-MCP tools; MCP oversized results truncate-to-disk.
+- OpenAI path **`tiktoken-rs`**: known models (`gpt-4o` → o200k, `gpt-4` / `gpt-3.5-turbo` → cl100k, etc.) use real BPE; unknown openai-compatible names and Anthropic keep the script-aware heuristic.
+- Script-aware token heuristic (Latin vs CJK) as the non-tiktoken default.
+- `/context` (alias `/tokens`) context report; preflight compact when estimate exceeds the hard window.
+- Docs: Cloudflare Pages pause guide; `deploy-web.sh` gated behind `ZENE_PAGES_DEPLOY=1`.
+
+### Changed
+- Stronger compaction ladder (reject thin summaries, tool-pair snap, sticky suppress after failed summarize).
+- Compaction / water-level behavior tuned closer to grok-build Inter/Intra lite semantics.
+
+### Fixed
+- Flaky `PreToolUse` hook test: ignore stdin BrokenPipe when the hook exits before reading payload.
+
 ## v0.1.6 (2026-07-18)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "zene-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "zene-config"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3560,7 +3560,7 @@ dependencies = [
 
 [[package]]
 name = "zene-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "zene-llm"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3604,7 +3604,7 @@ dependencies = [
 
 [[package]]
 name = "zene-mcp"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "zene-sandbox"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "zene-session"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3655,7 +3655,7 @@ dependencies = [
 
 [[package]]
 name = "zene-tools"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -647,6 +648,17 @@ name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1253,7 +1265,7 @@ dependencies = [
  "base64",
  "bytecount",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.14.0",
  "fraction",
  "idna",
  "itoa",
@@ -2483,6 +2495,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiktoken-rs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027853bbf8c7763b77c5c595f1c271c7d536ced7d6f83452911b944621e57fc2"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bstr",
+ "fancy-regex 0.17.0",
+ "lazy_static",
+ "regex",
+ "rustc-hash",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3544,6 +3571,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "tiktoken-rs",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 license = "MIT"
 authors = ["Zene Contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,4 @@ zene-tools = { path = "crates/tools" }
 zene-mcp = { path = "crates/mcp" }
 unigateway-sdk = "2.1.1"
 llm_providers = "0.12.0"
+tiktoken-rs = "0.12"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,6 +15,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+tiktoken-rs.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 zene-config = { workspace = true }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -58,7 +58,7 @@ pub use permission::{
 };
 pub use plan_mode::PlanApprovalPrompter;
 pub use subagent::{run_subagent, ChatBackend, CoreSubagentRunner};
-pub use tokens::{estimate_context, TokenEstimator};
+pub use tokens::{estimate_context, EstimateMode, TiktokenEncoding, TokenEstimator};
 pub use turn::{SteerBuffer, StepId, TurnId, TurnState};
 use plan_mode::{
     build_effective_system_prompt, default_plan_approval_prompter, handle_enter_plan_mode,
@@ -452,7 +452,11 @@ impl Agent {
     }
 
     fn token_estimator(&self) -> TokenEstimator {
-        TokenEstimator::new(self.config.chars_per_token_for_model())
+        TokenEstimator::for_provider(
+            self.config.provider_kind(),
+            &self.config.model,
+            self.config.chars_per_token_for_model(),
+        )
     }
 
     fn estimated_context_tokens(&self, messages: &[Message], tools: &[zene_llm::ToolDefinition]) -> usize {
@@ -714,6 +718,7 @@ impl Agent {
             message_count = messages.len(),
             tool_count = tools.len(),
             chars_per_token = self.config.chars_per_token_for_model(),
+            estimate_mode = ?self.token_estimator().mode,
             "llm request context water level"
         );
         self.warn_if_near_context_limit(self.context_water.effective_tokens() as usize);

--- a/crates/core/src/tokens.rs
+++ b/crates/core/src/tokens.rs
@@ -1,7 +1,47 @@
+use tiktoken_rs::tokenizer::{Tokenizer, get_tokenizer};
+use tiktoken_rs::{
+    CoreBPE, cl100k_base_singleton, o200k_base_singleton, o200k_harmony_singleton,
+};
+use zene_config::ProviderKind;
 use zene_llm::{Message, MessageKind, Role, ToolDefinition};
 
 /// Per tool-call JSON/API framing beyond argument string length.
 const TOOL_CALL_FRAME_TOKENS: u32 = 12;
+
+/// OpenAI tiktoken BPE encoding used for accurate text counting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TiktokenEncoding {
+    Cl100kBase,
+    O200kBase,
+    O200kHarmony,
+}
+
+impl TiktokenEncoding {
+    /// Resolve encoding for a known OpenAI model name (via `tiktoken-rs` model map).
+    pub fn from_model(model: &str) -> Option<Self> {
+        match get_tokenizer(model)? {
+            Tokenizer::Cl100kBase => Some(Self::Cl100kBase),
+            Tokenizer::O200kBase => Some(Self::O200kBase),
+            Tokenizer::O200kHarmony => Some(Self::O200kHarmony),
+            _ => None,
+        }
+    }
+
+    fn bpe(self) -> &'static CoreBPE {
+        match self {
+            Self::Cl100kBase => cl100k_base_singleton(),
+            Self::O200kBase => o200k_base_singleton(),
+            Self::O200kHarmony => o200k_harmony_singleton(),
+        }
+    }
+
+    fn count(self, text: &str) -> u32 {
+        if text.is_empty() {
+            return 0;
+        }
+        self.bpe().encode_ordinary(text).len() as u32
+    }
+}
 
 /// How text is converted to token estimates.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -11,9 +51,11 @@ pub enum EstimateMode {
     ScriptAware,
     /// Legacy uniform chars/token ceiling division.
     Uniform,
+    /// OpenAI BPE via `tiktoken-rs` (encoding selected from model name).
+    Tiktoken(TiktokenEncoding),
 }
 
-/// Heuristic token estimator with configurable chars-per-token ratio.
+/// Token estimator: heuristic by default; OpenAI models use tiktoken BPE.
 #[derive(Debug, Clone, Copy)]
 pub struct TokenEstimator {
     pub chars_per_token: f32,
@@ -42,6 +84,27 @@ impl TokenEstimator {
         self
     }
 
+    /// Build an estimator for the active provider/model.
+    ///
+    /// OpenAI path: use `tiktoken-rs` when the model maps to a known encoding.
+    /// Unknown openai-compatible model names and Anthropic keep the script-aware heuristic.
+    pub fn for_provider(provider: ProviderKind, model: &str, chars_per_token: f32) -> Self {
+        let chars_per_token = chars_per_token.max(1.0);
+        match provider {
+            ProviderKind::OpenAi => {
+                if let Some(encoding) = TiktokenEncoding::from_model(model) {
+                    Self {
+                        chars_per_token,
+                        mode: EstimateMode::Tiktoken(encoding),
+                    }
+                } else {
+                    Self::new(chars_per_token)
+                }
+            }
+            ProviderKind::Anthropic => Self::new(chars_per_token),
+        }
+    }
+
     pub fn estimate_chars_as_tokens(&self, text: &str) -> u32 {
         if text.is_empty() {
             return 0;
@@ -51,16 +114,21 @@ impl TokenEstimator {
                 (text.chars().count() as f32 / self.chars_per_token).ceil() as u32
             }
             EstimateMode::ScriptAware => estimate_script_aware(text, self.chars_per_token),
+            EstimateMode::Tiktoken(encoding) => encoding.count(text),
         }
     }
 
     /// Role-specific framing overhead (JSON keys, role labels, separators).
     fn role_overhead(&self, role: Role, kind: Option<MessageKind>) -> u32 {
-        let base = match role {
-            Role::System => 8,
-            Role::User => 4,
-            Role::Assistant => 4,
-            Role::Tool => 8,
+        let base = match self.mode {
+            // OpenAI cookbook: ~3 tokens framing per chat message.
+            EstimateMode::Tiktoken(_) => 3,
+            EstimateMode::ScriptAware | EstimateMode::Uniform => match role {
+                Role::System => 8,
+                Role::User => 4,
+                Role::Assistant => 4,
+                Role::Tool => 8,
+            },
         };
         if kind == Some(MessageKind::CompactionSummary) {
             base + 4
@@ -69,17 +137,22 @@ impl TokenEstimator {
         }
     }
 
-    /// JSON tool arguments: string length plus structural punctuation overhead.
+    /// JSON tool arguments: BPE count as-is; heuristic adds structural punctuation overhead.
     fn estimate_json_args_tokens(&self, json: &str) -> u32 {
         if json.is_empty() {
             return 0;
         }
-        let content = self.estimate_chars_as_tokens(json);
-        let structure = json
-            .chars()
-            .filter(|c| matches!(c, '{' | '}' | '[' | ']' | ':' | ',' | '"'))
-            .count();
-        content + (structure as f32 / self.chars_per_token).ceil() as u32
+        match self.mode {
+            EstimateMode::Tiktoken(_) => self.estimate_chars_as_tokens(json),
+            EstimateMode::ScriptAware | EstimateMode::Uniform => {
+                let content = self.estimate_chars_as_tokens(json);
+                let structure = json
+                    .chars()
+                    .filter(|c| matches!(c, '{' | '}' | '[' | ']' | ':' | ',' | '"'))
+                    .count();
+                content + (structure as f32 / self.chars_per_token).ceil() as u32
+            }
+        }
     }
 
     pub fn estimate_message_tokens(&self, message: &Message) -> u32 {
@@ -91,7 +164,13 @@ impl TokenEstimator {
 
         if let Some(tool_calls) = &message.tool_calls {
             for call in tool_calls {
-                tokens += TOOL_CALL_FRAME_TOKENS;
+                // Cookbook uses ~1 token per tool call; keep a slightly higher
+                // constant for heuristic modes where argument framing is approximate.
+                let frame = match self.mode {
+                    EstimateMode::Tiktoken(_) => 1,
+                    EstimateMode::ScriptAware | EstimateMode::Uniform => TOOL_CALL_FRAME_TOKENS,
+                };
+                tokens += frame;
                 tokens += self.estimate_chars_as_tokens(&call.id);
                 tokens += self.estimate_chars_as_tokens(&call.name);
                 tokens += self.estimate_json_args_tokens(&call.arguments);
@@ -126,7 +205,13 @@ impl TokenEstimator {
     }
 
     pub fn estimate_request_tokens(&self, messages: &[Message], tools: &[ToolDefinition]) -> u32 {
-        self.estimate_messages_tokens(messages) + self.estimate_tools_tokens(tools)
+        let mut tokens =
+            self.estimate_messages_tokens(messages) + self.estimate_tools_tokens(tools);
+        // OpenAI cookbook reply priming: <|start|>assistant<|message|>
+        if matches!(self.mode, EstimateMode::Tiktoken(_)) {
+            tokens += 3;
+        }
+        tokens
     }
 }
 
@@ -309,5 +394,49 @@ mod tests {
         let plain = Message::assistant("summary text");
         let summary = Message::compaction_summary("summary text");
         assert!(estimator.estimate_message_tokens(&summary) > estimator.estimate_message_tokens(&plain));
+    }
+
+    #[test]
+    fn openai_gpt4o_uses_o200k_tiktoken() {
+        let est = TokenEstimator::for_provider(ProviderKind::OpenAi, "gpt-4o", 4.0);
+        assert_eq!(est.mode, EstimateMode::Tiktoken(TiktokenEncoding::O200kBase));
+        // cl100k/o200k: "hello world" → 2 tokens
+        assert_eq!(est.estimate_chars_as_tokens("hello world"), 2);
+    }
+
+    #[test]
+    fn openai_gpt4_uses_cl100k_tiktoken() {
+        let est = TokenEstimator::for_provider(ProviderKind::OpenAi, "gpt-4", 4.0);
+        assert_eq!(est.mode, EstimateMode::Tiktoken(TiktokenEncoding::Cl100kBase));
+        assert_eq!(est.estimate_chars_as_tokens("hello world"), 2);
+    }
+
+    #[test]
+    fn openai_compatible_unknown_model_falls_back_to_heuristic() {
+        let est = TokenEstimator::for_provider(ProviderKind::OpenAi, "deepseek-chat", 4.0);
+        assert_eq!(est.mode, EstimateMode::ScriptAware);
+    }
+
+    #[test]
+    fn anthropic_keeps_heuristic() {
+        let est = TokenEstimator::for_provider(ProviderKind::Anthropic, "claude-sonnet-4-5", 4.0);
+        assert_eq!(est.mode, EstimateMode::ScriptAware);
+    }
+
+    #[test]
+    fn tiktoken_counts_cjk_higher_than_latin_run() {
+        let est = TokenEstimator::for_provider(ProviderKind::OpenAi, "gpt-4o", 4.0);
+        let latin = est.estimate_chars_as_tokens("abcd");
+        let cjk = est.estimate_chars_as_tokens("中文测试");
+        assert!(cjk > latin);
+    }
+
+    #[test]
+    fn tiktoken_request_includes_reply_priming() {
+        let est = TokenEstimator::for_provider(ProviderKind::OpenAi, "gpt-4o", 4.0);
+        let messages = vec![Message::user("hi")];
+        let msg_only = est.estimate_messages_tokens(&messages);
+        let request = est.estimate_request_tokens(&messages, &[]);
+        assert_eq!(request, msg_only + 3);
     }
 }

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -10,26 +10,29 @@ Core agent loop lives in `crates/core`. This document tracks engine-level behavi
 - CLI REPL: `/steer <message>` when a turn is active (typically from TUI/async callers; blocking REPL waits on `prompt()`).
 - Event: `AgentEvent::SteerInput { text }` for UI/replay hooks.
 
-## Token estimation (v2 heuristic)
+## Token estimation
 
-Implemented in `tokens.rs` as `TokenEstimator` — no external tokenizer dependency (Option B). Default **script-aware** mode: Latin/code runs use configurable `chars_per_token` (default 4); CJK characters count ≈1 token each (closer to real BPE on mixed text). Uniform legacy mode remains available via `EstimateMode::Uniform`.
+Implemented in `tokens.rs` as `TokenEstimator`. Call sites use `Agent::token_estimator()` → `TokenEstimator::for_provider(provider, model, chars_per_token)`.
+
+**OpenAI path (Option A)**: when `provider` is OpenAI/openai-compatible **and** the model name maps in `tiktoken-rs` (`gpt-4o` → `o200k_base`, `gpt-4` / `gpt-3.5-turbo` → `cl100k_base`, etc.), text is counted with real BPE (`encode_ordinary`). Message framing follows the OpenAI cookbook (~3 tokens/message + 3 reply priming on the request). Unknown openai-compatible model names (e.g. DeepSeek) fall back to the heuristic below.
+
+**Heuristic path (Option B)**: default **script-aware** mode for Anthropic and unmapped models — Latin/code runs use configurable `chars_per_token` (default 4); CJK ≈1 token/char. Uniform legacy mode remains available via `EstimateMode::Uniform`.
 
 **Per-message estimate** (`estimate_message_tokens` / `TokenEstimator::estimate_message_tokens`):
 
-| Component | Heuristic |
-|-----------|-----------|
-| Role framing | system +8, user +4, assistant +4, tool +8 tokens |
-| Compaction summary kind | +4 tokens on top of assistant framing |
-| Text content | `ceil(char_count / chars_per_token)` |
-| Tool calls (assistant) | +12 framing per call + id/name/arguments length |
-| JSON tool arguments | string length **plus** structural punctuation (`{}[]:,"`) counted separately |
-| Tool result metadata | `tool_call_id`, `name`, error flag (+2) |
+| Component | Heuristic | Tiktoken (OpenAI) |
+|-----------|-----------|-------------------|
+| Role framing | system +8, user/assistant +4, tool +8 | +3 per message |
+| Compaction summary kind | +4 on top of framing | +4 on top of framing |
+| Text content | script-aware / uniform chars | BPE `encode_ordinary` length |
+| Tool calls (assistant) | +12 framing + id/name/args | +1 framing + BPE id/name/args |
+| JSON tool arguments | length + structural punctuation | BPE of full JSON string |
+| Tool result metadata | `tool_call_id`, `name`, error (+2) | same fields via BPE |
+| Request priming | — | +3 once (`estimate_request_tokens`) |
 
-**Request estimate**: `estimate_context(messages, tools, estimator)` = sum of message tokens + serialized tool-definition JSON (+4 framing). Used consistently before compaction triggers and inside `tail_start_index` / compaction planning.
+**Request estimate**: `estimate_context(messages, tools, estimator)` = sum of message tokens + serialized tool-definition JSON (+4 framing) [+ reply priming in tiktoken mode]. Used before compaction triggers and inside `tail_start_index` / compaction planning.
 
 Warn log when estimate ≥ 90% of `compaction.context_window_tokens`.
-
-Future: Option A (`tiktoken-rs` for OpenAI provider) can replace the char heuristic without changing call sites.
 
 ## Compaction (v2)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -75,7 +75,7 @@ Zene 目标：Rust 实现的本地 code agent CLI（对标 kimi-code / flue 的�
 
 ### P1.1 Token 估算
 
-- [x] 实现 message + tools 的 token 估算（初期可用字符数/heuristic，后期接 tiktoken 或 provider usage）
+- [x] 实现 message + tools 的 token 估算（启发式 + OpenAI 路径 `tiktoken-rs`；另累计 provider usage）
 - [x] 每次 LLM 调用前记录 context 大小
 - [x] 从 provider response 读取真实 usage 并累计
 
@@ -409,11 +409,11 @@ TUI、record/replay、安装分发。
 
 | 阶段 | 状态 | 内容 |
 |------|------|------|
-| P1 采样/上下文 | [x] | …续3 memory；续4 script-aware token 估计、Intra steps-first、memory 指纹去重 |
+| P1 采样/上下文 | [x] | …续4 script-aware；续5 OpenAI 路径 `tiktoken-rs` BPE 计数（未知兼容模型回退启发式） |
 | P2 权限 | [x] | default/accept_edits/dont_ask/bypass + allow/deny/ask 规则 |
 | P3 会话恢复 | [x] | compaction checkpoints、`/rewind`、`/fork`、`/session-info` |
 | P4 运行时 | [x] | 后台 Bash/Task + TaskOutput、`--worktree`、subagent 报告包装 |
 | P5 MCP/扩展 | [x] | stdio + HTTP MCP、`zene mcp doctor` |
 | P6 集成/产品化 | [x] | `zene -p` headless + `--output-format json`；`zene acp` 最小 ACP stdio |
 
-*最后更新：2026-07-18（P1 续4：script-aware tokens + steps-first）*
+*最后更新：2026-07-18（P1 续5：OpenAI tiktoken-rs）*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
将工作区版本升至 **0.1.7**，并在 `CHANGELOG.md` 汇总 v0.1.6 之后这轮 **grok 长上下文对齐** 优化。

本分支已包含尚未单独合并的 [#12](https://github.com/ParaTensor/zene/pull/12)（OpenAI `tiktoken-rs`）。

## 这轮优化概要
- 更强压缩阶梯、prefire two-pass、segment 持久化
- memory 注入/flush + 指纹去重；Intra steps-first 与工具输出边界
- script-aware 启发式 + OpenAI 已知模型 BPE 计数
- Pages 部署闸门与 hook BrokenPipe 偶发修复

合并后请打 tag `v0.1.7` 触发 GitHub Release 多平台构建。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-423cfb41-f08d-478e-a422-6c48bb8bbc01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

