### PR TITLE
feat: 可配置 Keel 沙箱 profile 与主机侧网络隔离

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- Configurable Keel sandbox profiles: `--sandbox` / `ZENE_SANDBOX` / `[sandbox]` in config, plus `~/.zene/sandbox.toml` custom profiles (`off` | `workspace` | `read-only` | `strict` | custom).
+- Host-side egress gating for `FetchUrl`, `WebSearch`, and HTTP MCP via Keel `check_egress`; `allow_hosts` allowlist support.
+- Default credential path denies (read + Keel policy) for `~/.ssh`, `~/.aws`, `**/.env*`, `**/*.pem`, etc.; Read/Write prefer Keel `SpaceFs` when enforced.
+- `[sandbox] auto_allow_bash` to skip Bash prompts while a sandbox profile is active.
+
 ## v0.1.6 (2026-07-18)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,6 +4458,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tracing",
  "walkdir",
 ]
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,14 @@ command = "./scripts/pre-tool.sh"
 [web_search]
 provider = "tavily"   # or "duckduckgo" (no API key, limited HTML parsing)
 api_key = "tvly-..."  # or export ZENE_WEB_SEARCH_API_KEY
+
+[sandbox]
+profile = "workspace"          # off | workspace | read-only | strict | custom
+# allow_hosts = ["api.github.com:443"]
+# auto_allow_bash = false      # skip Bash prompts when sandbox is active
 ```
+
+Custom Keel profiles can also live in `~/.zene/sandbox.toml` / `.zene/sandbox.toml` (same shape as Keel `[profiles.*]`). CLI `--sandbox` and `ZENE_SANDBOX` override config. Explore agent profile defaults to `read-only` when sandbox profile is unset.
 
 Per-project overrides in `.zene/config.toml` (merged over global; project wins on key collision):
 
@@ -72,8 +79,10 @@ trigger_ratio = 0.9
 
 | Path | Purpose |
 |------|---------|
-| `~/.zene/config.toml` | Model, provider, API keys, compaction, permission mode, inline hooks |
+| `~/.zene/config.toml` | Model, provider, API keys, compaction, permission mode, sandbox, inline hooks |
 | `.zene/config.toml` | Project-level config overrides (merged over global) |
+| `~/.zene/sandbox.toml` | Custom Keel sandbox profiles (`[profiles.<name>]`) |
+| `.zene/sandbox.toml` | Project-level custom sandbox profiles (additive names only) |
 | `~/.zene/hooks.json` | Additional lifecycle hooks (`PreToolUse`, `PostToolUse`) |
 | `~/.zene/mcp.json` | Global MCP server definitions (merged with project config) |
 | `.zene/mcp.json` | Project-level MCP server overrides |
@@ -115,6 +124,7 @@ zene config            # show config paths
 zene --session <id>    # resume a session
 zene --no-stream       # disable streaming output
 zene --yolo            # auto-approve Write / Edit / Bash
+zene --sandbox strict  # Keel profile: off | workspace | read-only | strict | custom
 zene --tui             # ratatui chat UI (PageUp/PageDown scroll)
 ```
 

--- a/apps/cli/src/acp/server.rs
+++ b/apps/cli/src/acp/server.rs
@@ -16,6 +16,7 @@ use zene_core::{
 use zene_sandbox::LocalSandbox;
 use zene_session::SessionRecord;
 
+use crate::sandbox_opts;
 use super::protocol::{
     err_response, is_notification, is_request, is_response, ok_response, prompt_text_from_params,
     RpcId,
@@ -282,7 +283,8 @@ impl AcpServer {
         } else {
             PermissionMode::parse(&config.permission_mode)
         };
-        let sandbox = LocalSandbox::with_keel(cwd)
+        let sandbox_opts = sandbox_opts::build_sandbox_options(&config, None);
+        let sandbox = LocalSandbox::with_options(cwd, sandbox_opts)
             .await
             .context("initialize Keel execution layer")?;
         let agent = Agent::new(config, sandbox, session, permission_mode).await?;

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -11,8 +11,9 @@ use zene_session::{export_session, list_sessions_for_workdir, SessionRecord};
 use std::sync::Arc;
 
 mod acp;
-mod repl;
 mod model_config;
+mod repl;
+mod sandbox_opts;
 mod tui;
 
 /// Shared cancel token for the in-flight REPL turn (Ctrl+C or `/cancel`).
@@ -81,6 +82,11 @@ pub struct Cli {
     /// Run the session inside a dedicated git worktree under `.zene/worktrees/`
     #[arg(long)]
     worktree: bool,
+
+    /// Keel sandbox profile: `off`, `workspace`, `read-only`, `strict`, or a custom
+    /// name from `~/.zene/sandbox.toml` / `.zene/sandbox.toml`
+    #[arg(long)]
+    sandbox: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -199,6 +205,14 @@ async fn main() -> Result<()> {
             println!("model: {}", config.model);
             println!("base_url: {}", config.base_url);
             println!("permission_mode: {}", config.permission_mode);
+            println!(
+                "sandbox.profile: {} (effective)",
+                config.sandbox.effective_profile(config.agent_profile)
+            );
+            if !config.sandbox.allow_hosts.is_empty() {
+                println!("sandbox.allow_hosts: {:?}", config.sandbox.allow_hosts);
+            }
+            println!("sandbox.auto_allow_bash: {}", config.sandbox.auto_allow_bash);
             return Ok(());
         }
         Some(Commands::Export { session, output }) => {
@@ -244,7 +258,17 @@ async fn main() -> Result<()> {
         PermissionMode::parse(&config.permission_mode)
     };
 
-    let sandbox = LocalSandbox::with_keel(&agent_workdir)
+    let sandbox_opts = sandbox_opts::build_sandbox_options(&config, cli.sandbox.as_deref());
+    eprintln!(
+        "Sandbox profile: {}{}",
+        sandbox_opts.profile,
+        if sandbox_opts.is_off() {
+            " (no Keel enforcement)"
+        } else {
+            ""
+        }
+    );
+    let sandbox = LocalSandbox::with_options(&agent_workdir, sandbox_opts)
         .await
         .context("initialize Keel execution layer")?;
     let mut agent = Agent::new(config.clone(), sandbox, session, permission_mode).await?;

--- a/apps/cli/src/sandbox_opts.rs
+++ b/apps/cli/src/sandbox_opts.rs
@@ -1,0 +1,36 @@
+use zene_config::ZeneConfig;
+use zene_sandbox::{url_host_port, SandboxOptions};
+
+/// Build Keel sandbox options from config + optional CLI `--sandbox` override.
+pub fn build_sandbox_options(config: &ZeneConfig, cli_profile: Option<&str>) -> SandboxOptions {
+    let profile = cli_profile
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| config.sandbox.effective_profile(config.agent_profile));
+
+    let mut trusted_hosts = Vec::new();
+    push_url_host(&mut trusted_hosts, &config.base_url);
+    if let Some(url) = config.anthropic_base_url.as_deref() {
+        push_url_host(&mut trusted_hosts, url);
+    }
+
+    SandboxOptions {
+        profile,
+        allow_hosts: config.sandbox.allow_hosts.clone(),
+        trusted_hosts,
+    }
+}
+
+fn push_url_host(out: &mut Vec<String>, url: &str) {
+    if let Ok((host, port)) = url_host_port(url) {
+        let entry = if port == 443 || port == 80 {
+            host
+        } else {
+            format!("{host}:{port}")
+        };
+        if !out.iter().any(|h| h.eq_ignore_ascii_case(&entry)) {
+            out.push(entry);
+        }
+    }
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -270,6 +270,44 @@ pub struct ZeneConfig {
     pub web_search: WebSearchConfig,
     #[serde(default)]
     pub agent_profile: AgentProfile,
+    #[serde(default)]
+    pub sandbox: SandboxSettings,
+}
+
+/// Keel sandbox profile selection and host-side network policy knobs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct SandboxSettings {
+    /// `off` | `workspace` | `read-only` | `strict` | custom name from `sandbox.toml`.
+    /// When omitted, defaults to `workspace` (or `read-only` for `agent_profile = "explore"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+    /// Extra egress allowlist entries (`host` or `host:port`). When non-empty,
+    /// network becomes an allowlist (even on top of workspace).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allow_hosts: Vec<String>,
+    /// When a sandbox profile is active (not `off`), auto-approve Bash prompts.
+    #[serde(default)]
+    pub auto_allow_bash: bool,
+}
+
+impl SandboxSettings {
+    /// Resolve the effective profile name.
+    pub fn effective_profile(&self, agent_profile: AgentProfile) -> String {
+        if let Some(profile) = self.profile.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+            return normalize_sandbox_profile(profile);
+        }
+        match agent_profile {
+            AgentProfile::Explore => "read-only".to_string(),
+            AgentProfile::Full | AgentProfile::Coder => "workspace".to_string(),
+        }
+    }
+}
+
+fn normalize_sandbox_profile(profile: &str) -> String {
+    match profile.trim().to_lowercase().as_str() {
+        "readonly" | "read_only" => "read-only".to_string(),
+        other => other.to_string(),
+    }
 }
 
 fn default_provider() -> String {
@@ -369,6 +407,7 @@ impl Default for ZeneConfig {
             hooks: Vec::new(),
             web_search: WebSearchConfig::default(),
             agent_profile: AgentProfile::default(),
+            sandbox: SandboxSettings::default(),
         }
     }
 }
@@ -586,6 +625,30 @@ impl ZeneConfig {
                 if let Ok(parsed) = AgentProfile::parse(&profile) {
                     self.agent_profile = parsed;
                 }
+            }
+        }
+        if let Ok(profile) = env::var("ZENE_SANDBOX") {
+            if !profile.is_empty() {
+                self.sandbox.profile = Some(normalize_sandbox_profile(&profile));
+            }
+        }
+        if let Ok(hosts) = env::var("ZENE_SANDBOX_ALLOW_HOSTS") {
+            let parsed: Vec<String> = hosts
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect();
+            if !parsed.is_empty() {
+                self.sandbox.allow_hosts = parsed;
+            }
+        }
+        if let Ok(flag) = env::var("ZENE_SANDBOX_AUTO_ALLOW_BASH") {
+            let lower = flag.trim().to_lowercase();
+            if matches!(lower.as_str(), "1" | "true" | "yes" | "on") {
+                self.sandbox.auto_allow_bash = true;
+            } else if matches!(lower.as_str(), "0" | "false" | "no" | "off") {
+                self.sandbox.auto_allow_bash = false;
             }
         }
     }
@@ -851,6 +914,27 @@ mod provider_tests {
         assert_eq!(AgentProfile::parse("explore").unwrap(), AgentProfile::Explore);
         assert_eq!(AgentProfile::parse("coder").unwrap(), AgentProfile::Coder);
         assert!(AgentProfile::parse("unknown").is_err());
+    }
+
+    #[test]
+    fn sandbox_effective_profile_defaults() {
+        let settings = SandboxSettings::default();
+        assert_eq!(
+            settings.effective_profile(AgentProfile::Full),
+            "workspace"
+        );
+        assert_eq!(
+            settings.effective_profile(AgentProfile::Explore),
+            "read-only"
+        );
+        let strict = SandboxSettings {
+            profile: Some("strict".into()),
+            ..SandboxSettings::default()
+        };
+        assert_eq!(
+            strict.effective_profile(AgentProfile::Explore),
+            "strict"
+        );
     }
 }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -148,9 +148,11 @@ impl Agent {
         let todos = shared_todo_store_from(session.todos.clone());
         let context_water =
             ContextWaterLevel::new(config.compaction.context_window_tokens);
+        let auto_allow_bash = config.sandbox.auto_allow_bash && sandbox.is_enforced();
         let permission = shared_permission_with_rules(
             permission_mode,
             permission_rules_from_config(&config),
+            auto_allow_bash,
         );
 
         Ok(Self {
@@ -479,7 +481,12 @@ impl Agent {
     }
 
     /// Replace the permission gate (e.g. TUI custom prompter).
-    pub fn set_permission_gate(&mut self, gate: PermissionGate) {
+    ///
+    /// Re-applies sandbox `auto_allow_bash` and config permission rules so a TUI
+    /// prompter swap does not drop sandbox-linked policy.
+    pub fn set_permission_gate(&mut self, mut gate: PermissionGate) {
+        gate.set_auto_allow_bash(self.config.sandbox.auto_allow_bash && self.sandbox.is_enforced());
+        gate.set_rules(permission_rules_from_config(&self.config));
         self.permission = Arc::new(Mutex::new(gate));
     }
 
@@ -1426,8 +1433,13 @@ fn truncate(input: &str, max: usize) -> String {
 fn shared_permission_with_rules(
     mode: PermissionMode,
     rules: Vec<PermissionRule>,
+    auto_allow_bash: bool,
 ) -> SharedToolPermission {
-    Arc::new(Mutex::new(PermissionGate::new(mode).with_rules(rules)))
+    Arc::new(Mutex::new(
+        PermissionGate::new(mode)
+            .with_rules(rules)
+            .with_auto_allow_bash(auto_allow_bash),
+    ))
 }
 
 fn permission_rules_from_config(config: &ZeneConfig) -> Vec<PermissionRule> {

--- a/crates/core/src/permission.rs
+++ b/crates/core/src/permission.rs
@@ -105,6 +105,9 @@ pub struct PermissionGate {
     approved_session: HashSet<String>,
     rules: Vec<PermissionRule>,
     prompter: Box<PermissionPrompter>,
+    /// When true and a sandbox profile is active, Bash is auto-approved
+    /// (aligned with grok `GROK_SANDBOX_AUTO_ALLOW_BASH`).
+    auto_allow_bash: bool,
 }
 
 impl PermissionGate {
@@ -114,6 +117,7 @@ impl PermissionGate {
             approved_session: HashSet::new(),
             rules: Vec::new(),
             prompter: Box::new(default_prompter),
+            auto_allow_bash: false,
         }
     }
 
@@ -123,6 +127,7 @@ impl PermissionGate {
             approved_session: HashSet::new(),
             rules: Vec::new(),
             prompter,
+            auto_allow_bash: false,
         }
     }
 
@@ -131,8 +136,33 @@ impl PermissionGate {
         self
     }
 
+    pub fn with_auto_allow_bash(mut self, enabled: bool) -> Self {
+        self.auto_allow_bash = enabled;
+        self
+    }
+
+    pub fn set_auto_allow_bash(&mut self, enabled: bool) {
+        self.auto_allow_bash = enabled;
+    }
+
+    pub fn auto_allow_bash(&self) -> bool {
+        self.auto_allow_bash
+    }
+
     pub fn set_rules(&mut self, rules: Vec<PermissionRule>) {
         self.rules = rules;
+    }
+
+    pub fn set_prompter(&mut self, prompter: Box<PermissionPrompter>) {
+        self.prompter = prompter;
+    }
+
+    /// Copy sandbox/session policy knobs from an existing gate (used when the TUI
+    /// swaps in a custom prompter without resetting rules).
+    pub fn inherit_policy_from(&mut self, other: &Self) {
+        self.auto_allow_bash = other.auto_allow_bash;
+        self.rules = other.rules.clone();
+        self.approved_session = other.approved_session.clone();
     }
 
     pub fn mode(&self) -> PermissionMode {
@@ -181,6 +211,10 @@ impl PermissionGate {
             }
 
             if self.mode.auto_approves_edits() && matches!(tool_name, "Write" | "Edit") {
+                return Ok(true);
+            }
+
+            if self.auto_allow_bash && tool_name == "Bash" {
                 return Ok(true);
             }
 
@@ -349,6 +383,25 @@ mod tests {
             .unwrap());
         assert_eq!(calls.load(Ordering::SeqCst), 0);
         assert!(gate.check("Bash", r#"{"command":"ls"}"#).unwrap());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn auto_allow_bash_skips_bash_prompt() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_clone = Arc::clone(&calls);
+        let mut gate = PermissionGate::with_prompter(PermissionMode::Default, {
+            Box::new(move |_tool, _args| {
+                calls_clone.fetch_add(1, Ordering::SeqCst);
+                Ok(PromptChoice::Deny)
+            })
+        })
+        .with_auto_allow_bash(true);
+        assert!(gate.check("Bash", r#"{"command":"ls"}"#).unwrap());
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(!gate
+            .check("Write", r#"{"path":"a.txt","content":"x"}"#)
+            .unwrap());
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -50,6 +50,16 @@ impl McpManager {
 
             let connected = if server_config.is_http() {
                 let url = server_config.url.as_deref().unwrap();
+                if let Some(sandbox) = sandbox {
+                    if let Err(err) = sandbox.authorize_egress(url).await {
+                        warn!(
+                            server = %server_name,
+                            error = %err,
+                            "mcp http egress denied by sandbox"
+                        );
+                        continue;
+                    }
+                }
                 McpHttpClient::connect(&server_name, url, &server_config.headers)
                     .await
                     .map(McpClientHandle::Http)

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -14,6 +14,7 @@ serde.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+tracing.workspace = true
 walkdir.workspace = true
 
 [dev-dependencies]

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -1,8 +1,10 @@
+mod options;
 mod path_policy;
 
 use std::path::{Path, PathBuf};
 
-pub use path_policy::check_write_allowed;
+pub use options::{url_host_port, SandboxOptions};
+pub use path_policy::{check_read_allowed, check_write_allowed};
 use path_policy::{canonical_workdir, resolve_existing, resolve_for_create, verify_resolved_path};
 use std::process::Stdio;
 use std::time::Duration;
@@ -15,7 +17,7 @@ use keel_core::backend_process_guard;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use keel_core::{backend_local_process, LocalProcessOptions};
 use keel_core::{
-    profile_workspace, ManagedProcess, Space, SpaceHandle, SpawnRequest, StdioMode,
+    check_egress, ManagedProcess, NetworkPolicy, Space, SpaceHandle, SpawnRequest, StdioMode,
     TerminationReason,
 };
 use tokio::io::AsyncReadExt;
@@ -81,23 +83,44 @@ impl InteractiveProcess {
 pub struct LocalSandbox {
     workdir: PathBuf,
     space: Option<SpaceHandle>,
+    network: NetworkPolicy,
+    profile: String,
 }
 
 impl LocalSandbox {
     /// Construct a local-only sandbox, primarily for isolated unit tests.
     ///
-    /// Production agent entry points should use [`Self::with_keel`].
+    /// Production agent entry points should use [`Self::with_options`] / [`Self::with_keel`].
     pub fn new(workdir: impl Into<PathBuf>) -> Self {
         Self {
             workdir: workdir.into(),
             space: None,
+            network: NetworkPolicy::Unrestricted,
+            profile: "off".to_string(),
         }
     }
 
-    /// Construct a sandbox backed by a Keel execution space.
+    /// Construct a sandbox with the default `workspace` Keel profile.
     pub async fn with_keel(workdir: impl Into<PathBuf>) -> Result<Self> {
+        Self::with_options(workdir, SandboxOptions::default()).await
+    }
+
+    /// Construct a sandbox from explicit profile / network options.
+    pub async fn with_options(workdir: impl Into<PathBuf>, opts: SandboxOptions) -> Result<Self> {
         let workdir = canonical_workdir(&workdir.into())?;
-        let policy = profile_workspace(&workdir).context("build Keel workspace policy")?;
+        let profile = opts.normalized_profile();
+
+        if opts.is_off() {
+            return Ok(Self {
+                workdir,
+                space: None,
+                network: NetworkPolicy::Unrestricted,
+                profile,
+            });
+        }
+
+        let policy = options::resolve_policy(&workdir, &opts)?;
+        let network = policy.network.clone();
 
         #[cfg(any(target_os = "linux", target_os = "macos"))]
         let backend = backend_local_process(LocalProcessOptions::default());
@@ -110,11 +133,51 @@ impl LocalSandbox {
         Ok(Self {
             workdir,
             space: Some(space),
+            network,
+            profile,
         })
     }
 
     pub fn workdir(&self) -> &Path {
         &self.workdir
+    }
+
+    pub fn profile(&self) -> &str {
+        &self.profile
+    }
+
+    pub fn network_policy(&self) -> &NetworkPolicy {
+        &self.network
+    }
+
+    /// True when a Keel execution space is active (profile is not `off`).
+    pub fn is_enforced(&self) -> bool {
+        self.space.is_some()
+    }
+
+    /// Host-side egress gate for tools (FetchUrl / WebSearch / HTTP MCP).
+    pub async fn authorize_egress(&self, url: &str) -> Result<()> {
+        let (host, port) = url_host_port(url)?;
+        if let Some(space) = &self.space {
+            if !space
+                .check_egress(&host, port)
+                .await
+                .context("check Keel egress policy")?
+            {
+                anyhow::bail!("sandbox denied network access to {host}:{port}");
+            }
+            return Ok(());
+        }
+
+        let decision = check_egress(&self.network, &host, port);
+        if !decision.is_allowed() {
+            let reason = match decision {
+                keel_core::EgressDecision::Deny { reason } => reason,
+                keel_core::EgressDecision::Allow => "denied".to_string(),
+            };
+            anyhow::bail!("sandbox denied network access to {host}:{port}: {reason}");
+        }
+        Ok(())
     }
 
     /// Re-scope a child agent to a directory while retaining the same Keel policy.
@@ -127,6 +190,8 @@ impl LocalSandbox {
         Ok(Self {
             workdir: resolved,
             space: self.space.clone(),
+            network: self.network.clone(),
+            profile: self.profile.clone(),
         })
     }
 
@@ -190,8 +255,24 @@ impl LocalSandbox {
     }
 
     pub async fn read_file_bytes(&self, path: &str, _hint_max: usize) -> Result<Vec<u8>> {
+        if let Err(msg) = path_policy::check_read_allowed(path) {
+            anyhow::bail!(msg);
+        }
         let resolved = self.resolve(path)?;
         verify_resolved_path(&self.workdir, &resolved)?;
+        if let Err(msg) = path_policy::check_read_allowed_resolved(&resolved) {
+            anyhow::bail!(msg);
+        }
+
+        if let Some(space) = &self.space {
+            let bytes = space
+                .fs()
+                .read(&resolved)
+                .await
+                .with_context(|| format!("Keel SpaceFs read: {}", resolved.display()))?;
+            return Ok(bytes);
+        }
+
         self.authorize_fs(&resolved, false).await?;
         read_file_bytes_nofollow(&resolved)
             .await
@@ -211,6 +292,16 @@ impl LocalSandbox {
             anyhow::bail!(msg);
         }
         let resolved = self.resolve_parent(path)?;
+
+        if let Some(space) = &self.space {
+            space
+                .fs()
+                .write(&resolved, content.as_bytes())
+                .await
+                .with_context(|| format!("Keel SpaceFs write: {}", resolved.display()))?;
+            return Ok(());
+        }
+
         self.authorize_fs(&resolved, true).await?;
         if let Some(parent) = resolved.parent() {
             tokio::fs::create_dir_all(parent)
@@ -803,6 +894,72 @@ mod tests {
         stdout.read_to_string(&mut response).await.unwrap();
         assert_eq!(response, "mcp-ping\n");
         process.cancel().await.unwrap();
+        sandbox.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn sandbox_off_skips_keel_space() {
+        let dir = tempfile::tempdir().unwrap();
+        let sandbox = LocalSandbox::with_options(
+            dir.path(),
+            SandboxOptions {
+                profile: "off".into(),
+                ..SandboxOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert!(!sandbox.is_enforced());
+        assert_eq!(sandbox.profile(), "off");
+        sandbox.write_text("a.txt", "ok").await.unwrap();
+        assert_eq!(sandbox.read_text("a.txt").await.unwrap(), "ok");
+    }
+
+    #[tokio::test]
+    async fn read_only_profile_denies_host_egress() {
+        let dir = tempfile::tempdir().unwrap();
+        let sandbox = LocalSandbox::with_options(
+            dir.path(),
+            SandboxOptions {
+                profile: "read-only".into(),
+                ..SandboxOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+        let err = sandbox
+            .authorize_egress("https://example.com/")
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("denied"),
+            "unexpected error: {err:#}"
+        );
+        sandbox.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn allow_hosts_permits_listed_egress() {
+        let dir = tempfile::tempdir().unwrap();
+        let sandbox = LocalSandbox::with_options(
+            dir.path(),
+            SandboxOptions {
+                profile: "strict".into(),
+                allow_hosts: vec!["example.com:443".into()],
+                ..SandboxOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+        sandbox
+            .authorize_egress("https://example.com/path")
+            .await
+            .unwrap();
+        let err = sandbox
+            .authorize_egress("https://evil.com/")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("denied"));
         sandbox.shutdown().await.unwrap();
     }
 }

--- a/crates/sandbox/src/options.rs
+++ b/crates/sandbox/src/options.rs
@@ -1,0 +1,303 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use keel_core::{
+    profile_read_only, profile_strict, profile_workspace, FsAccess, FsRule, NetworkPolicy,
+    NetworkRule, Policy, SandboxConfig,
+};
+
+/// How to construct a Keel-backed [`crate::LocalSandbox`].
+#[derive(Debug, Clone)]
+pub struct SandboxOptions {
+    /// `off` | `workspace` | `read-only` | `strict` | custom profile name.
+    pub profile: String,
+    /// Extra egress allowlist hosts (`host` or `host:port`).
+    pub allow_hosts: Vec<String>,
+    /// Hosts always merged into an allowlist when network is restricted
+    /// (typically the configured LLM `base_url` host).
+    pub trusted_hosts: Vec<String>,
+}
+
+impl Default for SandboxOptions {
+    fn default() -> Self {
+        Self {
+            profile: "workspace".to_string(),
+            allow_hosts: Vec::new(),
+            trusted_hosts: Vec::new(),
+        }
+    }
+}
+
+impl SandboxOptions {
+    pub fn normalized_profile(&self) -> String {
+        normalize_profile(&self.profile)
+    }
+
+    pub fn is_off(&self) -> bool {
+        self.normalized_profile() == "off"
+    }
+}
+
+pub(crate) fn normalize_profile(profile: &str) -> String {
+    match profile.trim().to_lowercase().as_str() {
+        "readonly" | "read_only" => "read-only".to_string(),
+        other => other.to_string(),
+    }
+}
+
+pub(crate) fn resolve_policy(workdir: &Path, opts: &SandboxOptions) -> Result<Policy> {
+    let profile = opts.normalized_profile();
+    anyhow::ensure!(profile != "off", "resolve_policy called for off profile");
+
+    let mut policy = load_named_policy(workdir, &profile)
+        .with_context(|| format!("resolve sandbox profile `{profile}`"))?;
+
+    inject_default_secret_denies(&mut policy);
+    apply_network_overrides(&mut policy, opts)?;
+    policy
+        .validate()
+        .map_err(|err| anyhow::anyhow!("invalid sandbox policy: {err}"))?;
+    Ok(policy)
+}
+
+fn load_named_policy(workdir: &Path, profile: &str) -> Result<Policy> {
+    let cfg = load_zene_sandbox_config(workdir);
+    if matches!(profile, "workspace" | "read-only" | "strict") {
+        if cfg.profiles.contains_key(profile) {
+            return cfg
+                .resolve_policy(profile, workdir)
+                .map_err(|err| anyhow::anyhow!("{err}"));
+        }
+        return builtin_policy(profile, workdir);
+    }
+
+    if cfg.profiles.contains_key(profile) {
+        return cfg
+            .resolve_policy(profile, workdir)
+            .map_err(|err| anyhow::anyhow!("{err}"));
+    }
+
+    // Fall back to Keel's ~/.keel/sandbox.toml + <ws>/.keel/sandbox.toml.
+    keel_core::load_policy_from_sandbox_toml(workdir, profile)
+        .map_err(|err| anyhow::anyhow!("{err}"))
+}
+
+fn load_zene_sandbox_config(workdir: &Path) -> SandboxConfig {
+    let home = std::env::var_os("ZENE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".zene")))
+        .unwrap_or_else(|| PathBuf::from(".zene"));
+    SandboxConfig::load_from(
+        home.join("sandbox.toml"),
+        workdir.join(".zene").join("sandbox.toml"),
+    )
+}
+
+fn builtin_policy(profile: &str, workdir: &Path) -> Result<Policy> {
+    match profile {
+        "workspace" => profile_workspace(workdir).map_err(|err| anyhow::anyhow!("{err}")),
+        "read-only" => profile_read_only(workdir).map_err(|err| anyhow::anyhow!("{err}")),
+        "strict" => profile_strict(workdir).map_err(|err| anyhow::anyhow!("{err}")),
+        other => anyhow::bail!("unknown built-in sandbox profile `{other}`"),
+    }
+}
+
+fn inject_default_secret_denies(policy: &mut Policy) {
+    // Linux Landlock read-deny for explicit deny paths requires bubblewrap. When it is
+    // missing, keep host-side `path_policy` protection and skip kernel deny injection so
+    // Space::create still succeeds.
+    if cfg!(target_os = "linux") && !bubblewrap_available() {
+        tracing::warn!(
+            "bubblewrap (bwrap) not found; credential denies are host path_policy only"
+        );
+        return;
+    }
+
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/tmp"));
+
+    let absolute = [
+        home.join(".ssh"),
+        home.join(".gnupg"),
+        home.join(".aws"),
+        home.join(".azure"),
+        home.join(".config").join("gcloud"),
+        home.join(".zene").join("auth"),
+    ];
+    for path in absolute {
+        if !policy
+            .fs
+            .iter()
+            .any(|rule| rule.access == FsAccess::Deny && !rule.glob && rule.path == path)
+        {
+            policy.fs.push(FsRule::deny(path));
+        }
+    }
+
+    for pattern in ["**/.env", "**/.env.*", "**/*.pem", "**/*.key"] {
+        let path = PathBuf::from(pattern);
+        if !policy
+            .fs
+            .iter()
+            .any(|rule| rule.access == FsAccess::Deny && rule.glob && rule.path == path)
+        {
+            policy.fs.push(FsRule::deny_glob(path));
+        }
+    }
+}
+
+fn bubblewrap_available() -> bool {
+    std::process::Command::new("bwrap")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn apply_network_overrides(policy: &mut Policy, opts: &SandboxOptions) -> Result<()> {
+    // Only user-configured allow_hosts trigger an allowlist. Trusted LLM hosts are
+    // merged in so child processes can still reach the model API when restricted.
+    if opts.allow_hosts.is_empty() {
+        return Ok(());
+    }
+
+    let mut hosts = opts.allow_hosts.clone();
+    for host in &opts.trusted_hosts {
+        if !hosts.iter().any(|h| h.eq_ignore_ascii_case(host)) {
+            hosts.push(host.clone());
+        }
+    }
+
+    let rules = parse_allow_hosts(&hosts)?;
+    // Restrictive profiles start as DenyAll; allow_hosts lifts them to an allowlist.
+    // Workspace (Unrestricted) becomes an allowlist when hosts are configured.
+    policy.network = NetworkPolicy::Allowlist(rules);
+    Ok(())
+}
+
+fn parse_allow_hosts(hosts: &[String]) -> Result<Vec<NetworkRule>> {
+    let mut rules = Vec::new();
+    for host in hosts {
+        let h = host.trim();
+        if h.is_empty() {
+            continue;
+        }
+        if let Some((name, port_s)) = h.rsplit_once(':') {
+            if let Ok(port) = port_s.parse::<u16>() {
+                rules.push(NetworkRule::host_port(name, port));
+                continue;
+            }
+        }
+        rules.push(NetworkRule::host(h));
+    }
+    anyhow::ensure!(!rules.is_empty(), "allow_hosts is empty after parsing");
+    Ok(rules)
+}
+
+/// Extract host + port from an HTTP(S) URL for egress checks.
+pub fn url_host_port(url: &str) -> Result<(String, u16)> {
+    let url = url.trim();
+    anyhow::ensure!(!url.is_empty(), "empty URL");
+
+    let without_scheme = if let Some(rest) = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .or_else(|| url.strip_prefix("HTTPS://"))
+        .or_else(|| url.strip_prefix("HTTP://"))
+    {
+        rest
+    } else if url.contains("://") {
+        anyhow::bail!("unsupported URL scheme (only http/https): {url}");
+    } else {
+        url
+    };
+
+    let authority = without_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default();
+    anyhow::ensure!(!authority.is_empty(), "URL missing host: {url}");
+
+    let default_port = if url.to_ascii_lowercase().starts_with("http://") {
+        80
+    } else {
+        443
+    };
+
+    if let Some(host) = authority.strip_prefix('[') {
+        // IPv6 literal [::1]:port
+        let (host, rest) = host
+            .split_once(']')
+            .ok_or_else(|| anyhow::anyhow!("invalid IPv6 URL host: {url}"))?;
+        let port = if let Some(port_s) = rest.strip_prefix(':') {
+            port_s
+                .parse::<u16>()
+                .with_context(|| format!("invalid port in URL: {url}"))?
+        } else {
+            default_port
+        };
+        return Ok((host.to_string(), port));
+    }
+
+    if let Some((host, port_s)) = authority.rsplit_once(':') {
+        if !host.is_empty() && port_s.chars().all(|c| c.is_ascii_digit()) {
+            let port: u16 = port_s
+                .parse()
+                .with_context(|| format!("invalid port in URL: {url}"))?;
+            return Ok((host.to_string(), port));
+        }
+    }
+
+    Ok((authority.to_string(), default_port))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_host_port_https_default() {
+        let (host, port) = url_host_port("https://api.openai.com/v1/models").unwrap();
+        assert_eq!(host, "api.openai.com");
+        assert_eq!(port, 443);
+    }
+
+    #[test]
+    fn url_host_port_custom() {
+        let (host, port) = url_host_port("http://localhost:8080/foo").unwrap();
+        assert_eq!(host, "localhost");
+        assert_eq!(port, 8080);
+    }
+
+    #[test]
+    fn network_override_builds_allowlist() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut policy = profile_workspace(dir.path()).unwrap();
+        let opts = SandboxOptions {
+            profile: "workspace".into(),
+            allow_hosts: vec!["example.com:443".into()],
+            trusted_hosts: vec!["api.openai.com".into()],
+        };
+        apply_network_overrides(&mut policy, &opts).unwrap();
+        match policy.network {
+            NetworkPolicy::Allowlist(rules) => assert_eq!(rules.len(), 2),
+            other => panic!("expected allowlist, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn trusted_hosts_alone_do_not_open_network() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut policy = profile_read_only(dir.path()).unwrap();
+        let opts = SandboxOptions {
+            profile: "read-only".into(),
+            allow_hosts: vec![],
+            trusted_hosts: vec!["api.openai.com".into()],
+        };
+        apply_network_overrides(&mut policy, &opts).unwrap();
+        assert!(matches!(policy.network, NetworkPolicy::DenyAll));
+    }
+}

--- a/crates/sandbox/src/path_policy.rs
+++ b/crates/sandbox/src/path_policy.rs
@@ -15,6 +15,53 @@ pub fn check_write_allowed(path: &str) -> Result<(), String> {
         return Err(format!("writes are denied under .git/: {path}"));
     }
 
+    if is_sensitive_credential_name(trimmed) {
+        return Err(format!("writes are denied for credential-like path: {path}"));
+    }
+
+    Ok(())
+}
+
+/// Deny Read/Grep of credential and secret paths (host-side soft gate).
+pub fn check_read_allowed(path: &str) -> Result<(), String> {
+    let normalized = path.replace('\\', "/");
+    let trimmed = normalized.trim_start_matches("./");
+
+    if is_sensitive_env_file(trimmed) {
+        return Err(format!("reads are denied for sensitive env file: {path}"));
+    }
+    if is_sensitive_credential_name(trimmed) {
+        return Err(format!("reads are denied for credential-like path: {path}"));
+    }
+    if is_under_secret_home_dir(trimmed) {
+        return Err(format!("reads are denied under protected credential directory: {path}"));
+    }
+    Ok(())
+}
+
+/// Re-check a resolved absolute path against home credential directories.
+pub fn check_read_allowed_resolved(resolved: &Path) -> Result<(), String> {
+    let normalized = resolved.to_string_lossy().replace('\\', "/");
+    if let Some(home) = std::env::var_os("HOME") {
+        let home = PathBuf::from(home);
+        for segment in [".ssh", ".gnupg", ".aws", ".azure"] {
+            let protected = home.join(segment);
+            if path_starts_with(resolved, &protected) {
+                return Err(format!(
+                    "reads are denied under protected credential directory: {normalized}"
+                ));
+            }
+        }
+        let gcloud = home.join(".config").join("gcloud");
+        if path_starts_with(resolved, &gcloud) {
+            return Err(format!(
+                "reads are denied under protected credential directory: {normalized}"
+            ));
+        }
+    }
+    if is_sensitive_env_file(&normalized) || is_sensitive_credential_name(&normalized) {
+        return Err(format!("reads are denied for credential-like path: {normalized}"));
+    }
     Ok(())
 }
 
@@ -24,6 +71,30 @@ fn is_sensitive_env_file(path: &str) -> bool {
         return true;
     }
     name.starts_with(".env.")
+}
+
+fn is_sensitive_credential_name(path: &str) -> bool {
+    let name = path.rsplit('/').next().unwrap_or(path).to_ascii_lowercase();
+    name.ends_with(".pem")
+        || name.ends_with(".key")
+        || name == "id_rsa"
+        || name == "id_ed25519"
+        || name == "credentials"
+        || name == "credentials.json"
+}
+
+fn is_under_secret_home_dir(path: &str) -> bool {
+    let lower = path.to_ascii_lowercase();
+    lower.contains("/.ssh/")
+        || lower.ends_with("/.ssh")
+        || lower.contains("/.gnupg/")
+        || lower.ends_with("/.gnupg")
+        || lower.contains("/.aws/")
+        || lower.ends_with("/.aws")
+        || lower.contains("/.azure/")
+        || lower.ends_with("/.azure")
+        || lower.contains("/.config/gcloud/")
+        || lower.ends_with("/.config/gcloud")
 }
 
 /// Blocks paths inside a `.git/` directory segment (not `.gitignore` at repo root).
@@ -265,6 +336,14 @@ mod tests {
         assert!(check_write_allowed(".env").is_err());
         assert!(check_write_allowed(".env.local").is_err());
         assert!(check_write_allowed("secrets/.env.production").is_err());
+    }
+
+    #[test]
+    fn denies_credential_reads() {
+        assert!(check_read_allowed(".env").is_err());
+        assert!(check_read_allowed("certs/server.pem").is_err());
+        assert!(check_read_allowed("/home/user/.ssh/id_rsa").is_err());
+        assert!(check_read_allowed("src/main.rs").is_ok());
     }
 
     #[test]

--- a/crates/tools/src/fetch_url.rs
+++ b/crates/tools/src/fetch_url.rs
@@ -58,6 +58,13 @@ impl Tool for FetchUrlTool {
             }
         }
 
+        if let Err(err) = ctx.sandbox.authorize_egress(&args.url).await {
+            return Ok(ToolResult {
+                content: format!("FetchUrl blocked by sandbox: {err}"),
+                is_error: true,
+            });
+        }
+
         match fetch_url_text(&args.url).await {
             Ok(text) => {
                 if text.trim().is_empty() {

--- a/crates/tools/src/web_search.rs
+++ b/crates/tools/src/web_search.rs
@@ -105,6 +105,17 @@ impl Tool for WebSearchTool {
             .unwrap_or(DEFAULT_NUM_RESULTS)
             .clamp(1, MAX_NUM_RESULTS);
 
+        let egress_url = match self.config.effective_provider() {
+            WebSearchProviderKind::Tavily => "https://api.tavily.com/search",
+            WebSearchProviderKind::DuckDuckGo => "https://html.duckduckgo.com/html/",
+        };
+        if let Err(err) = ctx.sandbox.authorize_egress(egress_url).await {
+            return Ok(ToolResult {
+                content: format!("WebSearch blocked by sandbox: {err}"),
+                is_error: true,
+            });
+        }
+
         match run_search(&self.config, &args.query, num_results).await {
             Ok(results) => Ok(ToolResult {
                 content: format_results(&results),

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -106,6 +106,20 @@ Non-MCP tool results over `ZENE_MAX_TOOL_OUTPUT_BYTES` (default 30_000) are trun
 
 When auto-compact is about to fire, zene first runs a Steps-first pass (`compaction.intra_steps_first`, default true): tool results after the last user message are truncated to ~200 chars. If that alone brings usage under the threshold, full summarize is skipped (grok Intra `StepsOnly` / HistoryThenSteps lite).
 
+## Sandbox profiles (Keel)
+
+Production entry points build `LocalSandbox::with_options` from config / CLI:
+
+| Profile | Filesystem | Child network | Notes |
+|---------|------------|---------------|-------|
+| `off` | path_policy only | unrestricted | No Keel space |
+| `workspace` (default) | broad read; write workspace + temps | unrestricted | Everyday coding |
+| `read-only` | broad read; write keel home + temps | deny-all | Explore default when unset |
+| `strict` | workspace + system paths only | deny-all | Untrusted repos |
+| custom | from `~/.zene/sandbox.toml` | per profile | Keel `SandboxConfig` loader |
+
+Overrides: CLI `--sandbox` > `ZENE_SANDBOX` > `[sandbox] profile` in config. `allow_hosts` (config / `ZENE_SANDBOX_ALLOW_HOSTS`) turns network into an allowlist and is enforced for Bash children (Keel egress proxy) plus host tools (`FetchUrl`, `WebSearch`, HTTP MCP) via `LocalSandbox::authorize_egress`. Default credential denies (`~/.ssh`, `~/.gnupg`, `~/.aws`, `**/.env*`, `**/*.pem`, …) are injected into every non-`off` policy; host Read also uses `check_read_allowed`. File I/O prefers Keel `SpaceFs` when a space is active. `[sandbox] auto_allow_bash = true` skips Bash permission prompts while enforcement is on.
+
 ## Permission modes (grok-aligned)
 
 | Mode | Behavior |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -415,5 +415,6 @@ TUI、record/replay、安装分发。
 | P4 运行时 | [x] | 后台 Bash/Task + TaskOutput、`--worktree`、subagent 报告包装 |
 | P5 MCP/扩展 | [x] | stdio + HTTP MCP、`zene mcp doctor` |
 | P6 集成/产品化 | [x] | `zene -p` headless + `--output-format json`；`zene acp` 最小 ACP stdio |
+| P7 沙箱产品化 | [x] | 可配置 Keel profile、egress allowlist、凭据 deny、SpaceFs、auto_allow_bash |
 
-*最后更新：2026-07-18（P1 续4：script-aware tokens + steps-first）*
+*最后更新：2026-07-19（P7：sandbox profile + egress + secrets）*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

将 Keel 沙箱从硬编码 `profile_workspace` 提升为可配置能力，并补齐 host 侧 egress / 凭据保护缺口（对齐 grok `--sandbox` 产品面）。

## Changes

- **Profile 可配置**：`--sandbox` / `ZENE_SANDBOX` / `[sandbox] profile`，支持 `off | workspace | read-only | strict | custom`；自定义 profile 读 `~/.zene/sandbox.toml` / `.zene/sandbox.toml`（Keel `SandboxConfig`）。explore agent 在未显式设置时默认 `read-only`。
- **网络隔离接线**：`allow_hosts` / `ZENE_SANDBOX_ALLOW_HOSTS` 转为 Keel allowlist；`FetchUrl` / `WebSearch` / HTTP MCP 走 `LocalSandbox::authorize_egress`（审计 + 策略）。
- **覆盖范围加固**：host Read/Write 优先 Keel `SpaceFs`；应用层 `check_read_allowed` 拒凭据路径；有 bubblewrap 时向 policy 注入默认 credential deny（无 bwrap 则仅 host 侧保护）。
- **权限联动**：`[sandbox] auto_allow_bash` 在沙箱激活时跳过 Bash 确认；TUI 替换 prompter 时保留该策略。

## Notes

- `--worktree` 仍使用 zene 自有 session worktree（未强行换成 Keel `worktree_sandboxed`，避免双重嵌套）。
- Linux 上内核级 read-deny 依赖 `bwrap`；环境无 bubblewrap 时 Space 仍可创建，凭据 deny 退化为 path_policy。

## Test plan

- [x] `cargo test -p zene-sandbox -p zene-config --lib`
- [x] `cargo test -p zene-tools -p zene-core -p zene-mcp --lib`
- [x] `cargo test -p zene-tools --tests`
- [x] `cargo check -p zene-cli`
- [ ] 手动：`zene --sandbox read-only` 后 FetchUrl 应被拒绝；`allow_hosts` 放行指定 host

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa9883a5-d4b6-4048-ba5a-bfbba8d58930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa9883a5-d4b6-4048-ba5a-bfbba8d58930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

