### PR TITLE
feat: integrate Keel as Zene execution layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4440,6 +4440,7 @@ dependencies = [
  "tracing",
  "zene-config",
  "zene-llm",
+ "zene-sandbox",
  "zene-tools",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -146,10 +146,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -179,6 +209,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -289,6 +328,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,7 +358,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -362,6 +412,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmpv2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "961b955a666e25ee5a1091d219128d6e6401e3dab84efb1a2bf6b4035d797b39"
+dependencies = [
+ "crmf",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
+name = "cms"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b77c319abfd5219629c45c34c89ba945ed3c5e49fcde9d16b6c3885f118a730"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,6 +465,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +493,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -424,6 +528,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crmf"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36fe21b96d5b87f5de4b5b7202ec41c00110ac817ce6728fe75fb2fe5962ed92"
+dependencies = [
+ "cms",
+ "der",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -465,6 +600,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -519,6 +663,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,9 +712,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -594,10 +773,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "eero-keel-core"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ae4109897131b19fe438dc70422d1b370fe8630c4dd6f19a3bb15bf192a054"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "eero-keel-enforce",
+ "eero-keel-policy",
+ "eero-keel-record",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "eero-keel-enforce"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd2c6ed43980780b59595fa2d2f96ff59d725331f5185d8abd8b28adb8741665"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "dirs",
+ "dunce",
+ "eero-keel-policy",
+ "eero-keel-record",
+ "globset",
+ "ignore",
+ "libc",
+ "nono",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "eero-keel-policy"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59957bfca7570e35f78bb5a75b31c0a17f235535d21c2e2e6a920e0880354ba2"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "toml 1.1.3+spec-1.1.0",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "eero-keel-record"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf19aecd0cc2c55884bcc384ccd7f2f4dfdfccc66427566a13cfbd788136be9"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "dirs",
+ "eero-keel-policy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "either"
@@ -619,6 +881,26 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -677,6 +959,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,6 +992,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +1015,12 @@ dependencies = [
  "lazy_static",
  "num",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -856,6 +1156,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -881,7 +1182,18 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -897,12 +1209,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -952,6 +1270,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1152,6 +1479,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b009b6744c1445efd7244084e25e498636412effb6760b55067553baa925cc7"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,10 +1605,21 @@ dependencies = [
  "percent-encoding",
  "referencing",
  "regex-syntax",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "uuid-simd",
+]
+
+[[package]]
+name = "landlock"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1446,6 +1800,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "nono"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae7eb523cc2036e9ad6527411c3da5dc2172dc454cc3447a03b910420a39bfee"
+dependencies = [
+ "der",
+ "getrandom 0.4.2",
+ "globset",
+ "ignore",
+ "landlock",
+ "libc",
+ "nix 0.31.3",
+ "prettyplease",
+ "regress",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "sigstore-trust-root",
+ "sigstore-verify",
+ "syn",
+ "thiserror 2.0.18",
+ "tracing",
+ "typify",
+ "walkdir",
+ "x509-cert",
+ "zeroize",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,8 +1996,27 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1829,6 +2231,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,6 +2278,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -1970,6 +2389,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "regress"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2441,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,7 +2482,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2087,9 +2548,10 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -2125,6 +2587,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
 
 [[package]]
 name = "same-file"
@@ -2170,6 +2638,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -2218,11 +2690,23 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe52319a927259afbfa5180c5157cd8167edfd3e8c254f9558c7fef44c5649f2"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2232,6 +2716,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_tokenstream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c49585c52c01f13c5c2ebb333f14f6885d76daa768d8a037d28017ec538c69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
 ]
 
 [[package]]
@@ -2253,8 +2758,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2304,6 +2831,175 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "sigstore-bundle"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7dc53c8a941858d01479622dbb7650aaa2ee0ca1fb58fb6cdddbfc3064abbb"
+dependencies = [
+ "base64",
+ "hex",
+ "serde",
+ "serde_json",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-rekor",
+ "sigstore-tsa",
+ "sigstore-types",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sigstore-crypto"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da90c3d9af638898a5fdc347479b18f950bb0dde11ecf2244f94cd28135da53b"
+dependencies = [
+ "aws-lc-rs",
+ "base64",
+ "const-oid 0.9.6",
+ "der",
+ "digest 0.10.7",
+ "pem",
+ "rand_core 0.10.1",
+ "sha2 0.10.9",
+ "signature",
+ "sigstore-types",
+ "spki",
+ "thiserror 2.0.18",
+ "tracing",
+ "x509-cert",
+]
+
+[[package]]
+name = "sigstore-merkle"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c0d53558825c77716855c13794306fff766854c1bf92948e77d7890da3f2455"
+dependencies = [
+ "base64",
+ "hex",
+ "sigstore-crypto",
+ "sigstore-types",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sigstore-rekor"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "641fdaaa40d0cd6e249cf1671c2240beff1a3ece578062cf43e750779e8db2b3"
+dependencies = [
+ "base64",
+ "hex",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-types",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "sigstore-trust-root"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8762a4813252faffdf6f7e2040213078eb2482fbc351381134f3fc60c1be9c"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "sigstore-crypto",
+ "sigstore-types",
+ "thiserror 2.0.18",
+ "x509-cert",
+]
+
+[[package]]
+name = "sigstore-tsa"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bc86c8abc1ece6832236e7e34e9baebb5d4d40490c0332b814a0d8624ca7255"
+dependencies = [
+ "aws-lc-rs",
+ "base64",
+ "chrono",
+ "cmpv2",
+ "cms",
+ "const-oid 0.9.6",
+ "der",
+ "hex",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "sigstore-crypto",
+ "sigstore-types",
+ "thiserror 2.0.18",
+ "tracing",
+ "x509-cert",
+ "x509-tsp",
+]
+
+[[package]]
+name = "sigstore-types"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8d870c9bcfdf83396ac2bd2d6a23c5d09ec02cc9fda50fa1cbb3dd71a9bee53"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "pem",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sigstore-verify"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d751d608afd334fb9d8c037ad9efef69f1954494eff99cd79a0a6fc8af34ccb"
+dependencies = [
+ "base64",
+ "chrono",
+ "cms",
+ "const-oid 0.9.6",
+ "hex",
+ "pem",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "serde_json_canonicalizer",
+ "sigstore-bundle",
+ "sigstore-crypto",
+ "sigstore-merkle",
+ "sigstore-rekor",
+ "sigstore-trust-root",
+ "sigstore-tsa",
+ "sigstore-types",
+ "thiserror 2.0.18",
+ "tls_codec",
+ "tracing",
+ "x509-cert",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +3037,16 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2527,6 +3233,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2584,6 +3311,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -2595,9 +3323,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -2610,6 +3353,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2617,10 +3369,19 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -2628,6 +3389,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -2748,6 +3515,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "typify"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0b89f47309feaeb23c4509c15c9a04234f7deccef6f96c3bfe95319819a304"
+dependencies = [
+ "typify-impl",
+ "typify-macro",
+]
+
+[[package]]
+name = "typify-impl"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7b026f540b148b81043c720889dbb942b08659aa8a43f624ac4f04dbfc1861"
+dependencies = [
+ "heck",
+ "log",
+ "proc-macro2",
+ "quote",
+ "regress",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "syn",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typify-macro"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ed96c57f06ae0839416b986921a98f18b220da63bbb243a8570a00c8492183"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "syn",
+ "typify-impl",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,7 +3611,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2849,6 +3663,12 @@ dependencies = [
  "unigateway-host",
  "unigateway-protocol",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -3360,6 +4180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3460,6 +4286,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "sha1",
+ "signature",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
+name = "x509-tsp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5ceece934a21607055b7ac5c25adb56a2ff559804b10705dc674d1d838c15e1"
+dependencies = [
+ "cmpv2",
+ "cms",
+ "der",
+]
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3528,7 +4379,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -3564,7 +4415,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3580,7 +4431,7 @@ version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
- "reqwest",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tempfile",
@@ -3598,6 +4449,7 @@ version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
+ "eero-keel-core",
  "globset",
  "regex",
  "serde",
@@ -3634,7 +4486,7 @@ dependencies = [
  "jsonschema",
  "parking_lot",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "schemars",
  "serde",
  "serde_json",

--- a/apps/cli/src/acp/server.rs
+++ b/apps/cli/src/acp/server.rs
@@ -282,7 +282,9 @@ impl AcpServer {
         } else {
             PermissionMode::parse(&config.permission_mode)
         };
-        let sandbox = LocalSandbox::new(cwd);
+        let sandbox = LocalSandbox::with_keel(cwd)
+            .await
+            .context("initialize Keel execution layer")?;
         let agent = Agent::new(config, sandbox, session, permission_mode).await?;
         Ok(AcpSession {
             agent,

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -244,7 +244,9 @@ async fn main() -> Result<()> {
         PermissionMode::parse(&config.permission_mode)
     };
 
-    let sandbox = LocalSandbox::new(&agent_workdir);
+    let sandbox = LocalSandbox::with_keel(&agent_workdir)
+        .await
+        .context("initialize Keel execution layer")?;
     let mut agent = Agent::new(config.clone(), sandbox, session, permission_mode).await?;
 
     if let Some(prompt) = cli.prompt.as_deref() {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -121,6 +121,7 @@ impl Agent {
         permission_mode: PermissionMode,
     ) -> Result<Self> {
         let workdir = sandbox.workdir().to_path_buf();
+        let sandbox = Arc::new(sandbox);
         let system_prompt =
             workspace::build_system_prompt(&config.system_prompt, &workdir, config.include_workspace_context);
         session.ensure_system_message(&system_prompt);
@@ -129,7 +130,8 @@ impl Agent {
         let record_writer = AgentRecordWriter::for_session(&session.meta.id)?;
 
         let mut tools = zene_tools::agent_tools(config.agent_profile, config.web_search.clone());
-        let (mcp, mcp_tools) = McpManager::connect(&workdir).await?;
+        let (mcp, mcp_tools) =
+            McpManager::connect_with_sandbox(&workdir, sandbox.as_ref()).await?;
         if !mcp_tools.definitions().is_empty() {
             info!(
                 tool_count = mcp_tools.definitions().len(),
@@ -155,7 +157,7 @@ impl Agent {
             config,
             client,
             tools: Arc::new(tools),
-            sandbox: Arc::new(sandbox),
+            sandbox,
             session,
             turn_usage: TokenUsage::default(),
             context_water,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -224,6 +224,7 @@ impl Agent {
         if let Some(mcp) = self.mcp.as_mut() {
             mcp.disconnect().await?;
         }
+        self.sandbox.shutdown().await?;
         Ok(())
     }
 

--- a/crates/core/src/subagent.rs
+++ b/crates/core/src/subagent.rs
@@ -285,7 +285,7 @@ fn resolve_subagent_sandbox(
             if !resolved.is_dir() {
                 anyhow::bail!("Task cwd is not a directory: {}", resolved.display());
             }
-            Ok(Arc::new(LocalSandbox::new(resolved)))
+            Ok(Arc::new(parent.scoped_to(resolved)?))
         }
     }
 }

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -15,6 +15,7 @@ tokio.workspace = true
 tracing.workspace = true
 zene-config = { workspace = true }
 zene-llm = { workspace = true }
+zene-sandbox = { version = "0.1.6", path = "../sandbox" }
 zene-tools = { workspace = true }
 
 [dev-dependencies]

--- a/crates/mcp/src/client.rs
+++ b/crates/mcp/src/client.rs
@@ -6,6 +6,7 @@ use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
 use tracing::debug;
+use zene_sandbox::{InteractiveProcess, LocalSandbox};
 
 use crate::config::McpServerConfig;
 
@@ -21,43 +22,70 @@ pub struct McpToolInfo {
 
 pub struct McpStdioClient {
     server_name: String,
-    child: Child,
+    process: Option<McpProcess>,
     stdin: ChildStdin,
     stdout: BufReader<tokio::process::ChildStdout>,
     next_id: u64,
 }
 
+enum McpProcess {
+    Direct(Child),
+    Sandboxed(InteractiveProcess),
+}
+
 impl McpStdioClient {
-    pub async fn connect(server_name: &str, config: &McpServerConfig) -> Result<Self> {
+    pub async fn connect(
+        server_name: &str,
+        config: &McpServerConfig,
+        sandbox: Option<&LocalSandbox>,
+    ) -> Result<Self> {
         let cmd = config
             .command
             .as_deref()
             .ok_or_else(|| anyhow!("MCP server `{server_name}` missing stdio command"))?;
-        let mut command = Command::new(cmd);
-        command
-            .args(&config.args)
-            .envs(&config.env)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
-            .kill_on_drop(true);
-
-        let mut child = command
-            .spawn()
-            .with_context(|| format!("spawn MCP server `{server_name}` ({cmd})"))?;
-
-        let stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| anyhow!("MCP server `{server_name}` stdin unavailable"))?;
-        let stdout = child
-            .stdout
-            .take()
-            .ok_or_else(|| anyhow!("MCP server `{server_name}` stdout unavailable"))?;
+        let (process, stdin, stdout) = if let Some(sandbox) = sandbox {
+            let env: Vec<(String, String)> = config
+                .env
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect();
+            let mut process = sandbox
+                .spawn_stdio(cmd, &config.args, &env)
+                .await
+                .with_context(|| format!("spawn MCP server `{server_name}` ({cmd}) with Keel"))?;
+            let stdin = process
+                .take_stdin()
+                .ok_or_else(|| anyhow!("MCP server `{server_name}` stdin unavailable"))?;
+            let stdout = process
+                .take_stdout()
+                .ok_or_else(|| anyhow!("MCP server `{server_name}` stdout unavailable"))?;
+            (McpProcess::Sandboxed(process), stdin, stdout)
+        } else {
+            let mut command = Command::new(cmd);
+            command
+                .args(&config.args)
+                .envs(&config.env)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::inherit())
+                .kill_on_drop(true);
+            let mut child = command
+                .spawn()
+                .with_context(|| format!("spawn MCP server `{server_name}` ({cmd})"))?;
+            let stdin = child
+                .stdin
+                .take()
+                .ok_or_else(|| anyhow!("MCP server `{server_name}` stdin unavailable"))?;
+            let stdout = child
+                .stdout
+                .take()
+                .ok_or_else(|| anyhow!("MCP server `{server_name}` stdout unavailable"))?;
+            (McpProcess::Direct(child), stdin, stdout)
+        };
 
         let mut client = Self {
             server_name: server_name.to_string(),
-            child,
+            process: Some(process),
             stdin,
             stdout: BufReader::new(stdout),
             next_id: 1,
@@ -111,8 +139,18 @@ impl McpStdioClient {
     }
 
     pub async fn disconnect(&mut self) -> Result<()> {
-        let _ = self.child.kill().await;
-        let _ = self.child.wait().await;
+        let Some(process) = self.process.take() else {
+            return Ok(());
+        };
+        match process {
+            McpProcess::Direct(mut child) => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+            }
+            McpProcess::Sandboxed(process) => {
+                process.cancel().await?;
+            }
+        }
         Ok(())
     }
 

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use tokio::sync::Mutex;
 use tracing::{info, warn};
+use zene_sandbox::LocalSandbox;
 use zene_tools::ToolRegistry;
 
 use crate::client::McpStdioClient;
@@ -22,7 +23,22 @@ impl McpManager {
         Self::from_config(config).await
     }
 
+    pub async fn connect_with_sandbox(
+        workdir: &Path,
+        sandbox: &LocalSandbox,
+    ) -> Result<(Self, ToolRegistry)> {
+        let config = load_mcp_config(workdir)?;
+        Self::from_config_inner(config, Some(sandbox)).await
+    }
+
     pub async fn from_config(config: McpConfig) -> Result<(Self, ToolRegistry)> {
+        Self::from_config_inner(config, None).await
+    }
+
+    async fn from_config_inner(
+        config: McpConfig,
+        sandbox: Option<&LocalSandbox>,
+    ) -> Result<(Self, ToolRegistry)> {
         let mut clients = Vec::new();
         let mut tool_boxes: Vec<Box<dyn zene_tools::Tool>> = Vec::new();
 
@@ -38,7 +54,7 @@ impl McpManager {
                     .await
                     .map(McpClientHandle::Http)
             } else {
-                McpStdioClient::connect(&server_name, &server_config)
+                McpStdioClient::connect(&server_name, &server_config, sandbox)
                     .await
                     .map(McpClientHandle::Stdio)
             };

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+eero-keel-core = "0.0.11"
 globset = "0.4"
 regex.workspace = true
 serde.workspace = true

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -14,7 +14,10 @@ use globset::GlobBuilder;
 use keel_core::backend_process_guard;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use keel_core::{backend_local_process, LocalProcessOptions};
-use keel_core::{profile_workspace, Space, SpaceHandle, SpawnRequest, TerminationReason};
+use keel_core::{
+    profile_workspace, ManagedProcess, Space, SpaceHandle, SpawnRequest, StdioMode,
+    TerminationReason,
+};
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
@@ -34,6 +37,44 @@ pub struct ExecResult {
     pub stdout: String,
     pub stderr: String,
     pub exit_code: i32,
+}
+
+pub struct InteractiveProcess {
+    inner: InteractiveProcessInner,
+}
+
+enum InteractiveProcessInner {
+    Local(tokio::process::Child),
+    Keel(ManagedProcess),
+}
+
+impl InteractiveProcess {
+    pub fn take_stdin(&mut self) -> Option<tokio::process::ChildStdin> {
+        match &mut self.inner {
+            InteractiveProcessInner::Local(child) => child.stdin.take(),
+            InteractiveProcessInner::Keel(process) => process.take_stdin(),
+        }
+    }
+
+    pub fn take_stdout(&mut self) -> Option<tokio::process::ChildStdout> {
+        match &mut self.inner {
+            InteractiveProcessInner::Local(child) => child.stdout.take(),
+            InteractiveProcessInner::Keel(process) => process.take_stdout(),
+        }
+    }
+
+    pub async fn cancel(self) -> Result<()> {
+        match self.inner {
+            InteractiveProcessInner::Local(mut child) => {
+                let _ = child.kill().await;
+                let _ = child.wait().await;
+            }
+            InteractiveProcessInner::Keel(process) => {
+                process.cancel().await.context("cancel Keel process")?;
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone)]
@@ -102,6 +143,45 @@ impl LocalSandbox {
 
     pub fn events_path(&self) -> Option<&Path> {
         self.space.as_ref().and_then(SpaceHandle::events_path)
+    }
+
+    /// Spawn an interactive stdio process such as an MCP server.
+    pub async fn spawn_stdio(
+        &self,
+        program: &str,
+        args: &[String],
+        env: &[(String, String)],
+    ) -> Result<InteractiveProcess> {
+        if let Some(space) = &self.space {
+            let mut request = SpawnRequest::new(program)
+                .args(args.iter().cloned())
+                .cwd(canonical_workdir(&self.workdir)?)
+                .stdin(StdioMode::Piped)
+                .stdout(StdioMode::Piped)
+                .stderr(StdioMode::Inherit);
+            request.env = env.to_vec();
+            let process = space
+                .spawn(request)
+                .await
+                .context("spawn interactive process with Keel")?;
+            return Ok(InteractiveProcess {
+                inner: InteractiveProcessInner::Keel(process),
+            });
+        }
+
+        let mut command = Command::new(program);
+        command
+            .args(args)
+            .envs(env.iter().cloned())
+            .current_dir(canonical_workdir(&self.workdir)?)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit())
+            .kill_on_drop(true);
+        let child = command.spawn().context("spawn interactive process")?;
+        Ok(InteractiveProcess {
+            inner: InteractiveProcessInner::Local(child),
+        })
     }
 
     pub fn resolve(&self, path: &str) -> Result<PathBuf> {
@@ -638,6 +718,7 @@ impl Sandbox for LocalSandbox {
 mod tests {
     use super::*;
     use std::fs;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     #[tokio::test]
     async fn keel_exec_records_redacted_command_and_completion() {
@@ -700,6 +781,26 @@ mod tests {
         let sandbox = LocalSandbox::with_keel(dir.path()).await.unwrap();
         sandbox.write_text("foo/bar.txt", "nested").await.unwrap();
         assert_eq!(sandbox.read_text("foo/bar.txt").await.unwrap(), "nested");
+        sandbox.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn keel_interactive_stdio_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let sandbox = LocalSandbox::with_keel(dir.path()).await.unwrap();
+        let mut process = sandbox
+            .spawn_stdio("sh", &["-c".into(), "cat".into()], &[])
+            .await
+            .unwrap();
+        let mut stdin = process.take_stdin().unwrap();
+        let mut stdout = process.take_stdout().unwrap();
+        stdin.write_all(b"mcp-ping\n").await.unwrap();
+        stdin.shutdown().await.unwrap();
+
+        let mut response = String::new();
+        stdout.read_to_string(&mut response).await.unwrap();
+        assert_eq!(response, "mcp-ping\n");
+        process.cancel().await.unwrap();
         sandbox.shutdown().await.unwrap();
     }
 }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -10,6 +10,11 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use globset::GlobBuilder;
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+use keel_core::backend_process_guard;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use keel_core::{backend_local_process, LocalProcessOptions};
+use keel_core::{profile_workspace, Space, SpaceHandle, SpawnRequest, TerminationReason};
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
@@ -31,20 +36,72 @@ pub struct ExecResult {
     pub exit_code: i32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct LocalSandbox {
     workdir: PathBuf,
+    space: Option<SpaceHandle>,
 }
 
 impl LocalSandbox {
+    /// Construct a local-only sandbox, primarily for isolated unit tests.
+    ///
+    /// Production agent entry points should use [`Self::with_keel`].
     pub fn new(workdir: impl Into<PathBuf>) -> Self {
         Self {
             workdir: workdir.into(),
+            space: None,
         }
+    }
+
+    /// Construct a sandbox backed by a Keel execution space.
+    pub async fn with_keel(workdir: impl Into<PathBuf>) -> Result<Self> {
+        let workdir = canonical_workdir(&workdir.into())?;
+        let policy = profile_workspace(&workdir).context("build Keel workspace policy")?;
+
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        let backend = backend_local_process(LocalProcessOptions::default());
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        let backend = backend_process_guard();
+
+        let space = Space::create(policy, backend)
+            .await
+            .context("create Keel execution space")?;
+        Ok(Self {
+            workdir,
+            space: Some(space),
+        })
     }
 
     pub fn workdir(&self) -> &Path {
         &self.workdir
+    }
+
+    /// Re-scope a child agent to a directory while retaining the same Keel policy.
+    pub fn scoped_to(&self, workdir: impl Into<PathBuf>) -> Result<Self> {
+        let requested = workdir.into();
+        let resolved = self.resolve(requested.to_string_lossy().as_ref())?;
+        if !resolved.is_dir() {
+            anyhow::bail!("sandbox cwd is not a directory: {}", resolved.display());
+        }
+        Ok(Self {
+            workdir: resolved,
+            space: self.space.clone(),
+        })
+    }
+
+    pub async fn shutdown(&self) -> Result<()> {
+        if let Some(space) = &self.space {
+            space
+                .clone()
+                .destroy()
+                .await
+                .context("destroy Keel execution space")?;
+        }
+        Ok(())
+    }
+
+    pub fn events_path(&self) -> Option<&Path> {
+        self.space.as_ref().and_then(SpaceHandle::events_path)
     }
 
     pub fn resolve(&self, path: &str) -> Result<PathBuf> {
@@ -54,6 +111,7 @@ impl LocalSandbox {
     pub async fn read_file_bytes(&self, path: &str, _hint_max: usize) -> Result<Vec<u8>> {
         let resolved = self.resolve(path)?;
         verify_resolved_path(&self.workdir, &resolved)?;
+        self.authorize_fs(&resolved, false).await?;
         read_file_bytes_nofollow(&resolved)
             .await
             .with_context(|| format!("read file: {}", resolved.display()))
@@ -62,9 +120,7 @@ impl LocalSandbox {
     pub async fn read_text(&self, path: &str) -> Result<String> {
         let bytes = self.read_file_bytes(path, 0).await?;
         if is_binary_content(&bytes) {
-            anyhow::bail!(
-                "cannot read binary file: {path}. Read supports text files only."
-            );
+            anyhow::bail!("cannot read binary file: {path}. Read supports text files only.");
         }
         String::from_utf8(bytes).context("file is not valid UTF-8 text")
     }
@@ -74,6 +130,7 @@ impl LocalSandbox {
             anyhow::bail!(msg);
         }
         let resolved = self.resolve_parent(path)?;
+        self.authorize_fs(&resolved, true).await?;
         if let Some(parent) = resolved.parent() {
             tokio::fs::create_dir_all(parent)
                 .await
@@ -90,13 +147,8 @@ impl LocalSandbox {
         cwd: Option<&str>,
         cancel: Option<&CancellationToken>,
     ) -> Result<ExecResult> {
-        self.exec_with_timeout(
-            command,
-            cwd,
-            cancel,
-            Duration::from_secs(BASH_TIMEOUT_SECS),
-        )
-        .await
+        self.exec_with_timeout(command, cwd, cancel, Duration::from_secs(BASH_TIMEOUT_SECS))
+            .await
     }
 
     /// Like [`Self::exec`] but with an explicit timeout (used by background Bash).
@@ -112,6 +164,21 @@ impl LocalSandbox {
         }
 
         let timeout_secs = timeout.as_secs().max(1);
+        if self.space.is_some() {
+            let cwd = match cwd {
+                Some(path) => self.resolve(path)?,
+                None => canonical_workdir(&self.workdir)?,
+            };
+            #[cfg(unix)]
+            let (program, args) = ("bash", vec!["-lc".to_string(), command.to_string()]);
+            #[cfg(windows)]
+            let (program, args) = ("cmd", vec!["/C".to_string(), command.to_string()]);
+
+            return self
+                .exec_keel(program, args, &cwd, cancel, timeout, false)
+                .await;
+        }
+
         let work = self.exec_inner(command, cwd);
         let timed = tokio::time::timeout(timeout, work);
 
@@ -131,6 +198,24 @@ impl LocalSandbox {
                 Err(_) => anyhow::bail!("command timed out after {timeout_secs} seconds"),
             }
         }
+    }
+
+    async fn authorize_fs(&self, path: &Path, write: bool) -> Result<()> {
+        let Some(space) = &self.space else {
+            return Ok(());
+        };
+        if !space
+            .check_fs(path, write)
+            .await
+            .context("check Keel filesystem policy")?
+        {
+            anyhow::bail!(
+                "Keel denied {} access: {}",
+                if write { "write" } else { "read" },
+                path.display()
+            );
+        }
+        Ok(())
     }
 
     async fn exec_inner(&self, command: &str, cwd: Option<&str>) -> Result<ExecResult> {
@@ -177,6 +262,54 @@ impl LocalSandbox {
         })
     }
 
+    async fn exec_keel(
+        &self,
+        program: &str,
+        args: Vec<String>,
+        cwd: &Path,
+        cancel: Option<&CancellationToken>,
+        timeout: Duration,
+        audit_args: bool,
+    ) -> Result<ExecResult> {
+        let space = self
+            .space
+            .as_ref()
+            .context("Keel execution space is not configured")?;
+        let request = SpawnRequest::new(program)
+            .args(args)
+            .cwd(cwd)
+            .audit_args(audit_args);
+        let process = space.spawn(request).await.context("spawn with Keel")?;
+        let (exit, output) = if let Some(token) = cancel {
+            process
+                .wait_with_output_cancel(token, timeout)
+                .await
+                .context("wait for Keel process")?
+        } else {
+            process
+                .wait_with_output_timeout(timeout)
+                .await
+                .context("wait for Keel process")?
+        };
+
+        match exit.termination_reason {
+            TerminationReason::TimedOut => {
+                anyhow::bail!(
+                    "command timed out after {} seconds",
+                    timeout.as_secs().max(1)
+                )
+            }
+            TerminationReason::Cancelled => anyhow::bail!("aborted"),
+            _ => {}
+        }
+
+        Ok(ExecResult {
+            stdout: output_text_limited(&output.stdout, BASH_OUTPUT_LIMIT),
+            stderr: output_text_limited(&output.stderr, BASH_OUTPUT_LIMIT),
+            exit_code: exit.exit_code.unwrap_or(-1),
+        })
+    }
+
     pub fn glob(&self, pattern: &str) -> Result<Vec<String>> {
         let pattern = pattern.trim_start_matches("./");
         let glob = GlobBuilder::new(pattern)
@@ -186,7 +319,10 @@ impl LocalSandbox {
         let matcher = glob.compile_matcher();
 
         let mut matches = Vec::new();
-        for entry in WalkDir::new(&self.workdir).into_iter().filter_map(|e| e.ok()) {
+        for entry in WalkDir::new(&self.workdir)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
             if !entry.file_type().is_file() {
                 continue;
             }
@@ -227,6 +363,52 @@ impl LocalSandbox {
     ) -> Result<Option<Vec<GrepMatch>>> {
         let workdir = canonical_workdir(&self.workdir)?;
 
+        if self.space.is_some() {
+            let mut args = vec![
+                "--line-number".to_string(),
+                "--no-heading".to_string(),
+                "--color=never".to_string(),
+                "--max-count".to_string(),
+                GREP_MAX_MATCHES.to_string(),
+            ];
+            if case_insensitive {
+                args.push("-i".to_string());
+            }
+            args.push(pattern.to_string());
+            if let Some(p) = path {
+                let resolved = self.resolve(p)?;
+                args.push(
+                    resolved
+                        .strip_prefix(&workdir)
+                        .unwrap_or(&resolved)
+                        .to_string_lossy()
+                        .into_owned(),
+                );
+            } else {
+                args.push(".".to_string());
+            }
+
+            let output = match self
+                .exec_keel(
+                    "rg",
+                    args,
+                    &workdir,
+                    None,
+                    Duration::from_secs(BASH_TIMEOUT_SECS),
+                    true,
+                )
+                .await
+            {
+                Ok(output) => output,
+                Err(err) if err.to_string().contains("No such file") => return Ok(None),
+                Err(err) => return Err(err).context("spawn rg with Keel"),
+            };
+            if output.exit_code != 0 && output.exit_code != 1 {
+                return Ok(None);
+            }
+            return Ok(Some(parse_rg_output(&output.stdout)));
+        }
+
         let mut cmd = Command::new("rg");
         cmd.arg("--line-number")
             .arg("--no-heading")
@@ -260,17 +442,9 @@ impl LocalSandbox {
             return Ok(None);
         }
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let mut matches = Vec::new();
-        for line in stdout.lines() {
-            if let Some(m) = parse_rg_line(line) {
-                matches.push(m);
-            }
-            if matches.len() >= GREP_MAX_MATCHES {
-                break;
-            }
-        }
-        Ok(Some(matches))
+        Ok(Some(parse_rg_output(&String::from_utf8_lossy(
+            &output.stdout,
+        ))))
     }
 
     async fn grep_fallback(
@@ -393,6 +567,23 @@ fn parse_rg_line(line: &str) -> Option<GrepMatch> {
     })
 }
 
+fn parse_rg_output(stdout: &str) -> Vec<GrepMatch> {
+    stdout
+        .lines()
+        .filter_map(parse_rg_line)
+        .take(GREP_MAX_MATCHES)
+        .collect()
+}
+
+fn output_text_limited(bytes: &[u8], limit: usize) -> String {
+    if bytes.len() <= limit {
+        return String::from_utf8_lossy(bytes).into_owned();
+    }
+    let mut output = String::from_utf8_lossy(&bytes[..limit]).into_owned();
+    output.push_str("\n...[truncated]");
+    output
+}
+
 async fn read_limited(reader: &mut (impl AsyncReadExt + Unpin), limit: usize) -> Result<String> {
     let mut buf = vec![0u8; 8192];
     let mut out = Vec::new();
@@ -440,5 +631,75 @@ impl Sandbox for LocalSandbox {
         cancel: Option<&CancellationToken>,
     ) -> Result<ExecResult> {
         LocalSandbox::exec(self, command, cwd, cancel).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[tokio::test]
+    async fn keel_exec_records_redacted_command_and_completion() {
+        let dir = tempfile::tempdir().unwrap();
+        let sandbox = LocalSandbox::with_keel(dir.path()).await.unwrap();
+        let events = sandbox.events_path().unwrap().to_path_buf();
+
+        let result = sandbox.exec("printf keel-ok", None, None).await.unwrap();
+        assert_eq!(result.stdout, "keel-ok");
+        assert_eq!(result.exit_code, 0);
+
+        sandbox.shutdown().await.unwrap();
+        let audit = fs::read_to_string(events).unwrap();
+        assert!(audit.contains("\"kind\":\"exec\""));
+        assert!(audit.contains("\"args_redacted\":true"));
+        assert!(!audit.contains("printf keel-ok"));
+        assert!(audit.contains("\"kind\":\"exec_finished\""));
+    }
+
+    #[tokio::test]
+    async fn keel_exec_honors_cancellation() {
+        let dir = tempfile::tempdir().unwrap();
+        let sandbox = LocalSandbox::with_keel(dir.path()).await.unwrap();
+        let token = CancellationToken::new();
+        let cancel = token.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cancel.cancel();
+        });
+
+        let err = sandbox
+            .exec_with_timeout("sleep 30", None, Some(&token), Duration::from_secs(5))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("aborted"), "{err:#}");
+        sandbox.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn keel_sandbox_blocks_child_write_outside_workspace() {
+        let root = tempfile::Builder::new()
+            .prefix(".zene-keel-test-")
+            .tempdir_in(std::env::current_dir().unwrap())
+            .unwrap();
+        let workspace = root.path().join("workspace");
+        fs::create_dir(&workspace).unwrap();
+        let outside = root.path().join("outside.txt");
+        let sandbox = LocalSandbox::with_keel(&workspace).await.unwrap();
+
+        let command = format!("printf escaped > '{}'", outside.display());
+        let result = sandbox.exec(&command, None, None).await.unwrap();
+        assert_ne!(result.exit_code, 0);
+        assert!(!outside.exists());
+        sandbox.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn keel_policy_and_path_checks_allow_nested_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let sandbox = LocalSandbox::with_keel(dir.path()).await.unwrap();
+        sandbox.write_text("foo/bar.txt", "nested").await.unwrap();
+        assert_eq!(sandbox.read_text("foo/bar.txt").await.unwrap(), "nested");
+        sandbox.shutdown().await.unwrap();
     }
 }

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -158,7 +158,8 @@ impl LocalSandbox {
                 .cwd(canonical_workdir(&self.workdir)?)
                 .stdin(StdioMode::Piped)
                 .stdout(StdioMode::Piped)
-                .stderr(StdioMode::Inherit);
+                .stderr(StdioMode::Inherit)
+                .audit_args(false);
             request.env = env.to_vec();
             let process = space
                 .spawn(request)

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -796,6 +796,7 @@ mod tests {
         let mut stdout = process.take_stdout().unwrap();
         stdin.write_all(b"mcp-ping\n").await.unwrap();
         stdin.shutdown().await.unwrap();
+        drop(stdin);
 
         let mut response = String::new();
         stdout.read_to_string(&mut response).await.unwrap();

--- a/crates/sandbox/src/path_policy.rs
+++ b/crates/sandbox/src/path_policy.rs
@@ -192,6 +192,9 @@ fn relative_path_within_workdir(
     original: &str,
 ) -> Result<String> {
     if candidate.is_absolute() {
+        if let Ok(relative) = candidate.strip_prefix(workdir) {
+            return Ok(relative.to_string_lossy().replace('\\', "/"));
+        }
         let workdir_canon = canonical_workdir(workdir)?;
         if let Some(parent) = candidate.parent() {
             if let Ok(parent_canon) = parent.canonicalize() {

--- a/crates/sandbox/src/path_policy.rs
+++ b/crates/sandbox/src/path_policy.rs
@@ -8,25 +8,18 @@ pub fn check_write_allowed(path: &str) -> Result<(), String> {
     let trimmed = normalized.trim_start_matches("./");
 
     if is_sensitive_env_file(trimmed) {
-        return Err(format!(
-            "writes are denied for sensitive env file: {path}"
-        ));
+        return Err(format!("writes are denied for sensitive env file: {path}"));
     }
 
     if is_under_git_internal(trimmed) {
-        return Err(format!(
-            "writes are denied under .git/: {path}"
-        ));
+        return Err(format!("writes are denied under .git/: {path}"));
     }
 
     Ok(())
 }
 
 fn is_sensitive_env_file(path: &str) -> bool {
-    let name = path
-        .rsplit('/')
-        .next()
-        .unwrap_or(path);
+    let name = path.rsplit('/').next().unwrap_or(path);
     if name == ".env" {
         return true;
     }
@@ -98,9 +91,8 @@ pub fn verify_resolved_path(workdir: &Path, resolved: &Path) -> Result<()> {
         .with_context(|| format!("path not found: {}", resolved.display()))?;
 
     if meta.file_type().is_symlink() {
-        let link = std::fs::read_link(resolved).with_context(|| {
-            format!("read symlink: {}", resolved.display())
-        })?;
+        let link = std::fs::read_link(resolved)
+            .with_context(|| format!("read symlink: {}", resolved.display()))?;
         let target = if link.is_absolute() {
             link
         } else {
@@ -163,8 +155,22 @@ fn resolve_missing_leaf(
                     ensure_within_workdir(workdir_canon, &current)?;
                     return Ok(current);
                 }
-                current = resolve_existing_component(&current, original)?;
-                ensure_within_workdir(workdir_canon, &current)?;
+                if current.symlink_metadata().is_ok() {
+                    current = resolve_existing_component(&current, original)?;
+                    ensure_within_workdir(workdir_canon, &current)?;
+                } else {
+                    for remaining in &components[index + 1..] {
+                        match remaining {
+                            Component::Normal(part) => current.push(part),
+                            Component::CurDir => {}
+                            Component::ParentDir | Component::RootDir | Component::Prefix(_) => {
+                                anyhow::bail!("path escapes workspace: {original}");
+                            }
+                        }
+                    }
+                    ensure_within_workdir(workdir_canon, &current)?;
+                    return Ok(current);
+                }
             }
             Component::CurDir => {}
             Component::ParentDir => {
@@ -180,7 +186,11 @@ fn resolve_missing_leaf(
     Ok(current)
 }
 
-fn relative_path_within_workdir(workdir: &Path, candidate: &Path, original: &str) -> Result<String> {
+fn relative_path_within_workdir(
+    workdir: &Path,
+    candidate: &Path,
+    original: &str,
+) -> Result<String> {
     if candidate.is_absolute() {
         let workdir_canon = canonical_workdir(workdir)?;
         if let Some(parent) = candidate.parent() {
@@ -218,9 +228,7 @@ fn resolve_existing_component(path: &Path, original: &str) -> Result<PathBuf> {
         let target = if link.is_absolute() {
             link
         } else {
-            path.parent()
-                .unwrap_or_else(|| Path::new("."))
-                .join(link)
+            path.parent().unwrap_or_else(|| Path::new(".")).join(link)
         };
         return target
             .canonicalize()
@@ -293,7 +301,22 @@ mod tests {
         fs::create_dir_all(dir.path().join("src")).unwrap();
         let resolved = resolve_for_create(dir.path(), "src/new.rs").unwrap();
         assert!(resolved.ends_with("src/new.rs"));
-        assert!(path_starts_with(&resolved, &canonical_workdir(dir.path()).unwrap()));
+        assert!(path_starts_with(
+            &resolved,
+            &canonical_workdir(dir.path()).unwrap()
+        ));
+    }
+
+    #[test]
+    fn resolve_for_create_keeps_missing_intermediate_directories() {
+        let dir = tempdir().unwrap();
+        let resolved = resolve_for_create(dir.path(), "foo/bar/new.rs").unwrap();
+        assert_eq!(
+            resolved
+                .strip_prefix(canonical_workdir(dir.path()).unwrap())
+                .unwrap(),
+            Path::new("foo/bar/new.rs")
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- initialize a Keel execution space for CLI and ACP sessions
- run Bash, ripgrep, and MCP stdio subprocesses through Keel
- support timeout, cancellation, process-tree cleanup, and piped stdio
- redact shell and MCP arguments from Keel audit events
- enforce Keel filesystem policy while retaining Zene's `O_NOFOLLOW` and path revalidation
- preserve the parent Keel space for scoped subagents and destroy it during agent shutdown
- support nested writes through missing intermediate directories

## Testing

- `cargo test -p zene-sandbox -p zene-mcp -- --nocapture` — 25 passed
- `cargo test --workspace --locked` — passed
- runtime tests verify kernel blocking of child writes outside the workspace, cancellation, nested writes, stdio round-trip, and audit redaction
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab6ce336-da02-4856-8d8b-a611283e62df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab6ce336-da02-4856-8d8b-a611283e62df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

