### PR TITLE
feat(acp): resume、prompt 队列、thought chunk 与 terminal 桥接

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Changed
-- ACP: bridge `tool_call` / `tool_call_update` / `plan` / `usage_update` / `current_mode_update` / `available_commands_update`; replay history on `session/load`; implement `session/list`, `session/close`, `session/set_mode`; optional client FS bridge (`fs/read_text_file` / `fs/write_text_file`); correlate permission `toolCallId`; accept embedded prompt context; tighten JSON-RPC error codes.
+- ACP: bridge `tool_call` / `tool_call_update` / `plan` / `usage_update` / `current_mode_update` / `available_commands_update` / `agent_thought_chunk`; replay history on `session/load`; implement `session/list`, `session/close`, `session/set_mode`, `session/resume`; optional client FS + terminal bridges; FIFO prompt queue with in-turn cancel; correlate permission `toolCallId`; accept embedded prompt context; tighten JSON-RPC error codes.
 
 ## v0.1.7 (2026-07-19)
 

--- a/apps/cli/src/acp/mod.rs
+++ b/apps/cli/src/acp/mod.rs
@@ -1,17 +1,18 @@
 //! ACP (Agent Client Protocol) stdio agent.
 //!
 //! Speaks JSON-RPC 2.0 NDJSON over stdin/stdout:
-//! `initialize`, `session/new`, `session/load`, `session/list`, `session/close`,
-//! `session/set_mode`, `session/prompt`, `session/cancel`,
+//! `initialize`, `session/new`, `session/load`, `session/resume`, `session/list`,
+//! `session/close`, `session/set_mode`, `session/prompt`, `session/cancel`,
 //! plus outbound `session/update` notifications
-//! (`agent_message_chunk`, `user_message_chunk`, `tool_call`, `tool_call_update`,
-//! `plan`, `current_mode_update`, `available_commands_update`, `usage_update`)
-//! and client requests `session/request_permission`, `fs/read_text_file`,
-//! `fs/write_text_file` (when the client advertises FS capabilities).
+//! (`agent_message_chunk`, `agent_thought_chunk`, `user_message_chunk`, `tool_call`,
+//! `tool_call_update`, `plan`, `current_mode_update`, `available_commands_update`,
+//! `usage_update`) and client requests `session/request_permission`,
+//! `fs/read_text_file`, `fs/write_text_file`, `terminal/*` (when advertised).
 
 mod fs_bridge;
 mod protocol;
 mod server;
+mod terminal_bridge;
 mod transport;
 mod updates;
 

--- a/apps/cli/src/acp/server.rs
+++ b/apps/cli/src/acp/server.rs
@@ -1,11 +1,11 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, bail, Context, Result};
 use serde_json::{json, Value};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot, Mutex as AsyncMutex};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 use zene_config::ZeneConfig;
@@ -20,10 +20,11 @@ use super::protocol::{
     err_response, error_codes, is_notification, is_request, is_response, ok_response,
     prompt_text_from_params, RpcId,
 };
+use super::terminal_bridge::AcpRemoteTerminal;
 use super::transport::{AcpWriter, SharedState};
 use super::updates::{
-    agent_message_chunk, available_commands_update, current_mode_update, modes_state,
-    plan_from_todo_arguments, replay_updates_from_messages, tool_call_result_update,
+    agent_message_chunk, agent_thought_chunk, available_commands_update, current_mode_update,
+    modes_state, plan_from_todo_arguments, replay_updates_from_messages, tool_call_result_update,
     tool_call_update, tool_kind, tool_title, usage_update,
 };
 
@@ -37,14 +38,28 @@ struct PendingToolCall {
 struct ClientCapabilities {
     fs_read: bool,
     fs_write: bool,
+    terminal: bool,
+}
+
+struct QueuedPrompt {
+    rpc_id: RpcId,
+    params: Value,
+}
+
+struct ActivePrompt {
+    session_id: String,
+    rpc_id: RpcId,
+    cancel: CancellationToken,
+    result_rx: oneshot::Receiver<Result<Value>>,
 }
 
 struct AcpSession {
-    agent: Agent,
+    agent: Arc<AsyncMutex<Agent>>,
     cancel: Option<CancellationToken>,
     permission_mode: PermissionMode,
     /// Last tool call id observed via AgentEvent (used by permission prompts).
     pending_tool: Arc<Mutex<PendingToolCall>>,
+    prompt_queue: VecDeque<QueuedPrompt>,
 }
 
 pub struct AcpServer {
@@ -128,42 +143,82 @@ impl AcpServer {
             writer,
             client_caps: ClientCapabilities::default(),
         };
+        let mut active: Option<ActivePrompt> = None;
+        let mut stdin_open = true;
 
-        while let Some(msg) = in_rx.recv().await {
-            if is_notification(&msg) {
-                let method = msg["method"].as_str().unwrap_or("");
-                if method == "session/cancel" {
-                    if let Some(sid) = msg["params"]["sessionId"].as_str() {
-                        if let Some(s) = server.sessions.get(sid) {
-                            if let Some(token) = &s.cancel {
-                                token.cancel();
+        while stdin_open || active.is_some() {
+            if let Some(mut current) = active.take() {
+                tokio::select! {
+                    msg = in_rx.recv(), if stdin_open => {
+                        match msg {
+                            Some(msg) => {
+                                if let Err(e) = server
+                                    .handle_incoming(msg, Some(&mut current), &mut active)
+                                    .await
+                                {
+                                    warn!("ACP incoming while prompting: {e:#}");
+                                }
+                                if active.is_none() {
+                                    active = Some(current);
+                                }
+                            }
+                            None => {
+                                stdin_open = false;
+                                current.cancel.cancel();
+                                active = Some(current);
                             }
                         }
                     }
+                    result = &mut current.result_rx => {
+                        let reply = match result {
+                            Ok(Ok(value)) => ok_response(current.rpc_id.clone(), value),
+                            Ok(Err(err)) => {
+                                warn!("ACP session/prompt: {err:#}");
+                                err_response(
+                                    current.rpc_id.clone(),
+                                    dispatch_error_code("session/prompt", &err),
+                                    &format!("{err:#}"),
+                                )
+                            }
+                            Err(_) => err_response(
+                                current.rpc_id.clone(),
+                                error_codes::APPLICATION_ERROR,
+                                "prompt worker dropped",
+                            ),
+                        };
+                        if let Err(e) = server.writer.send_raw(reply.to_string()) {
+                            warn!("ACP write failed: {e}");
+                            break;
+                        }
+                        if let Some(sess) = server.sessions.get_mut(&current.session_id) {
+                            sess.cancel = None;
+                            sess.pending_tool.lock().unwrap().id = None;
+                        }
+                        if let Err(e) = server.maybe_start_queued_prompt(&current.session_id, &mut active).await {
+                            warn!("ACP queued prompt: {e:#}");
+                        }
+                    }
                 }
-                continue;
-            }
-            if !is_request(&msg) {
-                continue;
-            }
-            let id = RpcId::from_value(&msg["id"]);
-            let method = msg["method"].as_str().unwrap_or("").to_string();
-            let params = msg.get("params").cloned().unwrap_or(Value::Null);
-            let reply = match server.dispatch(&method, params).await {
-                Ok(result) => ok_response(id, result),
-                Err(e) => {
-                    warn!("ACP {method}: {e:#}");
-                    err_response(id, dispatch_error_code(&method, &e), &format!("{e:#}"))
+            } else {
+                match in_rx.recv().await {
+                    Some(msg) => {
+                        if let Err(e) = server.handle_incoming(msg, None, &mut active).await {
+                            warn!("ACP incoming: {e:#}");
+                        }
+                    }
+                    None => {
+                        stdin_open = false;
+                    }
                 }
-            };
-            if let Err(e) = server.writer.send_raw(reply.to_string()) {
-                warn!("ACP write failed: {e}");
-                break;
             }
         }
 
-        for (_, mut sess) in server.sessions.drain() {
-            let _ = sess.agent.shutdown().await;
+        for (_, sess) in server.sessions.drain() {
+            if let Some(token) = &sess.cancel {
+                token.cancel();
+            }
+            let mut agent = sess.agent.lock().await;
+            let _ = agent.shutdown().await;
         }
         drop(server.writer);
         let _ = stdin_task.await;
@@ -171,16 +226,68 @@ impl AcpServer {
         Ok(())
     }
 
+    async fn handle_incoming(
+        &mut self,
+        msg: Value,
+        current: Option<&mut ActivePrompt>,
+        active: &mut Option<ActivePrompt>,
+    ) -> Result<()> {
+        if is_notification(&msg) {
+            let method = msg["method"].as_str().unwrap_or("");
+            if method == "session/cancel" {
+                if let Some(sid) = msg["params"]["sessionId"].as_str() {
+                    if let Some(s) = self.sessions.get(sid) {
+                        if let Some(token) = &s.cancel {
+                            token.cancel();
+                        }
+                    }
+                    if let Some(cur) = current {
+                        if cur.session_id == sid {
+                            cur.cancel.cancel();
+                        }
+                    }
+                }
+            }
+            return Ok(());
+        }
+        if !is_request(&msg) {
+            return Ok(());
+        }
+        let id = RpcId::from_value(&msg["id"]);
+        let method = msg["method"].as_str().unwrap_or("").to_string();
+        let params = msg.get("params").cloned().unwrap_or(Value::Null);
+
+        if method == "session/prompt" {
+            if let Err(e) = self.enqueue_or_start_prompt(id.clone(), params, active).await {
+                warn!("ACP {method}: {e:#}");
+                let reply = err_response(id, dispatch_error_code(&method, &e), &format!("{e:#}"));
+                self.writer.send_raw(reply.to_string())?;
+            }
+            Ok(())
+        } else {
+            let reply = match self.dispatch(&method, params).await {
+                Ok(result) => ok_response(id, result),
+                Err(e) => {
+                    warn!("ACP {method}: {e:#}");
+                    err_response(id, dispatch_error_code(&method, &e), &format!("{e:#}"))
+                }
+            };
+            self.writer.send_raw(reply.to_string())?;
+            Ok(())
+        }
+    }
+
     async fn dispatch(&mut self, method: &str, params: Value) -> Result<Value> {
         match method {
             "initialize" => self.handle_initialize(params),
             "session/new" => self.handle_session_new(params).await,
             "session/load" => self.handle_session_load(params).await,
-            "session/prompt" => self.handle_session_prompt(params).await,
+            "session/resume" => self.handle_session_resume(params).await,
             "session/list" => self.handle_session_list(params),
             "session/close" => self.handle_session_close(params).await,
             "session/set_mode" => self.handle_session_set_mode(params).await,
             "authenticate" => Ok(json!({})),
+            "session/prompt" => Err(anyhow!("session/prompt is handled by the async prompt queue")),
             other => Err(MethodNotFound(other.to_string()).into()),
         }
     }
@@ -204,12 +311,17 @@ impl AcpServer {
                 .and_then(|v| v.get("writeTextFile"))
                 .and_then(Value::as_bool)
                 .unwrap_or(false),
+            terminal: params
+                .pointer("/clientCapabilities/terminal")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
         };
-        if self.client_caps.fs_read || self.client_caps.fs_write {
+        if self.client_caps.fs_read || self.client_caps.fs_write || self.client_caps.terminal {
             debug!(
                 fs_read = self.client_caps.fs_read,
                 fs_write = self.client_caps.fs_write,
-                "ACP client advertised filesystem capabilities"
+                terminal = self.client_caps.terminal,
+                "ACP client advertised capabilities"
             );
         }
 
@@ -227,7 +339,8 @@ impl AcpServer {
                     "sse": false
                 },
                 "sessionCapabilities": {
-                    "list": {}
+                    "list": {},
+                    "resume": {}
                 }
             },
             "agentInfo": {
@@ -244,7 +357,10 @@ impl AcpServer {
         let session = SessionRecord::new(&cwd);
         let id = session.meta.id.clone();
         let acp_session = self.build_session(session, &cwd, &id).await?;
-        let mode = acp_session.agent.current_session_mode();
+        let mode = {
+            let agent = acp_session.agent.lock().await;
+            agent.current_session_mode()
+        };
         self.sessions.insert(id.clone(), acp_session);
         self.advertise_session(&id)?;
         Ok(json!({
@@ -263,7 +379,10 @@ impl AcpServer {
         let session = SessionRecord::load(&sid).context("load session")?;
         let updates = replay_updates_from_messages(&session.messages);
         let acp_session = self.build_session(session, &cwd, &sid).await?;
-        let mode = acp_session.agent.current_session_mode();
+        let mode = {
+            let agent = acp_session.agent.lock().await;
+            agent.current_session_mode()
+        };
         self.sessions.insert(sid.clone(), acp_session);
 
         // ACP requires replaying history via session/update before responding.
@@ -276,6 +395,28 @@ impl AcpServer {
         }
         self.advertise_session(&sid)?;
 
+        Ok(json!({
+            "sessionId": sid,
+            "modes": modes_state(mode),
+        }))
+    }
+
+    async fn handle_session_resume(&mut self, params: Value) -> Result<Value> {
+        let sid = params
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("sessionId required"))?
+            .to_string();
+        let cwd = resolve_cwd(&params, &self.workdir)?;
+        let session = SessionRecord::load(&sid).context("resume session")?;
+        // Resume restores context without replaying history.
+        let acp_session = self.build_session(session, &cwd, &sid).await?;
+        let mode = {
+            let agent = acp_session.agent.lock().await;
+            agent.current_session_mode()
+        };
+        self.sessions.insert(sid.clone(), acp_session);
+        self.advertise_session(&sid)?;
         Ok(json!({
             "sessionId": sid,
             "modes": modes_state(mode),
@@ -316,8 +457,9 @@ impl AcpServer {
         if let Some(token) = sess.cancel.take() {
             token.cancel();
         }
-        let _ = sess.agent.session().save();
-        let _ = sess.agent.shutdown().await;
+        let mut agent = sess.agent.lock().await;
+        let _ = agent.session().save();
+        let _ = agent.shutdown().await;
         Ok(json!({}))
     }
 
@@ -336,7 +478,10 @@ impl AcpServer {
             .sessions
             .get_mut(&sid)
             .ok_or_else(|| anyhow!("unknown sessionId: {sid}"))?;
-        let active = sess.agent.set_session_mode(&mode_id)?;
+        let active = {
+            let mut agent = sess.agent.lock().await;
+            agent.set_session_mode(&mode_id)?
+        };
         self.writer
             .session_update(&sid, current_mode_update(&active))?;
         Ok(json!({}))
@@ -371,16 +516,28 @@ impl AcpServer {
                 self.client_caps.fs_write,
             )));
         }
+        if self.client_caps.terminal {
+            sandbox = sandbox.with_remote_terminal(Arc::new(AcpRemoteTerminal::new(
+                self.writer.clone(),
+                session_id,
+            )));
+        }
         let agent = Agent::new(config, sandbox, session, permission_mode).await?;
         Ok(AcpSession {
-            agent,
+            agent: Arc::new(AsyncMutex::new(agent)),
             cancel: None,
             permission_mode,
             pending_tool: Arc::new(Mutex::new(PendingToolCall::default())),
+            prompt_queue: VecDeque::new(),
         })
     }
 
-    async fn handle_session_prompt(&mut self, params: Value) -> Result<Value> {
+    async fn enqueue_or_start_prompt(
+        &mut self,
+        rpc_id: RpcId,
+        params: Value,
+        active: &mut Option<ActivePrompt>,
+    ) -> Result<()> {
         let sid = params
             .get("sessionId")
             .and_then(|v| v.as_str())
@@ -390,7 +547,56 @@ impl AcpServer {
         if text.trim().is_empty() {
             bail!("empty prompt");
         }
+        let sess = self
+            .sessions
+            .get_mut(&sid)
+            .ok_or_else(|| anyhow!("unknown sessionId: {sid}"))?;
 
+        if sess.cancel.is_some() {
+            debug!(session = %sid, "ACP queueing prompt behind active turn");
+            sess.prompt_queue.push_back(QueuedPrompt { rpc_id, params });
+            return Ok(());
+        }
+
+        self.start_prompt(sid, rpc_id, text, active).await
+    }
+
+    async fn maybe_start_queued_prompt(
+        &mut self,
+        session_id: &str,
+        active: &mut Option<ActivePrompt>,
+    ) -> Result<()> {
+        loop {
+            let next = self
+                .sessions
+                .get_mut(session_id)
+                .and_then(|sess| sess.prompt_queue.pop_front());
+            let Some(next) = next else {
+                return Ok(());
+            };
+            let text = prompt_text_from_params(&next.params);
+            if text.trim().is_empty() {
+                let reply = err_response(
+                    next.rpc_id,
+                    error_codes::INVALID_PARAMS,
+                    "empty prompt",
+                );
+                self.writer.send_raw(reply.to_string())?;
+                continue;
+            }
+            return self
+                .start_prompt(session_id.to_string(), next.rpc_id, text, active)
+                .await;
+        }
+    }
+
+    async fn start_prompt(
+        &mut self,
+        sid: String,
+        rpc_id: RpcId,
+        text: String,
+        active: &mut Option<ActivePrompt>,
+    ) -> Result<()> {
         let writer = self.writer.clone();
         let yolo = self.yolo;
         let sess = self
@@ -398,15 +604,51 @@ impl AcpServer {
             .get_mut(&sid)
             .ok_or_else(|| anyhow!("unknown sessionId: {sid}"))?;
 
-        if sess.cancel.is_some() {
-            bail!("session already has an active prompt; cancel it first");
-        }
-
         let cancel = CancellationToken::new();
         sess.cancel = Some(cancel.clone());
         let pending_tool = Arc::clone(&sess.pending_tool);
-
+        let agent = Arc::clone(&sess.agent);
         let permission_mode = sess.permission_mode;
+
+        let (tx, rx) = oneshot::channel();
+        *active = Some(ActivePrompt {
+            session_id: sid.clone(),
+            rpc_id,
+            cancel: cancel.clone(),
+            result_rx: rx,
+        });
+
+        tokio::spawn(async move {
+            let result = run_prompt_job(
+                agent,
+                writer,
+                sid,
+                text,
+                yolo,
+                permission_mode,
+                pending_tool,
+                cancel,
+            )
+            .await;
+            let _ = tx.send(result);
+        });
+        Ok(())
+    }
+
+}
+
+async fn run_prompt_job(
+    agent: Arc<AsyncMutex<Agent>>,
+    writer: AcpWriter,
+    sid: String,
+    text: String,
+    yolo: bool,
+    permission_mode: PermissionMode,
+    pending_tool: Arc<Mutex<PendingToolCall>>,
+    cancel: CancellationToken,
+) -> Result<Value> {
+    {
+        let mut agent = agent.lock().await;
         if !yolo {
             let writer_perm = writer.clone();
             let session_id = sid.clone();
@@ -431,111 +673,118 @@ impl AcpServer {
                     )
                 }),
             );
-            sess.agent.set_permission_gate(gate);
+            agent.set_permission_gate(gate);
         }
+    }
 
-        let prompt_id = uuid::Uuid::new_v4().to_string();
-        let event_counter = Arc::new(Mutex::new(0u64));
-        let on_event: EventHandler = {
-            let writer = writer.clone();
-            let session_id = sid.clone();
-            let pending_tool = Arc::clone(&pending_tool);
-            let prompt_id = prompt_id.clone();
-            let event_counter = Arc::clone(&event_counter);
-            Arc::new(move |event: AgentEvent| {
-                let event_id = {
-                    let mut n = event_counter.lock().unwrap();
-                    *n += 1;
-                    format!("{prompt_id}-{}", *n)
-                };
-                let meta = json!({
-                    "promptId": prompt_id,
-                    "eventId": event_id,
-                    "isReplay": false,
-                });
-                match event {
-                    AgentEvent::TextDelta { delta } => {
-                        let mut update = agent_message_chunk(&delta);
-                        attach_meta(&mut update, meta);
-                        let _ = writer.session_update(&session_id, update);
-                    }
-                    AgentEvent::ToolCall {
-                        id,
-                        name,
-                        arguments,
-                    } => {
-                        pending_tool.lock().unwrap().id = Some(id.clone());
-                        let mut update = tool_call_update(&id, &name, &arguments, "pending");
-                        attach_meta(&mut update, meta);
-                        let _ = writer.session_update(&session_id, update);
-                        if name == "TodoWrite" {
-                            if let Some(mut plan) = plan_from_todo_arguments(&arguments) {
-                                attach_meta(
-                                    &mut plan,
-                                    json!({
-                                        "promptId": prompt_id,
-                                        "isReplay": false,
-                                    }),
-                                );
-                                let _ = writer.session_update(&session_id, plan);
-                            }
-                        }
-                    }
-                    AgentEvent::ToolResult {
-                        id,
-                        name: _,
-                        content,
-                        is_error,
-                        duration_ms,
-                    } => {
-                        let mut update = tool_call_result_update(&id, &content, is_error);
-                        let mut meta = json!({
-                            "promptId": prompt_id,
-                            "eventId": event_id,
-                            "isReplay": false,
-                        });
-                        if let Some(ms) = duration_ms {
-                            meta.as_object_mut()
-                                .unwrap()
-                                .insert("durationMs".into(), json!(ms));
-                        }
-                        attach_meta(&mut update, meta);
-                        let _ = writer.session_update(&session_id, update);
-                        pending_tool.lock().unwrap().id = None;
-                    }
-                    AgentEvent::ModeChanged { mode_id } => {
-                        let mut update = current_mode_update(&mode_id);
-                        attach_meta(&mut update, meta);
-                        let _ = writer.session_update(&session_id, update);
-                    }
-                    AgentEvent::UsageUpdate {
-                        usage,
-                        context_tokens,
-                        context_window,
-                        context_percent,
-                    } => {
-                        let mut update = usage_update(
-                            u64::from(context_tokens),
-                            u64::from(context_window.max(1)),
-                            usage.prompt_tokens,
-                            usage.completion_tokens,
-                            context_percent,
-                        );
-                        attach_meta(&mut update, meta);
-                        let _ = writer.session_update(&session_id, update);
-                    }
-                    AgentEvent::Error { message } => {
-                        let mut update = agent_message_chunk(&format!("\n[error] {message}\n"));
-                        attach_meta(&mut update, meta);
-                        let _ = writer.session_update(&session_id, update);
-                    }
-                    _ => {}
+    let prompt_id = uuid::Uuid::new_v4().to_string();
+    let event_counter = Arc::new(Mutex::new(0u64));
+    let on_event: EventHandler = {
+        let writer = writer.clone();
+        let session_id = sid.clone();
+        let pending_tool = Arc::clone(&pending_tool);
+        let prompt_id = prompt_id.clone();
+        let event_counter = Arc::clone(&event_counter);
+        Arc::new(move |event: AgentEvent| {
+            let event_id = {
+                let mut n = event_counter.lock().unwrap();
+                *n += 1;
+                format!("{prompt_id}-{}", *n)
+            };
+            let meta = json!({
+                "promptId": prompt_id,
+                "eventId": event_id,
+                "isReplay": false,
+            });
+            match event {
+                AgentEvent::TextDelta { delta } => {
+                    let mut update = agent_message_chunk(&delta);
+                    attach_meta(&mut update, meta);
+                    let _ = writer.session_update(&session_id, update);
                 }
-            })
-        };
+                AgentEvent::ThoughtDelta { delta } => {
+                    let mut update = agent_thought_chunk(&delta);
+                    attach_meta(&mut update, meta);
+                    let _ = writer.session_update(&session_id, update);
+                }
+                AgentEvent::ToolCall {
+                    id,
+                    name,
+                    arguments,
+                } => {
+                    pending_tool.lock().unwrap().id = Some(id.clone());
+                    let mut update = tool_call_update(&id, &name, &arguments, "pending");
+                    attach_meta(&mut update, meta);
+                    let _ = writer.session_update(&session_id, update);
+                    if name == "TodoWrite" {
+                        if let Some(mut plan) = plan_from_todo_arguments(&arguments) {
+                            attach_meta(
+                                &mut plan,
+                                json!({
+                                    "promptId": prompt_id,
+                                    "isReplay": false,
+                                }),
+                            );
+                            let _ = writer.session_update(&session_id, plan);
+                        }
+                    }
+                }
+                AgentEvent::ToolResult {
+                    id,
+                    name: _,
+                    content,
+                    is_error,
+                    duration_ms,
+                } => {
+                    let mut update = tool_call_result_update(&id, &content, is_error);
+                    let mut meta = json!({
+                        "promptId": prompt_id,
+                        "eventId": event_id,
+                        "isReplay": false,
+                    });
+                    if let Some(ms) = duration_ms {
+                        meta.as_object_mut()
+                            .unwrap()
+                            .insert("durationMs".into(), json!(ms));
+                    }
+                    attach_meta(&mut update, meta);
+                    let _ = writer.session_update(&session_id, update);
+                    pending_tool.lock().unwrap().id = None;
+                }
+                AgentEvent::ModeChanged { mode_id } => {
+                    let mut update = current_mode_update(&mode_id);
+                    attach_meta(&mut update, meta);
+                    let _ = writer.session_update(&session_id, update);
+                }
+                AgentEvent::UsageUpdate {
+                    usage,
+                    context_tokens,
+                    context_window,
+                    context_percent,
+                } => {
+                    let mut update = usage_update(
+                        u64::from(context_tokens),
+                        u64::from(context_window.max(1)),
+                        usage.prompt_tokens,
+                        usage.completion_tokens,
+                        context_percent,
+                    );
+                    attach_meta(&mut update, meta);
+                    let _ = writer.session_update(&session_id, update);
+                }
+                AgentEvent::Error { message } => {
+                    let mut update = agent_message_chunk(&format!("\n[error] {message}\n"));
+                    attach_meta(&mut update, meta);
+                    let _ = writer.session_update(&session_id, update);
+                }
+                _ => {}
+            }
+        })
+    };
 
-        let result = sess
-            .agent
+    let result = {
+        let mut agent = agent.lock().await;
+        let result = agent
             .prompt(
                 &text,
                 PromptOptions {
@@ -546,26 +795,24 @@ impl AcpServer {
                 },
             )
             .await;
+        let _ = agent.session().save();
+        result
+    };
 
-        sess.cancel = None;
-        sess.pending_tool.lock().unwrap().id = None;
-        let _ = sess.agent.session().save();
-
-        match result {
-            Ok(_) => {
-                debug!(session = %sid, "ACP prompt completed");
-                if cancel.is_cancelled() {
-                    Ok(json!({ "stopReason": "cancelled" }))
-                } else {
-                    Ok(json!({ "stopReason": "end_turn" }))
-                }
+    match result {
+        Ok(_) => {
+            debug!(session = %sid, "ACP prompt completed");
+            if cancel.is_cancelled() {
+                Ok(json!({ "stopReason": "cancelled" }))
+            } else {
+                Ok(json!({ "stopReason": "end_turn" }))
             }
-            Err(err) => {
-                if cancel.is_cancelled() || err.to_string().contains("aborted") {
-                    Ok(json!({ "stopReason": "cancelled" }))
-                } else {
-                    Err(err)
-                }
+        }
+        Err(err) => {
+            if cancel.is_cancelled() || err.to_string().contains("aborted") {
+                Ok(json!({ "stopReason": "cancelled" }))
+            } else {
+                Err(err)
             }
         }
     }

--- a/apps/cli/src/acp/terminal_bridge.rs
+++ b/apps/cli/src/acp/terminal_bridge.rs
@@ -1,0 +1,200 @@
+//! ACP client terminal bridge (`terminal/create|output|wait_for_exit|kill|release`).
+
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+use zene_sandbox::{ExecResult, RemoteTerminal};
+
+use super::transport::AcpWriter;
+
+pub struct AcpRemoteTerminal {
+    writer: AcpWriter,
+    session_id: String,
+}
+
+impl AcpRemoteTerminal {
+    pub fn new(writer: AcpWriter, session_id: impl Into<String>) -> Self {
+        Self {
+            writer,
+            session_id: session_id.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl RemoteTerminal for AcpRemoteTerminal {
+    async fn exec(
+        &self,
+        command: &str,
+        cwd: &Path,
+        timeout: Duration,
+        cancel: Option<&CancellationToken>,
+        output_byte_limit: usize,
+    ) -> Result<ExecResult> {
+        let cwd = cwd
+            .to_str()
+            .ok_or_else(|| anyhow!("cwd is not valid UTF-8"))?;
+
+        #[cfg(unix)]
+        let (program, args) = {
+            let quoted = shell_quote(command);
+            ("bash".to_string(), vec!["-lc".to_string(), quoted])
+        };
+        #[cfg(not(unix))]
+        let (program, args) = (command.to_string(), Vec::<String>::new());
+
+        let created = self
+            .writer
+            .request(
+                "terminal/create",
+                json!({
+                    "sessionId": self.session_id,
+                    "command": program,
+                    "args": args,
+                    "cwd": cwd,
+                    "outputByteLimit": output_byte_limit as u64,
+                }),
+            )
+            .await
+            .context("ACP terminal/create")?;
+        let terminal_id = created
+            .get("terminalId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("terminal/create missing terminalId"))?
+            .to_string();
+
+        let wait = self.writer.request(
+            "terminal/wait_for_exit",
+            json!({
+                "sessionId": self.session_id,
+                "terminalId": terminal_id,
+            }),
+        );
+        let timed = tokio::time::timeout(timeout, wait);
+
+        let wait_result = if let Some(token) = cancel {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    let _ = self
+                        .writer
+                        .request(
+                            "terminal/kill",
+                            json!({
+                                "sessionId": self.session_id,
+                                "terminalId": terminal_id,
+                            }),
+                        )
+                        .await;
+                    Err(anyhow!("aborted"))
+                }
+                result = timed => match result {
+                    Ok(inner) => inner.context("ACP terminal/wait_for_exit"),
+                    Err(_) => {
+                        let _ = self
+                            .writer
+                            .request(
+                                "terminal/kill",
+                                json!({
+                                    "sessionId": self.session_id,
+                                    "terminalId": terminal_id,
+                                }),
+                            )
+                            .await;
+                        Err(anyhow!(
+                            "command timed out after {} seconds",
+                            timeout.as_secs().max(1)
+                        ))
+                    }
+                },
+            }
+        } else {
+            match timed.await {
+                Ok(inner) => inner.context("ACP terminal/wait_for_exit"),
+                Err(_) => {
+                    let _ = self
+                        .writer
+                        .request(
+                            "terminal/kill",
+                            json!({
+                                "sessionId": self.session_id,
+                                "terminalId": terminal_id,
+                            }),
+                        )
+                        .await;
+                    Err(anyhow!(
+                        "command timed out after {} seconds",
+                        timeout.as_secs().max(1)
+                    ))
+                }
+            }
+        };
+
+        let output = self
+            .writer
+            .request(
+                "terminal/output",
+                json!({
+                    "sessionId": self.session_id,
+                    "terminalId": terminal_id,
+                }),
+            )
+            .await
+            .context("ACP terminal/output");
+
+        let _ = self
+            .writer
+            .request(
+                "terminal/release",
+                json!({
+                    "sessionId": self.session_id,
+                    "terminalId": terminal_id,
+                }),
+            )
+            .await;
+
+        // Prefer surfacing abort/timeout after cleanup.
+        wait_result?;
+        let output = output?;
+
+        let exit_code = output
+            .pointer("/exitStatus/exitCode")
+            .or_else(|| output.get("exitCode"))
+            .and_then(|v| v.as_u64())
+            .or_else(|| {
+                output
+                    .pointer("/exitStatus/exit_code")
+                    .and_then(|v| v.as_u64())
+            })
+            .unwrap_or(0) as i32;
+        let combined = output
+            .get("output")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        Ok(ExecResult {
+            stdout: combined,
+            stderr: String::new(),
+            exit_code,
+        })
+    }
+}
+
+#[cfg(unix)]
+fn shell_quote(input: &str) -> String {
+    // Minimal single-quote escaping for `bash -lc`.
+    let mut out = String::from("'");
+    for ch in input.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
+}

--- a/apps/cli/src/acp/updates.rs
+++ b/apps/cli/src/acp/updates.rs
@@ -41,6 +41,13 @@ pub fn agent_message_chunk(text: &str) -> Value {
     })
 }
 
+pub fn agent_thought_chunk(text: &str) -> Value {
+    json!({
+        "sessionUpdate": "agent_thought_chunk",
+        "content": { "type": "text", "text": text }
+    })
+}
+
 pub fn user_message_chunk(text: &str) -> Value {
     json!({
         "sessionUpdate": "user_message_chunk",
@@ -263,6 +270,10 @@ mod tests {
             "available_commands_update"
         );
         assert_eq!(current_mode_update("plan")["modeId"], "plan");
+        assert_eq!(
+            agent_thought_chunk("hmm")["sessionUpdate"],
+            "agent_thought_chunk"
+        );
     }
 
     #[test]

--- a/apps/cli/src/tui/app.rs
+++ b/apps/cli/src/tui/app.rs
@@ -464,6 +464,7 @@ impl App {
                 }
             }
             AgentEvent::SteerInput { .. }
+            | AgentEvent::ThoughtDelta { .. }
             | AgentEvent::ModeChanged { .. }
             | AgentEvent::UsageUpdate { .. } => {}
         }

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -19,6 +19,9 @@ pub enum AgentEvent {
     TextDelta {
         delta: String,
     },
+    ThoughtDelta {
+        delta: String,
+    },
     ToolCall {
         id: String,
         name: String,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1122,6 +1122,14 @@ impl Agent {
                     }
                     text.push_str(&delta);
                 }
+                StreamEvent::ThoughtDelta(delta) => {
+                    emit_event(
+                        &options.event_handler,
+                        AgentEvent::ThoughtDelta {
+                            delta: delta.clone(),
+                        },
+                    );
+                }
                 StreamEvent::ToolCallDelta {
                     index,
                     id,
@@ -1606,6 +1614,7 @@ fn record_entry_from_agent_event(event: &AgentEvent) -> Option<RecordEntry> {
         }),
         AgentEvent::TurnStart { .. }
         | AgentEvent::TextDelta { .. }
+        | AgentEvent::ThoughtDelta { .. }
         | AgentEvent::SteerInput { .. }
         | AgentEvent::ModeChanged { .. }
         | AgentEvent::UsageUpdate { .. } => None,

--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -379,6 +379,17 @@ impl AnthropicStreamState {
                                     events.push(StreamEvent::TextDelta(text.to_string()));
                                 }
                             }
+                            Some("thinking_delta") => {
+                                if let Some(text) = delta
+                                    .get("thinking")
+                                    .or_else(|| delta.get("text"))
+                                    .and_then(Value::as_str)
+                                {
+                                    if !text.is_empty() {
+                                        events.push(StreamEvent::ThoughtDelta(text.to_string()));
+                                    }
+                                }
+                            }
                             Some("input_json_delta") => {
                                 while self.tool_calls.len() <= index {
                                     self.tool_calls.push(ToolCallBuilder {

--- a/crates/llm/src/openai_compatible.rs
+++ b/crates/llm/src/openai_compatible.rs
@@ -334,20 +334,32 @@ fn parse_message_from_raw(raw: &Value) -> Option<Message> {
 fn chunk_to_events(chunk: &ChatResponseChunk) -> Vec<StreamEvent> {
     let mut events = Vec::new();
 
+    let delta_obj = chunk
+        .raw
+        .get("choices")
+        .and_then(Value::as_array)
+        .and_then(|choices| choices.first())
+        .and_then(|choice| choice.get("delta"));
+
+    if let Some(delta) = delta_obj {
+        if let Some(reasoning) = delta
+            .get("reasoning_content")
+            .or_else(|| delta.get("reasoning"))
+            .and_then(Value::as_str)
+        {
+            if !reasoning.is_empty() {
+                events.push(StreamEvent::ThoughtDelta(reasoning.to_string()));
+            }
+        }
+    }
+
     if let Some(delta) = &chunk.delta {
         if !delta.is_empty() {
             events.push(StreamEvent::TextDelta(delta.clone()));
         }
     }
 
-    if let Some(tool_calls) = chunk
-        .raw
-        .get("choices")
-        .and_then(Value::as_array)
-        .and_then(|choices| choices.first())
-        .and_then(|choice| choice.get("delta"))
-        .and_then(|delta| delta.get("tool_calls"))
-        .and_then(Value::as_array)
+    if let Some(tool_calls) = delta_obj.and_then(|delta| delta.get("tool_calls")).and_then(Value::as_array)
     {
         for call in tool_calls {
             events.push(StreamEvent::ToolCallDelta {
@@ -415,5 +427,29 @@ mod tests {
         let message = Message::tool_result("call_1", "Read", "ok");
         let api = message_to_api(&message).expect("api message");
         assert!(api.get("is_error").is_none());
+    }
+
+    #[test]
+    fn chunk_emits_thought_delta_from_reasoning_content() {
+        let chunk = ChatResponseChunk {
+            delta: Some("answer".into()),
+            raw: json!({
+                "choices": [{
+                    "delta": {
+                        "reasoning_content": "thinking...",
+                        "content": "answer"
+                    }
+                }]
+            }),
+        };
+        let events = chunk_to_events(&chunk);
+        assert!(events.iter().any(|e| matches!(
+            e,
+            StreamEvent::ThoughtDelta(t) if t == "thinking..."
+        )));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            StreamEvent::TextDelta(t) if t == "answer"
+        )));
     }
 }

--- a/crates/llm/src/provider.rs
+++ b/crates/llm/src/provider.rs
@@ -19,6 +19,8 @@ pub struct ChatRequest {
 #[derive(Debug, Clone)]
 pub enum StreamEvent {
     TextDelta(String),
+    /// Model reasoning / thinking tokens (when the provider streams them).
+    ThoughtDelta(String),
     ToolCallDelta {
         index: usize,
         id: Option<String>,

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -96,6 +96,22 @@ pub trait RemoteTextFs: Send + Sync {
     async fn write_text(&self, absolute_path: &Path, content: &str) -> Result<()>;
 }
 
+/// Optional remote terminal (e.g. ACP client `terminal/*`).
+///
+/// When set, [`LocalSandbox::exec_with_timeout`] delegates shell execution to
+/// the client after resolving the working directory.
+#[async_trait]
+pub trait RemoteTerminal: Send + Sync {
+    async fn exec(
+        &self,
+        command: &str,
+        cwd: &Path,
+        timeout: Duration,
+        cancel: Option<&CancellationToken>,
+        output_byte_limit: usize,
+    ) -> Result<ExecResult>;
+}
+
 #[derive(Clone)]
 pub struct LocalSandbox {
     workdir: PathBuf,
@@ -103,6 +119,7 @@ pub struct LocalSandbox {
     network: NetworkPolicy,
     profile: String,
     remote_fs: Option<Arc<dyn RemoteTextFs>>,
+    remote_terminal: Option<Arc<dyn RemoteTerminal>>,
 }
 
 impl LocalSandbox {
@@ -116,6 +133,7 @@ impl LocalSandbox {
             network: NetworkPolicy::Unrestricted,
             profile: "off".to_string(),
             remote_fs: None,
+            remote_terminal: None,
         }
     }
 
@@ -127,6 +145,16 @@ impl LocalSandbox {
 
     pub fn set_remote_fs(&mut self, remote: Option<Arc<dyn RemoteTextFs>>) {
         self.remote_fs = remote;
+    }
+
+    /// Attach a remote terminal bridge (ACP client terminals).
+    pub fn with_remote_terminal(mut self, remote: Arc<dyn RemoteTerminal>) -> Self {
+        self.remote_terminal = Some(remote);
+        self
+    }
+
+    pub fn set_remote_terminal(&mut self, remote: Option<Arc<dyn RemoteTerminal>>) {
+        self.remote_terminal = remote;
     }
 
     /// Construct a sandbox with the default `workspace` Keel profile.
@@ -146,6 +174,7 @@ impl LocalSandbox {
                 network: NetworkPolicy::Unrestricted,
                 profile,
                 remote_fs: None,
+                remote_terminal: None,
             });
         }
 
@@ -166,6 +195,7 @@ impl LocalSandbox {
             network,
             profile,
             remote_fs: None,
+            remote_terminal: None,
         })
     }
 
@@ -224,6 +254,7 @@ impl LocalSandbox {
             network: self.network.clone(),
             profile: self.profile.clone(),
             remote_fs: self.remote_fs.clone(),
+            remote_terminal: self.remote_terminal.clone(),
         })
     }
 
@@ -390,6 +421,15 @@ impl LocalSandbox {
         }
 
         let timeout_secs = timeout.as_secs().max(1);
+        if let Some(remote) = &self.remote_terminal {
+            let cwd = match cwd {
+                Some(path) => self.resolve(path)?,
+                None => canonical_workdir(&self.workdir)?,
+            };
+            return remote
+                .exec(command, &cwd, timeout, cancel, BASH_OUTPUT_LIMIT)
+                .await;
+        }
         if self.space.is_some() {
             let cwd = match cwd {
                 Some(path) => self.resolve(path)?,

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -159,12 +159,14 @@ Before/after compaction, checkpoints are saved under `~/.zene/sessions/<id>/comp
 
 `zene acp` (--yolo optional) speaks an Agent Client Protocol subset over stdin/stdout NDJSON JSON-RPC:
 
-- Requests: `initialize`, `session/new`, `session/load`, `session/list`, `session/close`, `session/set_mode`, `session/prompt`
-- Notifications in: `session/cancel`
-- Notifications out: `session/update` (`agent_message_chunk`, `user_message_chunk`, `tool_call`, `tool_call_update`, `plan`, `current_mode_update`, `available_commands_update`, `usage_update`)
+- Requests: `initialize`, `session/new`, `session/load`, `session/resume`, `session/list`, `session/close`, `session/set_mode`, `session/prompt`
+- Notifications in: `session/cancel` (honored during an active prompt)
+- Notifications out: `session/update` (`agent_message_chunk`, `agent_thought_chunk`, `user_message_chunk`, `tool_call`, `tool_call_update`, `plan`, `current_mode_update`, `available_commands_update`, `usage_update`)
 - Requests out: `session/request_permission` (client replies with `optionId`; `toolCallId` matches the live tool call)
 - When the client advertises FS capabilities, text Read/Write/Edit go through `fs/read_text_file` / `fs/write_text_file`
-- `session/new` and `session/load` return `modes` (`default` / `plan`); `session/load` also replays history (`_meta.isReplay=true`)
+- When the client advertises `terminal`, Bash goes through `terminal/create|wait_for_exit|output|kill|release`
+- `session/new` / `load` / `resume` return `modes` (`default` / `plan`); `load` replays history, `resume` does not
+- Concurrent prompts on one session are queued FIFO; cancel aborts the active turn
 - Prompt content accepts `text`, embedded `resource`, and `resource_link` blocks
 
 Stdout is reserved for protocol frames; logs go to stderr.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -414,7 +414,7 @@ TUI、record/replay、安装分发。
 | P3 会话恢复 | [x] | compaction checkpoints、`/rewind`、`/fork`、`/session-info` |
 | P4 运行时 | [x] | 后台 Bash/Task + TaskOutput、`--worktree`、subagent 报告包装 |
 | P5 MCP/扩展 | [x] | stdio + HTTP MCP、`zene mcp doctor` |
-| P6 集成/产品化 | [x] | `zene -p` headless + `--output-format json`；`zene acp`（modes/close/usage/FS bridge、tool updates、load replay） |
+| P6 集成/产品化 | [x] | `zene -p` headless + `--output-format json`；`zene acp`（resume/queue/thought/terminal + modes/FS/tool updates） |
 | P7 沙箱产品化 | [x] | 可配置 Keel profile、egress allowlist、凭据 deny、SpaceFs、auto_allow_bash |
 
 *最后更新：2026-07-19（ACP session updates + P7 沙箱 + P1 续5 tiktoken-rs）*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
在 PR #19 合并后补齐剩余标准 ACP 缺口（不含任何 `x.ai/*` 专有扩展）。

## 变更

- **session/resume**：按会话 ID 恢复内存会话，不回放历史；`initialize` 声明 `sessionCapabilities.resume`
- **Prompt 队列 + 取消**：活跃 prompt 期间新请求入 FIFO 队列并返回 `Queued`；`session/cancel` 可中断当前 prompt；结束后自动拉起队列中下一项
- **agent_thought_chunk**：LLM 层解析 OpenAI `reasoning_content` / Anthropic `thinking_delta`，经 core `ThoughtDelta` 转发为 ACP `agent_thought_chunk`
- **terminal/\***：客户端声明 `clientCapabilities.terminal` 时，sandbox 通过反向 RPC（create / wait_for_exit / output / kill / release）桥接客户端终端

## 测试

- `cargo test -p zene-llm --lib`
- `cargo test -p zene-core --lib`
- `cargo test -p zene-sandbox --lib`
- `cargo test -p zene-cli --bin zene acp`
- `cargo check -p zene-cli --bin zene`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab3880ba-03bb-4b7f-a564-692c1685708d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab3880ba-03bb-4b7f-a564-692c1685708d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

