### PR TITLE
docs(www): 更新落地页介绍以匹配当前功能

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<!-- Deploy trigger: 2026-05-31T02:40:00Z -->
+<!-- Deploy trigger: 2026-07-19T12:20:00Z -->
 <html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Zene · Local Coding Agent CLI</title>
-  <meta name="description" content="A local coding agent CLI written in Rust. Read, write, edit files, execute shell commands, and manage sessions securely on your machine.">
+  <meta name="description" content="A local coding agent CLI written in Rust. Edit files, run shell commands, sandbox execution with Keel, and keep sessions on your machine.">
   <meta property="og:title" content="Zene">
-  <meta property="og:description" content="Local coding agent CLI. Write, edit, run bash, and manage sessions privately.">
+  <meta property="og:description" content="Local coding agent CLI. Write, edit, run bash, sandbox with Keel, and manage sessions privately.">
   <meta property="og:url" content="https://zene.sh">
   <meta property="og:type" content="website">
   <link rel="icon" href="logo.svg">
@@ -64,14 +64,14 @@
 
           <!-- Run command -->
           <text x="20" y="70" font-family="JetBrains Mono,monospace" font-size="13" fill="#a855f7">❯</text>
-          <text x="38" y="70" font-family="JetBrains Mono,monospace" font-size="13" fill="#e4e4e7">zene --tui</text>
+          <text x="38" y="70" font-family="JetBrains Mono,monospace" font-size="13" fill="#e4e4e7">zene</text>
 
           <!-- Output: session started -->
           <text x="20" y="100" font-family="JetBrains Mono,monospace" font-size="12" fill="#71717a">[zene] session started</text>
           <text x="20" y="120" font-family="JetBrains Mono,monospace" font-size="12" fill="#71717a">  id:      </text>
           <text x="112" y="120" font-family="JetBrains Mono,monospace" font-size="12" fill="#fde047">b8f1d3c0-9a4f-4b0e</text>
-          <text x="20" y="140" font-family="JetBrains Mono,monospace" font-size="12" fill="#71717a">  profile: </text>
-          <text x="112" y="140" font-family="JetBrains Mono,monospace" font-size="12" fill="#4ade80">full (read & write)</text>
+          <text x="20" y="140" font-family="JetBrains Mono,monospace" font-size="12" fill="#71717a">  sandbox: </text>
+          <text x="112" y="140" font-family="JetBrains Mono,monospace" font-size="12" fill="#4ade80">workspace</text>
           <text x="20" y="160" font-family="JetBrains Mono,monospace" font-size="12" fill="#71717a">  mcp:     </text>
           <text x="112" y="160" font-family="JetBrains Mono,monospace" font-size="12" fill="#e4e4e7">connected (mcp__filesystem)</text>
 
@@ -104,47 +104,57 @@
       <h2>What is Zene?</h2>
       <p>
         Zene is a local-first <strong>AI coding agent CLI</strong> written in Rust.
-        It runs entirely in your project directory, parses workspace contexts, edits files with high precision,
-        runs test suites, and orchestrates tasks locally on your machine.
+        It runs in your project directory, reads and edits files with high precision,
+        executes shell commands, searches the web, and keeps conversation sessions on disk.
       </p>
       <p>
-        Zene prioritizes safety, speed, and reliability. It is fully configurable and supports stdio-based MCP servers and lifecycle hooks.
+        The default UI is a Ratatui TUI. Zene supports Keel sandbox profiles, permission modes,
+        stdio/HTTP MCP servers, lifecycle hooks, skills, and a minimal ACP bridge for editors.
       </p>
 
-      <h2>Local Sandbox Safety</h2>
+      <h2>Keel Sandbox</h2>
       <p>
-        Zene protects your machine's environment. File read/write and command execution are constrained by a path isolation policy. Sensitive folders like <code>.git/</code> and <code>node_modules/</code> are protected by hard denylist policies.
+        File and shell access are constrained by configurable Keel sandbox profiles:
+        <code>off</code>, <code>workspace</code>, <code>read-only</code>, <code>strict</code>, or a custom profile
+        from <code>~/.zene/sandbox.toml</code>. Credential paths such as <code>~/.ssh</code> and <code>**/.env*</code>
+        are denied by default. Network tools (<code>FetchUrl</code>, <code>WebSearch</code>, HTTP MCP) can be gated
+        with an <code>allow_hosts</code> egress allowlist.
       </p>
       <div class="code-block config-block">
-<pre><code># Start with manual approval (asks y/n on Write/Edit/Bash)
+<pre><code># Default TUI (asks before Write / Edit / Bash)
 zene
 
-# Start in YOLO mode (auto-approves changes)
-zene --yolo</code></pre>
+# Auto-approve Write / Edit / Bash
+zene --yolo
+
+# Stricter sandbox profile
+zene --sandbox strict</code></pre>
       </div>
 
-      <h2>Context Compaction (v2)</h2>
+      <h2>Context Compaction</h2>
       <p>
-        Say goodbye to context window exhaustion. Zene automatically calculates model Token load before every step and utilizes an efficient three-stage compaction pipeline:
-      </p>
-      <p>
-        1. <strong>Truncate</strong>: Local truncation of oversized tool outputs.<br>
-        2. <strong>Slice Keep</strong>: Drops middle-tier history while preserving system instructions and history summaries.<br>
-        3. <strong>LLM Summarize</strong>: Collapses old dialog turns into a concise structural summary.
+        Long sessions stay within the model window. Zene tracks usage-driven context water level
+        and applies full-replace compaction with an input ladder:
+        <strong>verbatim → fitted → lossy</strong>.
+        Oversized tool outputs are truncated first; older turns are summarized when needed.
+        Recover with <code>/compact</code>, <code>/rewind</code>, and <code>/fork</code>.
       </p>
 
       <h2>Steerable Control (Human-in-the-loop)</h2>
       <p>
-        Keep the agent on track without waiting for a turn to complete. The steer buffer allows you to queue follow-up instructions mid-step. Use <code>/steer &lt;msg&gt;</code> in REPL to inject guidance between tools or assistant steps.
+        Keep the agent on track without waiting for a turn to finish. Queue follow-up instructions
+        mid-step with <code>/steer &lt;msg&gt;</code>, or cancel the in-flight turn with Esc / <code>/cancel</code>.
       </p>
       <div class="code-block config-block">
-<pre><code># Inside a session, when Zene is running:
+<pre><code># Inside a session, while Zene is running:
 /steer check if compiling before running tests</code></pre>
       </div>
 
       <h2>Planning Mode</h2>
       <p>
-        For complex restructurings, toggle planning mode. In <code>/plan</code> mode, Zene's actuators are locked to read-only tools. It explores the workspace and generates a proposed plan file. Moving back to coding mode requires explicit user confirmation.
+        For complex work, switch to <code>/plan</code>. Actuators lock to read-only tools while Zene
+        explores the workspace and writes a proposed plan under <code>.zene/plan.md</code>.
+        Returning to coding mode requires explicit confirmation.
       </p>
       <div class="code-block config-block">
 <pre><code># Enter plan mode inside the CLI
@@ -153,19 +163,24 @@ zene --yolo</code></pre>
 
       <h2>Extensible with MCP & Skills</h2>
       <p>
-        Zene integrates with Model Context Protocol (MCP) servers and local Skill folders. Define custom stdio MCP servers to register new tools dynamically. Add skill instruction files under <code>.agents/skills/</code> to teach Zene target guidelines.
+        Register MCP servers over stdio or HTTP in <code>~/.zene/mcp.json</code> (or project
+        <code>.zene/mcp.json</code>). Probe connectivity with <code>zene mcp doctor</code>.
+        Add skill instruction files under <code>.agents/skills/*/SKILL.md</code> and load them with the Skill tool.
       </p>
       <div class="code-block config-block">
-<pre><code># ~/.zene/config.toml
-# Register MCP servers globally
-[[mcp_servers]]
-name = "my_database"
-command = "npx"
-args = [
-  "-y",
-  "@modelcontextprotocol/server-postgres",
-  "postgresql://localhost"
-]</code></pre>
+<pre><code># ~/.zene/mcp.json
+{
+  "servers": {
+    "my_database": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-postgres",
+        "postgresql://localhost"
+      ]
+    }
+  }
+}</code></pre>
       </div>
 
       <h2>Commands</h2>
@@ -174,27 +189,44 @@ args = [
           <tr><th>Command</th><th>Description</th></tr>
         </thead>
         <tbody>
-          <tr><td>zene</td><td>Launch Zene interactive REPL in the current directory</td></tr>
-          <tr><td>--tui</td><td>Launch the beautiful Ratatui-based terminal UI</td></tr>
-          <tr><td>--yolo</td><td>Launch in auto-approve mode, skipping permission gates</td></tr>
-          <tr><td>sessions</td><td>List saved conversation sessions in the current directory</td></tr>
+          <tr><td>zene</td><td>Launch the Ratatui TUI in the current directory (default)</td></tr>
+          <tr><td>--repl</td><td>Use the line-oriented REPL instead of the TUI</td></tr>
+          <tr><td>--yolo</td><td>Auto-approve Write / Edit / Bash</td></tr>
+          <tr><td>--sandbox &lt;profile&gt;</td><td>Keel profile: off, workspace, read-only, strict, or custom</td></tr>
+          <tr><td>-p / --prompt</td><td>Run a single headless prompt; optional --output-format json</td></tr>
+          <tr><td>--worktree</td><td>Run the session in a dedicated git worktree under .zene/worktrees/</td></tr>
+          <tr><td>sessions</td><td>List saved conversation sessions for the current directory</td></tr>
           <tr><td>--session &lt;id&gt;</td><td>Resume a previous conversation session by ID</td></tr>
+          <tr><td>mcp doctor</td><td>Probe configured MCP servers</td></tr>
+          <tr><td>acp</td><td>Speak Agent Client Protocol over stdio JSON-RPC</td></tr>
         </tbody>
       </table>
 
       <h2>Configure</h2>
       <p>
-        Configure Zene globally in <code>~/.zene/config.toml</code> or override settings locally per-project in <code>.zene/config.toml</code>. Set provider keys directly or via environment variables.
+        Configure Zene globally in <code>~/.zene/config.toml</code> or override per project in
+        <code>.zene/config.toml</code>. Set provider keys in the file or via environment variables.
+        Custom Keel profiles live in <code>~/.zene/sandbox.toml</code>.
       </p>
       <div class="code-block config-block">
 <pre><code># ~/.zene/config.toml
 provider = "openai"     # "openai" or "anthropic"
 model = "gpt-4o"
 include_workspace_context = true
+permission_mode = "default"   # default | accept_edits | dont_ask | bypass
+
+[sandbox]
+profile = "workspace"         # off | workspace | read-only | strict | custom
+# allow_hosts = ["api.github.com:443"]
+# auto_allow_bash = false
 
 [compaction]
 trigger_ratio = 0.85
-min_keep_messages = 20</code></pre>
+min_keep_messages = 20
+
+[web_search]
+provider = "tavily"           # or "duckduckgo"
+# api_key = "tvly-..."</code></pre>
       </div>
 
     </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

刷新 `www/index.html` 落地页文案，使其与当前 README / CHANGELOG 能力对齐。

主要更新：
- 终端示例改为默认启动 `zene`（TUI），sandbox 显示为 Keel `workspace` profile
- Sandbox 章节改为 Keel profiles、凭据路径拒绝、`allow_hosts` egress
- Compaction 改为 usage-driven water level + verbatim/fitted/lossy，并提到 `/compact` `/rewind` `/fork`
- MCP 配置示例改为 `~/.zene/mcp.json`（stdio/HTTP），并提到 `zene mcp doctor`
- Commands 表补充 `--repl`、`--sandbox`、`-p`、`--worktree`、`mcp doctor`、`acp`
- Configure 示例补充 `permission_mode`、`[sandbox]`、`[web_search]`

## Test plan

- [ ] 打开 `www/index.html` 确认文案与示例无误
- [ ] 对照 README / CHANGELOG 抽查命令与配置项是否仍准确

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dfa2d12d-e1bf-43fc-b836-990966b6a71e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dfa2d12d-e1bf-43fc-b836-990966b6a71e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

