### PR TITLE
Set up Cursor Cloud dev environment for Zene

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Zene is a single Rust product: a local coding-agent CLI (binary `zene`, workspace version in `Cargo.toml`). There is no backend server, database, or web app to run — the `web/`, `www/`, `apps/web/`, and root `package.json` files are just static-site copy stubs, not real Node apps. At runtime the CLI makes outbound HTTPS calls to an external LLM provider (OpenAI-compatible or Anthropic); nothing is self-hosted.
+
+Toolchain caveat (non-obvious): a dependency (`unigateway-sdk`) requires Rust `edition2024`, so the toolchain must be Rust >= 1.85. The base image historically defaulted to an older `rustc` (1.83); the update script pins `rustup default stable`. If you ever hit `feature edition2024 is required`, run `rustup default stable`.
+
+Standard commands (see `README.md`, `.github/workflows/ci.yml`, `install.sh`):
+- Build: `cargo build --workspace --locked`
+- Test (CI gate): `cargo test --workspace --locked`
+- Lint: `cargo clippy --workspace --locked` (note: `cargo fmt --all --check` currently reports pre-existing formatting diffs and is NOT enforced in CI)
+- Run: `cargo run -p zene-cli` or the built `./target/debug/zene`
+- Install: `./install.sh` (= `cargo install --path apps/cli --locked`)
+
+Running the agent requires an LLM API key (`ZENE_API_KEY`/`OPENAI_API_KEY`, or `ANTHROPIC_API_KEY` with `ZENE_PROVIDER=anthropic`). Config lives at `~/.zene/config.toml` (auto-created on first run) and env vars override it (`ZENE_MODEL`, `ZENE_BASE_URL`, etc.). Sessions persist under `~/.zene/sessions/`.
+
+Testing the agent loop without a paid key: point it at a local OpenAI-compatible mock via `ZENE_BASE_URL` and run headless, e.g. `zene --yolo -p "<prompt>" --output-format json`. The mock only needs to serve `POST /chat/completions` returning `choices[0].message` (optionally with `tool_calls`); `--output-format json` forces non-streaming so a plain JSON completion is sufficient. `--yolo` auto-approves Write/Edit/Bash tools so headless tool calls run unattended.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the Zene coding-agent CLI and documents it for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section (toolchain caveat, standard build/test/lint/run commands, and how to exercise the agent loop without a paid LLM key).
- Registers an update script (`rustup toolchain install stable` + `rustup default stable` + `cargo fetch --locked`) so future VMs use a Rust toolchain new enough for `edition2024` (the base image pinned 1.83; `unigateway-sdk` needs >= 1.85).

No application code was modified.

## Verification

- Build: `cargo build --workspace --locked` — success (warnings only)
- Test: `cargo test --workspace --locked` — 218 passed, 0 failed
- Lint: `cargo clippy --workspace --locked` — success (warnings only)
- Run (hello-world): drove a real headless agent turn against a local OpenAI-compatible mock; the agent issued a `Write` tool call that actually created `hello_zene.txt`, then returned a final message, and the session persisted.

[Zene hello-world demo output](https://cursor.com/agents/bc-aea4d8e9-4e80-4970-ad2e-22a0de0383f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fzene_hello_world_demo.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aea4d8e9-4e80-4970-ad2e-22a0de0383f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aea4d8e9-4e80-4970-ad2e-22a0de0383f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

