### PR TITLE
feat(gateway): HTTP 长轮询 ACP Gateway（Web Agent 阶段 A）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,11 @@
 
 ## Cursor Cloud specific instructions
 
-Zene is a single Rust product: a local coding-agent CLI (binary `zene`, workspace version in `Cargo.toml`). There is no backend server, database, or web app to run — the `web/`, `www/`, `apps/web/`, and root `package.json` files are just static-site copy stubs, not real Node apps. At runtime the CLI makes outbound HTTPS calls to an external LLM provider (OpenAI-compatible or Anthropic); nothing is self-hosted.
+Zene is a local coding-agent product (workspace version in `Cargo.toml`). Primary binaries:
+- `zene` (`apps/cli`): REPL/TUI, headless `-p`, and `zene acp` stdio Agent Client Protocol
+- `zene-gateway` (`apps/gateway`): thin local HTTP gateway that spawns `zene acp` and serves a minimal Web Agent UI via long-polling (see `docs/WEB_AGENT_GATEWAY.md`)
+
+The `web/`, `www/`, and root `package.json` files are still mostly static-site copy stubs, not the Agent UI. At runtime the agent makes outbound HTTPS calls to an external LLM provider (OpenAI-compatible or Anthropic); nothing is self-hosted except the optional local gateway.
 
 Toolchain caveat (non-obvious): a dependency (`unigateway-sdk`) requires Rust `edition2024`, so the toolchain must be Rust >= 1.85. The base image historically defaulted to an older `rustc` (1.83); the update script pins `rustup default stable`. If you ever hit `feature edition2024 is required`, run `rustup default stable`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+- Headless Web direction: `docs/WEB_AGENT_GATEWAY.md` design for HTTP Gateway + Web Agent UI (long-polling first; SSE optional; WebSocket not required).
+- New `zene-gateway` binary (`apps/gateway`): thin local HTTP bridge over `zene acp` with token/Origin checks, `POST /api/v1/agents/{id}/messages`, cursor-based `GET /api/v1/agents/{id}/events` long polling, bootstrap/health, embedded minimal Web page, and mock-ACP integration tests.
+
 ### Changed
 - ACP: bridge `tool_call` / `tool_call_update` / `plan` / `usage_update` / `current_mode_update` / `available_commands_update` / `agent_thought_chunk`; replay history on `session/load`; implement `session/list`, `session/close`, `session/set_mode`, `session/resume`; optional client FS + terminal bridges; FIFO prompt queue with in-turn cancel; correlate permission `toolCallId`; accept embedded prompt context; tighten JSON-RPC error codes.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "axum-macros",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1348,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,6 +1375,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1751,10 +1822,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2722,6 +2805,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,6 +3530,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3453,6 +3548,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 
@@ -3474,6 +3570,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4434,6 +4531,25 @@ dependencies = [
  "zene-sandbox",
  "zene-session",
  "zene-tools",
+]
+
+[[package]]
+name = "zene-gateway"
+version = "0.1.7"
+dependencies = [
+ "anyhow",
+ "axum",
+ "chrono",
+ "clap",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "apps/cli",
+    "apps/gateway",
     "crates/config",
     "crates/llm",
     "crates/sandbox",
@@ -20,10 +21,12 @@ authors = ["Zene Contributors"]
 [workspace.dependencies]
 anyhow = "1"
 async-trait = "0.1"
+axum = { version = "0.8", features = ["macros"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
 futures = "0.3"
+tower-http = { version = "0.6", features = ["trace"] }
 jsonschema = "0.26"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }

--- a/README.md
+++ b/README.md
@@ -126,13 +126,24 @@ zene --no-stream       # disable streaming output
 zene --yolo            # auto-approve Write / Edit / Bash
 zene --sandbox strict  # Keel profile: off | workspace | read-only | strict | custom
 zene --tui             # ratatui chat UI (PageUp/PageDown scroll)
+zene acp               # Agent Client Protocol over stdio (for editors / gateway)
 ```
+
+Headless Web UI (phase A vertical slice):
+
+```bash
+cargo run -p zene-gateway -- --zene-bin ./target/debug/zene
+# open the printed http://127.0.0.1:8787/#token=... URL
+```
+
+`zene-gateway` is a thin local HTTP bridge: Web UI talks HTTP long-polling; the gateway speaks ACP NDJSON to a `zene acp` child process. See [docs/WEB_AGENT_GATEWAY.md](docs/WEB_AGENT_GATEWAY.md).
 
 ## Architecture
 
 ```
 zene/
-├── apps/cli/          # REPL entrypoint
+├── apps/cli/          # REPL / TUI / headless / ACP entrypoint
+├── apps/gateway/      # local HTTP gateway for Web Agent UI
 └── crates/
     ├── core/          # agent turn loop, hooks
     ├── llm/           # OpenAI-compatible (unigateway-sdk from crates.io) + Anthropic clients

--- a/apps/gateway/Cargo.toml
+++ b/apps/gateway/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "zene-gateway"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Thin local HTTP gateway for Zene ACP and Web Agent UI"
+
+[[bin]]
+name = "zene-gateway"
+path = "src/main.rs"
+
+[[bin]]
+name = "zene-gateway-mock-acp"
+path = "src/bin/mock_acp.rs"
+
+[dependencies]
+anyhow.workspace = true
+axum.workspace = true
+chrono.workspace = true
+clap.workspace = true
+serde = { workspace = true }
+serde_json.workspace = true
+tokio.workspace = true
+tower-http.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+uuid.workspace = true
+
+[dev-dependencies]
+reqwest = { workspace = true, features = ["json"] }
+tempfile = "3"

--- a/apps/gateway/src/agent.rs
+++ b/apps/gateway/src/agent.rs
@@ -1,0 +1,329 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Serialize;
+use serde_json::Value;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::{Mutex, RwLock};
+use uuid::Uuid;
+
+use crate::event_journal::EventJournal;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AgentState {
+    Starting,
+    Running,
+    Exited,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentInfo {
+    pub agent_id: String,
+    pub workspace: PathBuf,
+    pub state: AgentState,
+    pub pid: Option<u32>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub exit_code: Option<i32>,
+}
+
+struct AgentRuntime {
+    info: AgentInfo,
+    stdin: Option<ChildStdin>,
+    child: Child,
+    journal: EventJournal,
+}
+
+#[derive(Clone)]
+pub struct AgentManager {
+    inner: Arc<RwLock<HashMap<String, Arc<Mutex<AgentRuntime>>>>>,
+    command: PathBuf,
+    command_args: Vec<String>,
+}
+
+impl AgentManager {
+    pub fn new(command: PathBuf, command_args: Vec<String>) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            command,
+            command_args,
+        }
+    }
+
+    pub async fn create(&self, workspace: PathBuf) -> Result<AgentInfo> {
+        let workspace = canonicalize_workspace(&workspace)?;
+        let agent_id = format!("agent_{}", Uuid::new_v4().simple());
+        let journal = EventJournal::new();
+
+        let mut child = Command::new(&self.command)
+            .args(&self.command_args)
+            .current_dir(&workspace)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .with_context(|| {
+                format!(
+                    "failed to spawn ACP process {} {:?}",
+                    self.command.display(),
+                    self.command_args
+                )
+            })?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow!("ACP process stdin missing"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow!("ACP process stdout missing"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| anyhow!("ACP process stderr missing"))?;
+
+        let info = AgentInfo {
+            agent_id: agent_id.clone(),
+            workspace,
+            state: AgentState::Running,
+            pid: child.id(),
+            created_at: chrono::Utc::now(),
+            exit_code: None,
+        };
+
+        let runtime = Arc::new(Mutex::new(AgentRuntime {
+            info: info.clone(),
+            stdin: Some(stdin),
+            child,
+            journal: journal.clone(),
+        }));
+
+        {
+            let mut map = self.inner.write().await;
+            map.insert(agent_id.clone(), runtime.clone());
+        }
+
+        let stdout_runtime = runtime.clone();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let payload = match serde_json::from_str::<Value>(&line) {
+                    Ok(value) => value,
+                    Err(err) => serde_json::json!({
+                        "type": "gateway.system",
+                        "kind": "invalid_stdout",
+                        "message": format!("invalid ACP JSON: {err}"),
+                        "raw": line,
+                    }),
+                };
+                let journal = {
+                    let guard = stdout_runtime.lock().await;
+                    guard.journal.clone()
+                };
+                journal.append(payload).await;
+            }
+        });
+
+        let stderr_agent = agent_id.clone();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                tracing::warn!(agent_id = %stderr_agent, "acp stderr: {line}");
+            }
+        });
+
+        let wait_runtime = runtime.clone();
+        let wait_agent = agent_id.clone();
+        tokio::spawn(async move {
+            let exit = loop {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                let mut guard = wait_runtime.lock().await;
+                match guard.child.try_wait() {
+                    Ok(Some(status)) => break Ok(status),
+                    Ok(None) => {}
+                    Err(err) => break Err(err),
+                }
+            };
+
+            let mut guard = wait_runtime.lock().await;
+            match exit {
+                Ok(status) => {
+                    guard.info.state = if status.success() {
+                        AgentState::Exited
+                    } else {
+                        AgentState::Failed
+                    };
+                    guard.info.exit_code = status.code();
+                    guard.stdin = None;
+                    let code = status.code();
+                    let journal = guard.journal.clone();
+                    drop(guard);
+                    journal
+                        .append_system(
+                            "process_exit",
+                            format!("ACP process {wait_agent} exited with code {code:?}"),
+                        )
+                        .await;
+                }
+                Err(err) => {
+                    guard.info.state = AgentState::Failed;
+                    guard.stdin = None;
+                    let journal = guard.journal.clone();
+                    drop(guard);
+                    journal
+                        .append_system("process_wait_error", format!("failed to wait: {err}"))
+                        .await;
+                }
+            }
+        });
+
+        journal
+            .append_system(
+                "agent_started",
+                format!("ACP process started for {}", info.workspace.display()),
+            )
+            .await;
+
+        Ok(info)
+    }
+
+    pub async fn get(&self, agent_id: &str) -> Option<AgentInfo> {
+        let map = self.inner.read().await;
+        let runtime = map.get(agent_id)?.clone();
+        let guard = runtime.lock().await;
+        Some(guard.info.clone())
+    }
+
+    pub async fn journal(&self, agent_id: &str) -> Option<EventJournal> {
+        let map = self.inner.read().await;
+        let runtime = map.get(agent_id)?.clone();
+        let guard = runtime.lock().await;
+        Some(guard.journal.clone())
+    }
+
+    pub async fn write_messages(&self, agent_id: &str, messages: &[Value]) -> Result<usize> {
+        let map = self.inner.read().await;
+        let runtime = map
+            .get(agent_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("agent not found"))?;
+        drop(map);
+
+        let mut guard = runtime.lock().await;
+        if !matches!(guard.info.state, AgentState::Running | AgentState::Starting) {
+            bail!("agent is not running");
+        }
+        let Some(stdin) = guard.stdin.as_mut() else {
+            bail!("agent stdin closed");
+        };
+        let mut written = 0usize;
+        for message in messages {
+            let mut line = serde_json::to_string(message)?;
+            line.push('\n');
+            stdin
+                .write_all(line.as_bytes())
+                .await
+                .context("failed writing to ACP stdin")?;
+            written += 1;
+        }
+        stdin.flush().await.context("failed flushing ACP stdin")?;
+        Ok(written)
+    }
+
+    pub async fn health(&self, agent_id: &str) -> Option<AgentHealth> {
+        let map = self.inner.read().await;
+        let runtime = map.get(agent_id)?.clone();
+        let guard = runtime.lock().await;
+        let (oldest, latest, count) = guard.journal.snapshot_meta().await;
+        Some(AgentHealth {
+            agent_id: guard.info.agent_id.clone(),
+            state: guard.info.state,
+            pid: guard.info.pid,
+            exit_code: guard.info.exit_code,
+            workspace: guard.info.workspace.clone(),
+            oldest_cursor: oldest,
+            latest_cursor: latest,
+            event_count: count,
+            uptime_ms: (chrono::Utc::now() - guard.info.created_at).num_milliseconds().max(0)
+                as u64,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentHealth {
+    pub agent_id: String,
+    pub state: AgentState,
+    pub pid: Option<u32>,
+    pub exit_code: Option<i32>,
+    pub workspace: PathBuf,
+    pub oldest_cursor: Option<u64>,
+    pub latest_cursor: u64,
+    pub event_count: usize,
+    pub uptime_ms: u64,
+}
+
+pub fn resolve_zene_bin(explicit: Option<PathBuf>) -> PathBuf {
+    if let Some(path) = explicit {
+        return path;
+    }
+    if let Ok(path) = std::env::var("ZENE_BIN") {
+        return PathBuf::from(path);
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        let sibling = exe.with_file_name("zene");
+        if sibling.exists() {
+            return sibling;
+        }
+        #[cfg(windows)]
+        {
+            let sibling = exe.with_file_name("zene.exe");
+            if sibling.exists() {
+                return sibling;
+            }
+        }
+    }
+    PathBuf::from("zene")
+}
+
+fn canonicalize_workspace(path: &Path) -> Result<PathBuf> {
+    if !path.exists() {
+        bail!("workspace does not exist: {}", path.display());
+    }
+    if !path.is_dir() {
+        bail!("workspace is not a directory: {}", path.display());
+    }
+    let canonical = path
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize {}", path.display()))?;
+    Ok(canonical)
+}
+
+/// Best-effort wait helper used by tests.
+pub async fn wait_until<F, Fut>(timeout: std::time::Duration, mut check: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if check().await {
+            return true;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    false
+}

--- a/apps/gateway/src/auth.rs
+++ b/apps/gateway/src/auth.rs
@@ -1,0 +1,162 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::http::{HeaderMap, StatusCode};
+use serde::Serialize;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+#[derive(Debug, Clone)]
+pub struct AuthState {
+    pub token: String,
+    pub bind_host: String,
+    pub port: u16,
+    idempotency: Arc<Mutex<HashMap<String, IdempotentEntry>>>,
+}
+
+#[derive(Debug, Clone)]
+struct IdempotentEntry {
+    status: StatusCode,
+    body: serde_json::Value,
+    stored_at: Instant,
+}
+
+impl AuthState {
+    pub fn new(token: String, bind_host: String, port: u16) -> Self {
+        Self {
+            token,
+            bind_host,
+            port,
+            idempotency: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn generate_token() -> String {
+        format!("zg_{}", Uuid::new_v4().simple())
+    }
+
+    pub fn extract_token(headers: &HeaderMap, query_token: Option<&str>) -> Option<String> {
+        if let Some(value) = headers.get("x-zene-token").and_then(|v| v.to_str().ok()) {
+            return Some(value.to_string());
+        }
+        if let Some(value) = headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+        {
+            let value = value.trim();
+            if let Some(rest) = value.strip_prefix("Bearer ") {
+                return Some(rest.trim().to_string());
+            }
+        }
+        query_token.map(str::to_string)
+    }
+
+    pub fn authorize(&self, headers: &HeaderMap, query_token: Option<&str>) -> Result<(), StatusCode> {
+        let Some(provided) = Self::extract_token(headers, query_token) else {
+            return Err(StatusCode::UNAUTHORIZED);
+        };
+        if provided != self.token {
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+        self.check_origin(headers)
+    }
+
+    pub fn check_origin(&self, headers: &HeaderMap) -> Result<(), StatusCode> {
+        let Some(origin) = headers.get(axum::http::header::ORIGIN) else {
+            return Ok(());
+        };
+        let Ok(origin) = origin.to_str() else {
+            return Err(StatusCode::FORBIDDEN);
+        };
+        if self.allowed_origins().iter().any(|allowed| allowed == origin) {
+            Ok(())
+        } else {
+            Err(StatusCode::FORBIDDEN)
+        }
+    }
+
+    pub fn allowed_origins(&self) -> Vec<String> {
+        let mut origins = vec![
+            format!("http://{}:{}", self.bind_host, self.port),
+            format!("http://127.0.0.1:{}", self.port),
+            format!("http://localhost:{}", self.port),
+        ];
+        origins.sort();
+        origins.dedup();
+        origins
+    }
+
+    pub async fn recall_idempotent(
+        &self,
+        request_id: &str,
+    ) -> Option<(StatusCode, serde_json::Value)> {
+        self.prune_idempotent().await;
+        let map = self.idempotency.lock().await;
+        map.get(request_id)
+            .map(|entry| (entry.status, entry.body.clone()))
+    }
+
+    pub async fn store_idempotent(
+        &self,
+        request_id: String,
+        status: StatusCode,
+        body: serde_json::Value,
+    ) {
+        let mut map = self.idempotency.lock().await;
+        map.insert(
+            request_id,
+            IdempotentEntry {
+                status,
+                body,
+                stored_at: Instant::now(),
+            },
+        );
+    }
+
+    async fn prune_idempotent(&self) {
+        let mut map = self.idempotency.lock().await;
+        let cutoff = Instant::now() - Duration::from_secs(10 * 60);
+        map.retain(|_, entry| entry.stored_at >= cutoff);
+        while map.len() > 2_000 {
+            if let Some(oldest) = map
+                .iter()
+                .min_by_key(|(_, entry)| entry.stored_at)
+                .map(|(key, _)| key.clone())
+            {
+                map.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ErrorBody {
+    pub error: String,
+    pub message: String,
+    pub trace_id: String,
+    pub retryable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oldest_cursor: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_cursor: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery: Option<String>,
+}
+
+impl ErrorBody {
+    pub fn new(error: impl Into<String>, message: impl Into<String>, retryable: bool) -> Self {
+        Self {
+            error: error.into(),
+            message: message.into(),
+            trace_id: Uuid::new_v4().to_string(),
+            retryable,
+            oldest_cursor: None,
+            latest_cursor: None,
+            recovery: None,
+        }
+    }
+}

--- a/apps/gateway/src/bin/mock_acp.rs
+++ b/apps/gateway/src/bin/mock_acp.rs
@@ -1,0 +1,241 @@
+//! Minimal ACP stdio peer used by gateway integration tests.
+
+use std::collections::HashMap;
+use std::io::{self, BufRead, Write};
+
+use serde_json::{json, Value};
+
+fn main() {
+    let stdin = io::stdin();
+    let mut input = stdin.lock();
+    let mut stdout = io::stdout();
+    let session_id = String::from("mock-session-1");
+    let mut pending_permission: HashMap<String, bool> = HashMap::new();
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let n = match input.read_line(&mut line) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => break,
+        };
+        if n == 0 || line.trim().is_empty() {
+            continue;
+        }
+        let Ok(msg) = serde_json::from_str::<Value>(line.trim()) else {
+            continue;
+        };
+
+        // Client JSON-RPC response to our permission request.
+        if msg.get("method").is_none() && msg.get("id").is_some() {
+            if let Some(id) = msg.get("id") {
+                pending_permission.insert(id_to_key(id), true);
+            }
+            continue;
+        }
+
+        let method = msg.get("method").and_then(|m| m.as_str()).unwrap_or("");
+        let id = msg.get("id").cloned();
+        let params = msg.get("params").cloned().unwrap_or(json!({}));
+
+        match method {
+            "initialize" => {
+                write_msg(
+                    &mut stdout,
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": {
+                            "protocolVersion": 1,
+                            "agentCapabilities": {
+                                "loadSession": true,
+                                "promptCapabilities": {
+                                    "image": false,
+                                    "audio": false,
+                                    "embeddedContext": true
+                                }
+                            },
+                            "agentInfo": { "name": "mock-acp", "version": "0.0.1" }
+                        }
+                    }),
+                );
+            }
+            "session/new" => {
+                write_msg(
+                    &mut stdout,
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": {
+                            "sessionId": session_id,
+                            "modes": {
+                                "currentModeId": "default",
+                                "availableModes": [
+                                    { "id": "default", "name": "Default" },
+                                    { "id": "plan", "name": "Plan" }
+                                ]
+                            }
+                        }
+                    }),
+                );
+            }
+            "session/prompt" => {
+                handle_prompt(
+                    &mut input,
+                    &mut stdout,
+                    &session_id,
+                    &mut pending_permission,
+                    id,
+                    &params,
+                    &mut line,
+                );
+            }
+            "session/cancel" => {}
+            _ => {
+                if let Some(id) = id {
+                    write_msg(
+                        &mut stdout,
+                        json!({
+                            "jsonrpc": "2.0",
+                            "id": id,
+                            "error": {
+                                "code": -32601,
+                                "message": format!("Method not found: {method}")
+                            }
+                        }),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn handle_prompt(
+    input: &mut impl BufRead,
+    stdout: &mut impl Write,
+    session_id: &str,
+    pending_permission: &mut HashMap<String, bool>,
+    id: Option<Value>,
+    params: &Value,
+    line: &mut String,
+) {
+    let prompt_text = extract_prompt_text(params);
+    let want_permission = prompt_text.contains("NEED_PERMISSION");
+
+    write_msg(
+        stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": session_id,
+                "update": {
+                    "sessionUpdate": "agent_thought_chunk",
+                    "content": { "type": "text", "text": "thinking…" }
+                }
+            }
+        }),
+    );
+
+    if want_permission {
+        let perm_id = 9001;
+        write_msg(
+            stdout,
+            json!({
+                "jsonrpc": "2.0",
+                "id": perm_id,
+                "method": "session/request_permission",
+                "params": {
+                    "sessionId": session_id,
+                    "toolCall": {
+                        "toolCallId": "call_mock_1",
+                        "title": "Bash",
+                        "kind": "execute",
+                        "status": "pending"
+                    },
+                    "options": [
+                        {
+                            "optionId": "allow-once",
+                            "name": "Allow once",
+                            "kind": "allow_once"
+                        },
+                        {
+                            "optionId": "reject",
+                            "name": "Reject",
+                            "kind": "reject_once"
+                        }
+                    ]
+                }
+            }),
+        );
+
+        let key = perm_id.to_string();
+        while !pending_permission.contains_key(&key) {
+            line.clear();
+            let n = match input.read_line(line) {
+                Ok(0) => return,
+                Ok(n) => n,
+                Err(_) => return,
+            };
+            if n == 0 || line.trim().is_empty() {
+                continue;
+            }
+            if let Ok(resp) = serde_json::from_str::<Value>(line.trim()) {
+                if resp.get("method").is_none() {
+                    if let Some(rid) = resp.get("id") {
+                        pending_permission.insert(id_to_key(rid), true);
+                    }
+                }
+            }
+        }
+    }
+
+    write_msg(
+        stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": session_id,
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": { "type": "text", "text": format!("echo:{prompt_text}") }
+                }
+            }
+        }),
+    );
+    write_msg(
+        stdout,
+        json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": { "stopReason": "end_turn" }
+        }),
+    );
+}
+
+fn extract_prompt_text(params: &Value) -> String {
+    params
+        .get("prompt")
+        .and_then(|p| p.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|block| block.get("text"))
+        .and_then(|t| t.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn id_to_key(id: &Value) -> String {
+    match id {
+        Value::Number(n) => n.to_string(),
+        Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+fn write_msg(stdout: &mut impl Write, value: Value) {
+    let line = value.to_string();
+    let _ = writeln!(stdout, "{line}");
+    let _ = stdout.flush();
+}

--- a/apps/gateway/src/event_journal.rs
+++ b/apps/gateway/src/event_journal.rs
@@ -1,0 +1,222 @@
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::{Notify, RwLock};
+
+const DEFAULT_MAX_EVENTS: usize = 10_000;
+const DEFAULT_RETENTION: Duration = Duration::from_secs(30 * 60);
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JournalEvent {
+    pub cursor: u64,
+    pub created_at: DateTime<Utc>,
+    pub payload: Value,
+}
+
+#[derive(Debug, Clone)]
+struct StoredEvent {
+    event: JournalEvent,
+    stored_at: Instant,
+}
+
+#[derive(Debug)]
+struct JournalInner {
+    next_cursor: u64,
+    events: VecDeque<StoredEvent>,
+    max_events: usize,
+    retention: Duration,
+}
+
+impl JournalInner {
+    fn prune(&mut self) {
+        let cutoff = Instant::now()
+            .checked_sub(self.retention)
+            .unwrap_or_else(Instant::now);
+        while self.events.len() > self.max_events {
+            self.events.pop_front();
+        }
+        while self
+            .events
+            .front()
+            .is_some_and(|event| event.stored_at < cutoff)
+            && self.events.len() > 1
+        {
+            // Keep at least the newest event when pruning by age so nextCursor remains meaningful.
+            if self.events.len() == 1 {
+                break;
+            }
+            self.events.pop_front();
+        }
+    }
+
+    fn oldest_cursor(&self) -> Option<u64> {
+        self.events.front().map(|event| event.event.cursor)
+    }
+
+    fn latest_cursor(&self) -> u64 {
+        self.next_cursor.saturating_sub(1)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EventJournal {
+    inner: Arc<RwLock<JournalInner>>,
+    notify: Arc<Notify>,
+}
+
+impl EventJournal {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(JournalInner {
+                next_cursor: 1,
+                events: VecDeque::new(),
+                max_events: DEFAULT_MAX_EVENTS,
+                retention: DEFAULT_RETENTION,
+            })),
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    pub async fn append(&self, payload: Value) -> u64 {
+        let cursor = {
+            let mut inner = self.inner.write().await;
+            let cursor = inner.next_cursor;
+            inner.next_cursor += 1;
+            inner.events.push_back(StoredEvent {
+                event: JournalEvent {
+                    cursor,
+                    created_at: Utc::now(),
+                    payload,
+                },
+                stored_at: Instant::now(),
+            });
+            inner.prune();
+            cursor
+        };
+        self.notify.notify_waiters();
+        cursor
+    }
+
+    pub async fn append_system(&self, kind: &str, message: impl Into<String>) -> u64 {
+        self.append(serde_json::json!({
+            "type": "gateway.system",
+            "kind": kind,
+            "message": message.into(),
+        }))
+        .await
+    }
+
+    pub async fn snapshot_meta(&self) -> (Option<u64>, u64, usize) {
+        let inner = self.inner.read().await;
+        (
+            inner.oldest_cursor(),
+            inner.latest_cursor(),
+            inner.events.len(),
+        )
+    }
+
+    pub async fn read_after(
+        &self,
+        cursor: u64,
+        limit: usize,
+    ) -> Result<(Vec<JournalEvent>, u64, bool), CursorExpired> {
+        let inner = self.inner.read().await;
+        if let Some(oldest) = inner.oldest_cursor() {
+            // Client missed events between cursor+1 and oldest-1.
+            if oldest > cursor.saturating_add(1) {
+                return Err(CursorExpired {
+                    oldest_cursor: oldest,
+                    latest_cursor: inner.latest_cursor(),
+                });
+            }
+        }
+
+        let mut events = Vec::new();
+        for stored in &inner.events {
+            if stored.event.cursor > cursor {
+                events.push(stored.event.clone());
+                if events.len() >= limit {
+                    break;
+                }
+            }
+        }
+        let next_cursor = events
+            .last()
+            .map(|event| event.cursor)
+            .unwrap_or(cursor);
+        let has_more = inner
+            .events
+            .back()
+            .is_some_and(|event| event.event.cursor > next_cursor);
+        Ok((events, next_cursor, has_more))
+    }
+
+    pub async fn wait_for_events(
+        &self,
+        cursor: u64,
+        limit: usize,
+        wait: Duration,
+    ) -> Result<(Vec<JournalEvent>, u64, bool), CursorExpired> {
+        let (events, next_cursor, has_more) = self.read_after(cursor, limit).await?;
+        if !events.is_empty() || wait.is_zero() {
+            return Ok((events, next_cursor, has_more));
+        }
+
+        let notified = self.notify.notified();
+        tokio::pin!(notified);
+        let _ = tokio::time::timeout(wait, &mut notified).await;
+        self.read_after(cursor, limit).await
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CursorExpired {
+    pub oldest_cursor: u64,
+    pub latest_cursor: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn append_and_read_after_cursor() {
+        let journal = EventJournal::new();
+        let c1 = journal.append(json!({"n": 1})).await;
+        let c2 = journal.append(json!({"n": 2})).await;
+        assert_eq!(c1, 1);
+        assert_eq!(c2, 2);
+
+        let (events, next, has_more) = journal.read_after(0, 10).await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(next, 2);
+        assert!(!has_more);
+
+        let (events, next, _) = journal.read_after(1, 10).await.unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].cursor, 2);
+        assert_eq!(next, 2);
+    }
+
+    #[tokio::test]
+    async fn wait_returns_when_event_arrives() {
+        let journal = EventJournal::new();
+        let journal2 = journal.clone();
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            journal2.append(json!({"hello": true})).await;
+        });
+        let (events, _, _) = journal
+            .wait_for_events(0, 10, Duration::from_secs(2))
+            .await
+            .unwrap();
+        handle.await.unwrap();
+        assert_eq!(events.len(), 1);
+    }
+}

--- a/apps/gateway/src/http.rs
+++ b/apps/gateway/src/http.rs
@@ -1,0 +1,343 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{Html, IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tower_http::trace::TraceLayer;
+use uuid::Uuid;
+
+use crate::agent::AgentManager;
+use crate::auth::{AuthState, ErrorBody};
+use crate::event_journal::CursorExpired;
+use crate::static_page::INDEX_HTML;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub auth: AuthState,
+    pub agents: AgentManager,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub version: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateAgentRequest {
+    pub request_id: String,
+    pub workspace: PathBuf,
+    #[serde(default)]
+    pub sandbox_profile: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostMessagesRequest {
+    pub request_id: String,
+    pub messages: Vec<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventsQuery {
+    pub cursor: Option<u64>,
+    pub wait_ms: Option<u64>,
+    pub limit: Option<usize>,
+    pub token: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ApiMeta {
+    server_time: chrono::DateTime<chrono::Utc>,
+    trace_id: String,
+}
+
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/", get(index))
+        .route("/api/v1/bootstrap", get(bootstrap))
+        .route("/api/v1/health", get(health))
+        .route("/api/v1/agents", post(create_agent))
+        .route("/api/v1/agents/{agent_id}/messages", post(post_messages))
+        .route("/api/v1/agents/{agent_id}/events", get(get_events))
+        .route("/api/v1/agents/{agent_id}/health", get(agent_health))
+        .layer(TraceLayer::new_for_http())
+        .with_state(Arc::new(state))
+}
+
+async fn index() -> Html<&'static str> {
+    Html(INDEX_HTML)
+}
+
+async fn bootstrap(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    Json(json!({
+        "gatewayVersion": state.version,
+        "apiVersion": "v1",
+        "acpTransport": "stdio-ndjson",
+        "transports": {
+            "longPolling": true,
+            "sse": false,
+            "shortPolling": true,
+            "websocket": false
+        },
+        "auth": {
+            "header": "X-Zene-Token",
+            "query": "token"
+        },
+        "limits": {
+            "maxPostBodyBytes": 1_048_576,
+            "maxMessagesPerPost": 100,
+            "defaultWaitMs": 25_000,
+            "maxWaitMs": 30_000,
+            "maxEventsPerPoll": 200
+        },
+        "bind": {
+            "host": state.auth.bind_host,
+            "port": state.auth.port
+        },
+        "serverTime": chrono::Utc::now(),
+        "startedAt": state.started_at,
+    }))
+}
+
+async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    Json(json!({
+        "ok": true,
+        "gatewayVersion": state.version,
+        "uptimeMs": (chrono::Utc::now() - state.started_at).num_milliseconds().max(0),
+        "serverTime": chrono::Utc::now(),
+    }))
+}
+
+async fn create_agent(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(body): Json<CreateAgentRequest>,
+) -> Response {
+    if let Err(status) = state.auth.authorize(&headers, None) {
+        return auth_error(status);
+    }
+    if body.request_id.trim().is_empty() {
+        return json_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "requestId is required",
+            false,
+        );
+    }
+    if let Some((status, cached)) = state.auth.recall_idempotent(&body.request_id).await {
+        return (status, Json(cached)).into_response();
+    }
+
+    // sandbox_profile reserved for later; phase A passes workspace cwd only.
+    let _ = body.sandbox_profile;
+    match state.agents.create(body.workspace).await {
+        Ok(info) => {
+            let payload = json!({
+                "agent": info,
+                "meta": meta(),
+            });
+            state
+                .auth
+                .store_idempotent(body.request_id, StatusCode::OK, payload.clone())
+                .await;
+            (StatusCode::OK, Json(payload)).into_response()
+        }
+        Err(err) => json_error(
+            StatusCode::BAD_REQUEST,
+            "agent_create_failed",
+            err.to_string(),
+            true,
+        ),
+    }
+}
+
+async fn post_messages(
+    State(state): State<Arc<AppState>>,
+    Path(agent_id): Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<PostMessagesRequest>,
+) -> Response {
+    if let Err(status) = state.auth.authorize(&headers, None) {
+        return auth_error(status);
+    }
+    if body.request_id.trim().is_empty() {
+        return json_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "requestId is required",
+            false,
+        );
+    }
+    if body.messages.is_empty() {
+        return json_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "messages must not be empty",
+            false,
+        );
+    }
+    if body.messages.len() > 100 {
+        return json_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "too_many_messages",
+            "max 100 messages per POST",
+            false,
+        );
+    }
+    if let Some((status, cached)) = state.auth.recall_idempotent(&body.request_id).await {
+        return (status, Json(cached)).into_response();
+    }
+    if state.agents.get(&agent_id).await.is_none() {
+        return json_error(
+            StatusCode::NOT_FOUND,
+            "agent_not_found",
+            "unknown agentId",
+            false,
+        );
+    }
+
+    match state.agents.write_messages(&agent_id, &body.messages).await {
+        Ok(accepted) => {
+            let payload = json!({
+                "accepted": accepted,
+                "agentId": agent_id,
+                "meta": meta(),
+            });
+            state
+                .auth
+                .store_idempotent(body.request_id, StatusCode::ACCEPTED, payload.clone())
+                .await;
+            (StatusCode::ACCEPTED, Json(payload)).into_response()
+        }
+        Err(err) => {
+            let retryable = err.to_string().contains("not running");
+            json_error(
+                StatusCode::CONFLICT,
+                "agent_not_running",
+                err.to_string(),
+                retryable,
+            )
+        }
+    }
+}
+
+async fn get_events(
+    State(state): State<Arc<AppState>>,
+    Path(agent_id): Path<String>,
+    Query(query): Query<EventsQuery>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(status) = state
+        .auth
+        .authorize(&headers, query.token.as_deref())
+    {
+        return auth_error(status);
+    }
+    let Some(info) = state.agents.get(&agent_id).await else {
+        return json_error(
+            StatusCode::NOT_FOUND,
+            "agent_not_found",
+            "unknown agentId",
+            false,
+        );
+    };
+    let Some(journal) = state.agents.journal(&agent_id).await else {
+        return json_error(
+            StatusCode::NOT_FOUND,
+            "agent_not_found",
+            "unknown agentId",
+            false,
+        );
+    };
+
+    let cursor = query.cursor.unwrap_or(0);
+    let limit = query.limit.unwrap_or(200).clamp(1, 200);
+    let wait_ms = query.wait_ms.unwrap_or(25_000).min(30_000);
+    let wait = Duration::from_millis(wait_ms);
+
+    match journal.wait_for_events(cursor, limit, wait).await {
+        Ok((events, next_cursor, has_more)) => {
+            let payload = json!({
+                "events": events,
+                "nextCursor": next_cursor,
+                "hasMore": has_more,
+                "agentState": info.state,
+                "meta": meta(),
+            });
+            (StatusCode::OK, Json(payload)).into_response()
+        }
+        Err(CursorExpired {
+            oldest_cursor,
+            latest_cursor,
+        }) => {
+            let mut body = ErrorBody::new(
+                "cursor_expired",
+                "event cursor is older than the retained journal",
+                false,
+            );
+            body.oldest_cursor = Some(oldest_cursor);
+            body.latest_cursor = Some(latest_cursor);
+            body.recovery = Some("reload_session".into());
+            (StatusCode::CONFLICT, Json(body)).into_response()
+        }
+    }
+}
+
+async fn agent_health(
+    State(state): State<Arc<AppState>>,
+    Path(agent_id): Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(status) = state.auth.authorize(&headers, None) {
+        return auth_error(status);
+    }
+    match state.agents.health(&agent_id).await {
+        Some(health) => Json(json!({
+            "agent": health,
+            "meta": meta(),
+        }))
+        .into_response(),
+        None => json_error(
+            StatusCode::NOT_FOUND,
+            "agent_not_found",
+            "unknown agentId",
+            false,
+        ),
+    }
+}
+
+fn meta() -> ApiMeta {
+    ApiMeta {
+        server_time: chrono::Utc::now(),
+        trace_id: Uuid::new_v4().to_string(),
+    }
+}
+
+fn auth_error(status: StatusCode) -> Response {
+    let (error, message) = match status {
+        StatusCode::UNAUTHORIZED => ("unauthorized", "missing or invalid X-Zene-Token"),
+        StatusCode::FORBIDDEN => ("forbidden_origin", "Origin is not allowed"),
+        _ => ("unauthorized", "authentication failed"),
+    };
+    json_error(status, error, message, false)
+}
+
+fn json_error(
+    status: StatusCode,
+    error: &str,
+    message: impl Into<String>,
+    retryable: bool,
+) -> Response {
+    (
+        status,
+        Json(ErrorBody::new(error, message, retryable)),
+    )
+        .into_response()
+}
+

--- a/apps/gateway/src/lib.rs
+++ b/apps/gateway/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod agent;
+pub mod auth;
+pub mod event_journal;
+pub mod http;
+pub mod static_page;

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -1,0 +1,118 @@
+use std::path::PathBuf;
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use tracing_subscriber::EnvFilter;
+use zene_gateway::agent::{resolve_zene_bin, AgentManager};
+use zene_gateway::auth::AuthState;
+use zene_gateway::http::{self, AppState};
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "zene-gateway",
+    about = "Thin local HTTP gateway for Zene ACP / Web Agent UI"
+)]
+struct Cli {
+    /// Address to bind. Defaults to loopback only.
+    #[arg(long, default_value = "127.0.0.1")]
+    bind: String,
+
+    /// Port to listen on. Use 0 to let the OS assign an ephemeral port.
+    #[arg(long, default_value_t = 8787)]
+    port: u16,
+
+    /// Shared access token. Generated when omitted.
+    #[arg(long)]
+    token: Option<String>,
+
+    /// Path to the `zene` binary.
+    #[arg(long)]
+    zene_bin: Option<PathBuf>,
+
+    /// Override the full ACP command. When set, `--zene-bin` is ignored.
+    #[arg(long)]
+    acp_command: Option<PathBuf>,
+
+    /// Extra args for the ACP process after the command.
+    /// Defaults to `acp` when using `zene`.
+    #[arg(long = "acp-arg")]
+    acp_args: Vec<String>,
+
+    /// Allow non-loopback binds. Required for any bind outside 127.0.0.1/::1.
+    #[arg(long, default_value_t = false)]
+    allow_remote: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env().add_directive("info".parse()?))
+        .with_writer(std::io::stderr)
+        .init();
+
+    let cli = Cli::parse();
+    ensure_bind_safe(&cli.bind, cli.allow_remote)?;
+
+    let token = cli.token.clone().unwrap_or_else(AuthState::generate_token);
+    let (command, args) = resolve_acp_command(&cli)?;
+    let agents = AgentManager::new(command.clone(), args.clone());
+
+    let listener = tokio::net::TcpListener::bind((cli.bind.as_str(), cli.port))
+        .await
+        .with_context(|| format!("failed to bind {}:{}", cli.bind, cli.port))?;
+    let addr = listener.local_addr()?;
+    let auth = AuthState::new(token.clone(), cli.bind.clone(), addr.port());
+    let state = AppState {
+        auth,
+        agents,
+        started_at: chrono::Utc::now(),
+        version: env!("CARGO_PKG_VERSION"),
+    };
+
+    let url = format!(
+        "http://{}:{}/#token={}",
+        display_host(&cli.bind),
+        addr.port(),
+        token
+    );
+    eprintln!("zene-gateway listening on {addr}");
+    eprintln!("open {url}");
+    eprintln!("acp command: {} {:?}", command.display(), args);
+
+    let app = http::router(state);
+    axum::serve(listener, app)
+        .await
+        .context("gateway server terminated")?;
+    Ok(())
+}
+
+fn resolve_acp_command(cli: &Cli) -> Result<(PathBuf, Vec<String>)> {
+    if let Some(command) = &cli.acp_command {
+        return Ok((command.clone(), cli.acp_args.clone()));
+    }
+    let command = resolve_zene_bin(cli.zene_bin.clone());
+    let args = if cli.acp_args.is_empty() {
+        vec!["acp".to_string()]
+    } else {
+        cli.acp_args.clone()
+    };
+    Ok((command, args))
+}
+
+fn ensure_bind_safe(bind: &str, allow_remote: bool) -> Result<()> {
+    let is_loopback = matches!(bind, "127.0.0.1" | "localhost" | "::1");
+    if !is_loopback && !allow_remote {
+        bail!(
+            "refusing to bind {bind}; pass --allow-remote for non-loopback addresses (TLS/auth required for production remote use)"
+        );
+    }
+    Ok(())
+}
+
+fn display_host(bind: &str) -> &str {
+    if bind == "0.0.0.0" || bind == "::" {
+        "127.0.0.1"
+    } else {
+        bind
+    }
+}

--- a/apps/gateway/src/static_page.rs
+++ b/apps/gateway/src/static_page.rs
@@ -1,0 +1,452 @@
+pub const INDEX_HTML: &str = r#"<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Zene Web Agent</title>
+  <style>
+    :root {
+      --bg: #f4efe6;
+      --ink: #1f1a14;
+      --muted: #6d6256;
+      --panel: rgba(255, 252, 246, 0.92);
+      --line: #d7ccbc;
+      --accent: #0f6a5b;
+      --accent-ink: #f7fffc;
+      --warn: #8a4b12;
+      --danger: #8b2430;
+      --ok: #1f6b3a;
+      --mono: "IBM Plex Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+      --sans: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      color: var(--ink);
+      font-family: var(--sans);
+      background:
+        radial-gradient(circle at top left, rgba(15, 106, 91, 0.12), transparent 40%),
+        linear-gradient(160deg, #f7f1e6 0%, #ebe2d2 48%, #f3efe7 100%);
+    }
+    main {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: 28px 18px 48px;
+      display: grid;
+      gap: 14px;
+    }
+    h1 {
+      margin: 0;
+      font-size: 1.7rem;
+      letter-spacing: 0.01em;
+    }
+    .sub {
+      color: var(--muted);
+      margin: 4px 0 0;
+      font-size: 0.95rem;
+    }
+    .card {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 14px;
+      backdrop-filter: blur(6px);
+    }
+    .row {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    label { font-size: 0.85rem; color: var(--muted); }
+    input, textarea, button {
+      font: inherit;
+    }
+    input, textarea {
+      width: 100%;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 10px 12px;
+      background: #fffdf8;
+      color: var(--ink);
+    }
+    textarea { min-height: 88px; resize: vertical; }
+    button {
+      border: 0;
+      border-radius: 8px;
+      padding: 9px 14px;
+      background: var(--accent);
+      color: var(--accent-ink);
+      cursor: pointer;
+    }
+    button.secondary {
+      background: transparent;
+      color: var(--ink);
+      border: 1px solid var(--line);
+    }
+    button.danger { background: var(--danger); color: #fff; }
+    button:disabled { opacity: 0.55; cursor: not-allowed; }
+    #log {
+      min-height: 320px;
+      max-height: 52vh;
+      overflow: auto;
+      font-family: var(--mono);
+      font-size: 0.84rem;
+      line-height: 1.45;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .msg { margin: 0 0 10px; }
+    .msg.user { color: var(--accent); }
+    .msg.assistant { color: var(--ink); }
+    .msg.thought { color: var(--muted); font-style: italic; }
+    .msg.system { color: var(--warn); }
+    .msg.tool { color: #355f7a; }
+    .pending {
+      border-left: 3px solid var(--warn);
+      padding-left: 10px;
+      margin: 10px 0;
+    }
+    .status {
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      color: var(--muted);
+    }
+    .ok { color: var(--ok); }
+    .err { color: var(--danger); }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>Zene</h1>
+      <p class="sub">Headless agent over HTTP long-polling ACP gateway</p>
+    </header>
+
+    <section class="card">
+      <div class="row" style="margin-bottom:10px">
+        <div style="flex:1; min-width:220px">
+          <label for="workspace">Workspace</label>
+          <input id="workspace" placeholder="/absolute/path/to/project" />
+        </div>
+        <div style="width:220px">
+          <label for="token">Token</label>
+          <input id="token" placeholder="from launch URL hash" />
+        </div>
+      </div>
+      <div class="row">
+        <button id="btnStart">Start agent</button>
+        <button id="btnCancel" class="secondary" disabled>Cancel turn</button>
+        <span id="status" class="status">idle</span>
+      </div>
+    </section>
+
+    <section class="card">
+      <div id="log"></div>
+    </section>
+
+    <section class="card">
+      <label for="prompt">Prompt</label>
+      <textarea id="prompt" placeholder="Ask Zene to inspect or change code…"></textarea>
+      <div class="row" style="margin-top:10px">
+        <button id="btnSend" disabled>Send</button>
+        <button id="btnClear" class="secondary">Clear log</button>
+      </div>
+    </section>
+  </main>
+  <script>
+    const state = {
+      token: "",
+      agentId: null,
+      sessionId: null,
+      cursor: 0,
+      nextRpcId: 1,
+      polling: false,
+      assistantBuf: "",
+      thoughtBuf: "",
+    };
+
+    const el = (id) => document.getElementById(id);
+    const logEl = el("log");
+    const statusEl = el("status");
+
+    function setStatus(text, cls) {
+      statusEl.textContent = text;
+      statusEl.className = "status " + (cls || "");
+    }
+
+    function appendLog(kind, text) {
+      const div = document.createElement("div");
+      div.className = "msg " + kind;
+      div.textContent = text;
+      logEl.appendChild(div);
+      logEl.scrollTop = logEl.scrollHeight;
+      return div;
+    }
+
+    function uuid() {
+      if (crypto.randomUUID) return crypto.randomUUID();
+      return "req-" + Math.random().toString(16).slice(2) + Date.now();
+    }
+
+    function tokenFromHash() {
+      const hash = new URLSearchParams(location.hash.replace(/^#/, ""));
+      return hash.get("token") || "";
+    }
+
+    async function api(path, options = {}) {
+      const headers = Object.assign({ "content-type": "application/json" }, options.headers || {});
+      if (state.token) headers["X-Zene-Token"] = state.token;
+      const res = await fetch(path, Object.assign({}, options, { headers }));
+      const text = await res.text();
+      let body = null;
+      try { body = text ? JSON.parse(text) : null; } catch (_) { body = { raw: text }; }
+      if (!res.ok) {
+        const msg = body && (body.message || body.error) || res.statusText;
+        throw new Error(msg);
+      }
+      return body;
+    }
+
+    async function postMessages(messages) {
+      return api(`/api/v1/agents/${state.agentId}/messages`, {
+        method: "POST",
+        body: JSON.stringify({ requestId: uuid(), messages }),
+      });
+    }
+
+    function rpcRequest(method, params) {
+      const id = state.nextRpcId++;
+      return { jsonrpc: "2.0", id, method, params };
+    }
+
+    function renderChunk(kind, text) {
+      if (!text) return;
+      if (kind === "assistant") {
+        state.assistantBuf += text;
+        let node = logEl.querySelector(".live-assistant");
+        if (!node) {
+          node = appendLog("assistant", "");
+          node.classList.add("live-assistant");
+        }
+        node.textContent = "assistant: " + state.assistantBuf;
+      } else if (kind === "thought") {
+        state.thoughtBuf += text;
+        let node = logEl.querySelector(".live-thought");
+        if (!node) {
+          node = appendLog("thought", "");
+          node.classList.add("live-thought");
+        }
+        node.textContent = "thought: " + state.thoughtBuf;
+      }
+    }
+
+    function finalizeStreams() {
+      const a = logEl.querySelector(".live-assistant");
+      if (a) a.classList.remove("live-assistant");
+      const t = logEl.querySelector(".live-thought");
+      if (t) t.classList.remove("live-thought");
+      state.assistantBuf = "";
+      state.thoughtBuf = "";
+    }
+
+    function handlePayload(payload) {
+      if (!payload || typeof payload !== "object") return;
+
+      if (payload.type === "gateway.system") {
+        appendLog("system", `[gateway:${payload.kind}] ${payload.message || ""}`);
+        return;
+      }
+
+      if (payload.method === "session/update") {
+        const update = payload.params && payload.params.update || {};
+        const sessionId = payload.params && payload.params.sessionId;
+        if (sessionId) state.sessionId = sessionId;
+        if (update.sessionUpdate === "agent_message_chunk") {
+          renderChunk("assistant", (update.content && update.content.text) || "");
+        } else if (update.sessionUpdate === "agent_thought_chunk") {
+          renderChunk("thought", (update.content && update.content.text) || "");
+        } else if (update.sessionUpdate === "tool_call" || update.sessionUpdate === "tool_call_update") {
+          finalizeStreams();
+          appendLog("tool", `${update.sessionUpdate}: ${update.title || update.toolCallId || "tool"}`);
+        } else {
+          appendLog("system", JSON.stringify(update));
+        }
+        return;
+      }
+
+      if (payload.method === "session/request_permission") {
+        finalizeStreams();
+        const params = payload.params || {};
+        const box = document.createElement("div");
+        box.className = "pending";
+        const title = document.createElement("div");
+        title.textContent = `Permission required: ${(params.toolCall && (params.toolCall.title || params.toolCall.toolCallId)) || "tool"}`;
+        box.appendChild(title);
+        const options = (params.options || []);
+        const row = document.createElement("div");
+        row.className = "row";
+        row.style.marginTop = "8px";
+        for (const opt of options) {
+          const btn = document.createElement("button");
+          btn.textContent = opt.name || opt.optionId;
+          if ((opt.kind || "").includes("reject") || /deny|reject|no/i.test(opt.optionId || "")) {
+            btn.className = "danger";
+          }
+          btn.onclick = async () => {
+            row.querySelectorAll("button").forEach((b) => b.disabled = true);
+            try {
+              await postMessages([{
+                jsonrpc: "2.0",
+                id: payload.id,
+                result: { outcome: { outcome: "selected", optionId: opt.optionId } },
+              }]);
+              appendLog("system", `permission -> ${opt.optionId}`);
+            } catch (err) {
+              appendLog("system", "permission reply failed: " + err.message);
+            }
+          };
+          row.appendChild(btn);
+        }
+        if (!options.length) {
+          const allow = document.createElement("button");
+          allow.textContent = "allow-once";
+          allow.onclick = async () => {
+            await postMessages([{
+              jsonrpc: "2.0",
+              id: payload.id,
+              result: { outcome: { outcome: "selected", optionId: "allow-once" } },
+            }]);
+          };
+          const deny = document.createElement("button");
+          deny.className = "danger";
+          deny.textContent = "reject";
+          deny.onclick = async () => {
+            await postMessages([{
+              jsonrpc: "2.0",
+              id: payload.id,
+              result: { outcome: { outcome: "selected", optionId: "reject" } },
+            }]);
+          };
+          row.appendChild(allow);
+          row.appendChild(deny);
+        }
+        box.appendChild(row);
+        logEl.appendChild(box);
+        logEl.scrollTop = logEl.scrollHeight;
+        return;
+      }
+
+      if (Object.prototype.hasOwnProperty.call(payload, "result") || Object.prototype.hasOwnProperty.call(payload, "error")) {
+        if (payload.result && payload.result.sessionId) {
+          state.sessionId = payload.result.sessionId;
+          appendLog("system", `session ready: ${state.sessionId}`);
+        } else if (payload.error) {
+          appendLog("system", `rpc error: ${JSON.stringify(payload.error)}`);
+        }
+        return;
+      }
+
+      appendLog("system", JSON.stringify(payload));
+    }
+
+    async function pollLoop() {
+      if (state.polling || !state.agentId) return;
+      state.polling = true;
+      while (state.agentId) {
+        try {
+          const qs = new URLSearchParams({
+            cursor: String(state.cursor),
+            waitMs: "25000",
+            limit: "100",
+          });
+          const body = await api(`/api/v1/agents/${state.agentId}/events?${qs}`);
+          for (const event of body.events || []) {
+            state.cursor = event.cursor;
+            handlePayload(event.payload);
+          }
+          if (body.hasMore) continue;
+        } catch (err) {
+          setStatus("poll error: " + err.message, "err");
+          await new Promise((r) => setTimeout(r, 1500));
+        }
+      }
+      state.polling = false;
+    }
+
+    async function startAgent() {
+      state.token = el("token").value.trim() || tokenFromHash();
+      el("token").value = state.token;
+      const workspace = el("workspace").value.trim();
+      if (!state.token) {
+        setStatus("token required", "err");
+        return;
+      }
+      if (!workspace) {
+        setStatus("workspace required", "err");
+        return;
+      }
+      setStatus("starting…");
+      const created = await api("/api/v1/agents", {
+        method: "POST",
+        body: JSON.stringify({ requestId: uuid(), workspace }),
+      });
+      state.agentId = created.agent.agentId;
+      state.cursor = 0;
+      appendLog("system", `agent ${state.agentId} @ ${created.agent.workspace}`);
+      pollLoop();
+
+      await postMessages([
+        rpcRequest("initialize", {
+          protocolVersion: 1,
+          clientCapabilities: {
+            fs: { readTextFile: true, writeTextFile: true },
+            terminal: true,
+          },
+          clientInfo: { name: "zene-web", version: "0.1.0" },
+        }),
+      ]);
+      await postMessages([
+        rpcRequest("session/new", {
+          cwd: workspace,
+          mcpServers: [],
+        }),
+      ]);
+      el("btnSend").disabled = false;
+      el("btnCancel").disabled = false;
+      setStatus("ready", "ok");
+    }
+
+    async function sendPrompt() {
+      const text = el("prompt").value.trim();
+      if (!text || !state.sessionId) return;
+      finalizeStreams();
+      appendLog("user", "user: " + text);
+      el("prompt").value = "";
+      await postMessages([
+        rpcRequest("session/prompt", {
+          sessionId: state.sessionId,
+          prompt: [{ type: "text", text }],
+        }),
+      ]);
+    }
+
+    async function cancelTurn() {
+      if (!state.sessionId) return;
+      await postMessages([
+        { jsonrpc: "2.0", method: "session/cancel", params: { sessionId: state.sessionId } },
+      ]);
+      appendLog("system", "cancel sent");
+    }
+
+    el("btnStart").onclick = () => startAgent().catch((err) => setStatus(err.message, "err"));
+    el("btnSend").onclick = () => sendPrompt().catch((err) => setStatus(err.message, "err"));
+    el("btnCancel").onclick = () => cancelTurn().catch((err) => setStatus(err.message, "err"));
+    el("btnClear").onclick = () => { logEl.innerHTML = ""; };
+    el("token").value = tokenFromHash();
+    setStatus(el("token").value ? "token loaded" : "waiting for token");
+  </script>
+</body>
+</html>
+"#;

--- a/apps/gateway/tests/gateway_http.rs
+++ b/apps/gateway/tests/gateway_http.rs
@@ -1,0 +1,365 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tempfile::tempdir;
+use zene_gateway::agent::AgentManager;
+use zene_gateway::auth::AuthState;
+use zene_gateway::http::{self, AppState};
+
+fn mock_acp_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_zene-gateway-mock-acp"))
+}
+
+async fn start_server(token: &str) -> (SocketAddr, reqwest::Client) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let agents = AgentManager::new(mock_acp_bin(), Vec::new());
+    let state = AppState {
+        auth: AuthState::new(token.to_string(), "127.0.0.1".into(), addr.port()),
+        agents,
+        started_at: chrono::Utc::now(),
+        version: "test",
+    };
+    let app = http::router(state);
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve");
+    });
+    let client = reqwest::Client::new();
+    (addr, client)
+}
+
+fn auth_json(token: &str) -> reqwest::header::HeaderMap {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert("X-Zene-Token", token.parse().unwrap());
+    headers.insert("content-type", "application/json".parse().unwrap());
+    headers
+}
+
+async fn wait_for_payload<F>(
+    client: &reqwest::Client,
+    addr: SocketAddr,
+    token: &str,
+    agent_id: &str,
+    cursor: &mut u64,
+    mut pred: F,
+) -> Value
+where
+    F: FnMut(&Value) -> bool,
+{
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let url = format!(
+            "http://{addr}/api/v1/agents/{agent_id}/events?cursor={cursor}&waitMs=500&limit=50"
+        );
+        let res = client
+            .get(url)
+            .header("X-Zene-Token", token)
+            .send()
+            .await
+            .expect("events");
+        assert!(res.status().is_success(), "events status {}", res.status());
+        let body: Value = res.json().await.expect("events json");
+        for event in body["events"].as_array().cloned().unwrap_or_default() {
+            *cursor = event["cursor"].as_u64().unwrap_or(*cursor);
+            let payload = event["payload"].clone();
+            if pred(&payload) {
+                return payload;
+            }
+        }
+        if tokio::time::Instant::now() > deadline {
+            panic!("timed out waiting for payload; cursor={cursor}");
+        }
+    }
+}
+
+#[tokio::test]
+async fn bootstrap_and_health_are_public() {
+    let token = "test-token";
+    let (addr, client) = start_server(token).await;
+
+    let boot: Value = client
+        .get(format!("http://{addr}/api/v1/bootstrap"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(boot["apiVersion"], "v1");
+    assert_eq!(boot["transports"]["longPolling"], true);
+    assert_eq!(boot["transports"]["websocket"], false);
+
+    let health: Value = client
+        .get(format!("http://{addr}/api/v1/health"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(health["ok"], true);
+}
+
+#[tokio::test]
+async fn rejects_missing_token_and_bad_origin() {
+    let token = "secret";
+    let (addr, client) = start_server(token).await;
+    let dir = tempdir().unwrap();
+
+    let res = client
+        .post(format!("http://{addr}/api/v1/agents"))
+        .header("content-type", "application/json")
+        .body(
+            json!({
+                "requestId": "r1",
+                "workspace": dir.path()
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let res = client
+        .post(format!("http://{addr}/api/v1/agents"))
+        .headers(auth_json(token))
+        .header("Origin", "http://evil.example")
+        .body(
+            json!({
+                "requestId": "r2",
+                "workspace": dir.path()
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), reqwest::StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn prompt_stream_and_permission_roundtrip() {
+    let token = "secret";
+    let (addr, client) = start_server(token).await;
+    let dir = tempdir().unwrap();
+
+    let created: Value = client
+        .post(format!("http://{addr}/api/v1/agents"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "create-1",
+            "workspace": dir.path()
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let agent_id = created["agent"]["agentId"].as_str().unwrap().to_string();
+    let mut cursor = 0u64;
+
+    // idempotent recreate
+    let created2: Value = client
+        .post(format!("http://{addr}/api/v1/agents"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "create-1",
+            "workspace": dir.path()
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(created2["agent"]["agentId"], created["agent"]["agentId"]);
+
+    let accepted = client
+        .post(format!("http://{addr}/api/v1/agents/{agent_id}/messages"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "m-init",
+            "messages": [{
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": 1,
+                    "clientCapabilities": {},
+                    "clientInfo": { "name": "test", "version": "0" }
+                }
+            }]
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(accepted.status(), reqwest::StatusCode::ACCEPTED);
+
+    let init = wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p.get("id") == Some(&json!(1)) && p.get("result").is_some()
+    })
+    .await;
+    assert_eq!(init["result"]["agentInfo"]["name"], "mock-acp");
+
+    client
+        .post(format!("http://{addr}/api/v1/agents/{agent_id}/messages"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "m-new",
+            "messages": [{
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": { "cwd": dir.path(), "mcpServers": [] }
+            }]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let session = wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p.get("id") == Some(&json!(2)) && p.get("result").is_some()
+    })
+    .await;
+    let session_id = session["result"]["sessionId"].as_str().unwrap().to_string();
+
+    client
+        .post(format!("http://{addr}/api/v1/agents/{agent_id}/messages"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "m-prompt",
+            "messages": [{
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{ "type": "text", "text": "NEED_PERMISSION hello" }]
+                }
+            }]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let permission = wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p.get("method") == Some(&json!("session/request_permission"))
+    })
+    .await;
+    assert_eq!(permission["id"], 9001);
+
+    client
+        .post(format!("http://{addr}/api/v1/agents/{agent_id}/messages"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "m-perm",
+            "messages": [{
+                "jsonrpc": "2.0",
+                "id": 9001,
+                "result": {
+                    "outcome": { "outcome": "selected", "optionId": "allow-once" }
+                }
+            }]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let assistant = wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p.get("method") == Some(&json!("session/update"))
+            && p["params"]["update"]["sessionUpdate"] == "agent_message_chunk"
+    })
+    .await;
+    assert!(assistant["params"]["update"]["content"]["text"]
+        .as_str()
+        .unwrap()
+        .contains("NEED_PERMISSION hello"));
+
+    let prompt_done = wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p.get("id") == Some(&json!(3)) && p.get("result").is_some()
+    })
+    .await;
+    assert_eq!(prompt_done["result"]["stopReason"], "end_turn");
+}
+
+#[tokio::test]
+async fn long_poll_waits_then_returns_event() {
+    let token = "secret";
+    let (addr, client) = start_server(token).await;
+    let dir = tempdir().unwrap();
+
+    let created: Value = client
+        .post(format!("http://{addr}/api/v1/agents"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "c-wait",
+            "workspace": dir.path()
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let agent_id = created["agent"]["agentId"].as_str().unwrap().to_string();
+
+    // Drain the agent_started system event first.
+    let mut cursor = 0u64;
+    let _ = wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p.get("type") == Some(&json!("gateway.system"))
+    })
+    .await;
+
+    let poll = tokio::spawn({
+        let client = client.clone();
+        let token = token.to_string();
+        let agent_id = agent_id.clone();
+        async move {
+            let url = format!(
+                "http://{addr}/api/v1/agents/{agent_id}/events?cursor={cursor}&waitMs=2000&limit=20"
+            );
+            let started = std::time::Instant::now();
+            let res = client
+                .get(url)
+                .header("X-Zene-Token", token)
+                .send()
+                .await
+                .unwrap();
+            let body: Value = res.json().await.unwrap();
+            (started.elapsed(), body)
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    client
+        .post(format!("http://{addr}/api/v1/agents/{agent_id}/messages"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "late-init",
+            "messages": [{
+                "jsonrpc": "2.0",
+                "id": 42,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": 1,
+                    "clientCapabilities": {},
+                    "clientInfo": { "name": "test", "version": "0" }
+                }
+            }]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let (elapsed, body) = poll.await.unwrap();
+    assert!(elapsed >= Duration::from_millis(150));
+    assert!(elapsed < Duration::from_secs(2));
+    let events = body["events"].as_array().unwrap();
+    assert!(events.iter().any(|e| e["payload"]["id"] == 42));
+}

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -171,6 +171,16 @@ Before/after compaction, checkpoints are saved under `~/.zene/sessions/<id>/comp
 
 Stdout is reserved for protocol frames; logs go to stderr.
 
+## HTTP Gateway (Web Agent)
+
+`zene-gateway` is a thin local HTTP adapter in front of `zene acp` (see `docs/WEB_AGENT_GATEWAY.md`):
+
+- Default bind: `127.0.0.1` with a generated `X-Zene-Token`
+- `POST /api/v1/agents/{id}/messages` forwards raw ACP JSON-RPC frames to the child stdin
+- `GET /api/v1/agents/{id}/events?cursor=&waitMs=` long-polls a cursored event journal fed by child stdout
+- WebSocket is intentionally not required; SSE is planned as an optional enhancement
+- The gateway does not own Agent loop / tools / sessions — those stay in Zene
+
 ## LLM layer
 
 - `OpenAiCompatibleProvider` (`crates/llm`) intentionally depends on [`unigateway-sdk`](https://crates.io/crates/unigateway-sdk) from **crates.io** (not a sibling path repo). It drives proxy chat via `UniGatewayEngine` (pools, retry, streaming).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -416,5 +416,6 @@ TUI、record/replay、安装分发。
 | P5 MCP/扩展 | [x] | stdio + HTTP MCP、`zene mcp doctor` |
 | P6 集成/产品化 | [x] | `zene -p` headless + `--output-format json`；`zene acp`（resume/queue/thought/terminal + modes/FS/tool updates） |
 | P7 沙箱产品化 | [x] | 可配置 Keel profile、egress allowlist、凭据 deny、SpaceFs、auto_allow_bash |
+| P8 Web Agent | [~] | Headless + HTTP Gateway 阶段 A：`zene-gateway` 长轮询 / token / Origin / 最小 Web 页；见 `docs/WEB_AGENT_GATEWAY.md` |
 
-*最后更新：2026-07-19（ACP session updates + P7 沙箱 + P1 续5 tiktoken-rs）*
+*最后更新：2026-07-20（Web Agent Gateway 阶段 A 垂直切片）*

--- a/docs/WEB_AGENT_GATEWAY.md
+++ b/docs/WEB_AGENT_GATEWAY.md
@@ -748,3 +748,26 @@ Gateway bootstrap 返回：
 5. 增加模拟 ACP 与真实 `zene acp` 的端到端测试。
 
 这个切片可以最早验证三个关键假设：标准 ACP 是否足够、无 WebSocket 的 HTTP 双向映射是否可靠、Gateway 是否能保持足够薄。验证通过后再建设完整 Web Agent UI，并按迁移门槛移除 TUI。
+
+## 21. 实施状态
+
+### 阶段 A（已落地骨架）
+
+- [x] 设计文档
+- [x] `apps/gateway` / 二进制 `zene-gateway`
+- [x] ACP 子进程管理与 NDJSON 转发
+- [x] `GET /api/v1/bootstrap`、`GET /api/v1/health`
+- [x] `POST /api/v1/agents`
+- [x] `POST /api/v1/agents/{id}/messages`（含 `requestId` 幂等）
+- [x] `GET /api/v1/agents/{id}/events` 长轮询 + cursor journal
+- [x] loopback 默认绑定、`X-Zene-Token`、Origin 校验
+- [x] 嵌入式最小 Web 页（session/new、prompt、stream、permission）
+- [x] `zene-gateway-mock-acp` + HTTP 集成测试
+
+### 下一刀（阶段 B）
+
+- [ ] 真实 `zene acp` 端到端 smoke（需 API key 或 mock LLM）
+- [ ] 独立 `apps/web-agent` 前端工程（替代嵌入 HTML）
+- [ ] session load/resume UI、tool/diff 卡片、usage/context
+- [ ] SSE 可选通道与自动降级
+- [ ] 多标签页 controller lease

--- a/docs/WEB_AGENT_GATEWAY.md
+++ b/docs/WEB_AGENT_GATEWAY.md
@@ -1,0 +1,750 @@
+# Zene Headless Agent 与 Web UI 优化方案
+
+## 1. 背景与决策
+
+Zene 的核心价值是本地 coding agent 引擎，而不是终端界面。当前引擎已经具备会话、上下文压缩、权限、工具、MCP、沙箱、后台任务、Plan 模式和标准 ACP 接口；现有 TUI 只覆盖其中一部分能力，继续独立维护会产生重复的交互实现和长期兼容成本。
+
+后续产品方向统一为：
+
+- Zene 作为 **Headless Agent Runtime**，不再承担复杂 UI。
+- Web Agent UI 成为主要交互界面。
+- Web UI 与 Zene 之间只通过标准 ACP 语义通信，不引入 `x.ai/*` 私有扩展。
+- 增加一个职责严格受限的本地 HTTP Gateway，负责 Web 与 ACP stdio 之间的传输适配。
+- HTTP 长轮询作为默认实时通道，SSE 作为可选增强，普通短轮询作为最终降级；WebSocket 不作为首选或必需能力。
+- Web 功能达到迁移门槛后删除 TUI 代码和依赖，保留 headless、ACP 和必要的命令行运维入口。
+
+目标拓扑：
+
+```text
+┌──────────────────────┐
+│      Web Agent UI    │
+│ chat / plan / diff   │
+│ tasks / sessions     │
+└──────────┬───────────┘
+           │ same-origin HTTP
+           │ POST + long polling
+           │ optional SSE
+┌──────────▼───────────┐
+│  Local HTTP Gateway  │
+│ auth / event journal │
+│ process supervision  │
+│ ACP transport bridge │
+└──────────┬───────────┘
+           │ stdin/stdout NDJSON JSON-RPC
+┌──────────▼───────────┐
+│   zene acp process   │
+│ Agent / tools / MCP  │
+│ session / sandbox    │
+└──────────────────────┘
+```
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+1. 让浏览器在不依赖 WebSocket 的环境中稳定使用 Zene。
+2. 保持 Zene core 与 Web 技术栈解耦，使同一个 runtime 仍可被 IDE、桌面端和其他 ACP 客户端复用。
+3. 支持消息流、reasoning、工具调用、权限审批、Plan、会话恢复、取消、prompt 队列、后台任务和 terminal 等完整 agent 交互。
+4. 支持页面刷新、网络中断和 Gateway 重启后的可恢复交互。
+5. 默认只暴露本机最小权限，并明确远程访问的安全边界。
+6. 删除无人维护的 TUI，减少 `ratatui`、`crossterm` 和双套交互状态机的维护成本。
+
+### 2.2 非目标
+
+- 不把 Agent loop、工具执行或会话逻辑迁入 Gateway。
+- 不让浏览器直接访问本地文件系统、PTY 或 Zene 子进程。
+- 不把 ACP 替换成自定义 Agent 协议。
+- 不要求本地默认配置 TLS 证书。
+- 不在第一阶段建设云端多租户控制平面、账号系统或远程托管 Agent。
+- 不实现 `x.ai/*` 私有 ACP 扩展。
+
+## 3. 设计原则
+
+### 3.1 单一业务真相
+
+会话、消息、权限、工具状态和模式的业务真相属于 Zene。Gateway 可以缓存和投递事件，但不能自行推断 Agent 状态或复制 Agent loop。
+
+### 3.2 ACP 语义不变
+
+Gateway 只改变传输方式。HTTP 请求中的 ACP 消息应保持 JSON-RPC 字段和标准 ACP 方法名，使协议升级可以独立于 UI 迭代。
+
+### 3.3 默认 HTTP，可渐进增强
+
+所有核心流程必须在长轮询下可用。SSE 只能降低延迟和请求数量，不能成为正确性的前提。WebSocket 可以以后作为可选 adapter 增加，但不得成为唯一通道。
+
+### 3.4 本地优先和最小暴露
+
+默认监听 `127.0.0.1`，Gateway 与 Web 静态资源同源。远程监听必须显式开启，并要求 TLS、强认证和更严格的工作区策略。
+
+### 3.5 可恢复而不是假定长连接可靠
+
+每个下行事件都必须有单调递增的游标。浏览器重连时从最后确认的游标继续读取，不依赖某条 TCP 连接持续存在。
+
+## 4. 组件职责
+
+### 4.1 Zene Headless Runtime
+
+继续由现有 Rust workspace 提供：
+
+- `crates/core`：Agent turn loop、上下文管理、compaction、Plan、steer、subagent 和事件。
+- `crates/llm`：OpenAI-compatible、Anthropic、流式输出、reasoning 和重试分类。
+- `crates/tools`：文件、搜索、Shell、Todo、Task、AskUser 等工具。
+- `crates/sandbox`：Keel profile、路径限制、网络出口控制。
+- `crates/session`：会话、checkpoint、record、todo 和持久化。
+- `crates/mcp`：stdio/HTTP MCP 客户端。
+- `apps/cli`：`zene acp`、`zene -p`、诊断和配置入口。
+
+Zene 通过 stdin/stdout NDJSON JSON-RPC 运行 ACP。stdout 只输出协议帧，日志写入 stderr。
+
+### 4.2 Local HTTP Gateway
+
+Gateway 只负责：
+
+- 托管编译后的 Web 静态资源。
+- 创建、复用、监控和终止 `zene acp` 子进程。
+- 在 HTTP envelope 与 ACP NDJSON 帧之间双向转发。
+- 维护连接、请求相关性、事件序号和短期事件日志。
+- 实现长轮询、可选 SSE 和短轮询降级。
+- 承担浏览器侧 ACP client capabilities，例如权限回复、terminal UI 桥接和可选 FS 桥接。
+- 执行 loopback token、Origin、CSRF、工作区和远程访问控制。
+- 暴露健康检查与本地诊断信息。
+
+Gateway 不应：
+
+- 解析模型输出或修改 tool call。
+- 替 Zene 决定权限结果。
+- 直接写入 Zene session 文件。
+- 保存 API key 到浏览器。
+- 在 HTTP API 中重新定义一套与 ACP 平行的 Agent 消息模型。
+
+### 4.3 Web Agent UI
+
+Web UI 负责纯交互状态：
+
+- 会话列表、创建、恢复、关闭和切换。
+- 用户输入、prompt 队列、取消与 steer。
+- assistant message 和 thought 的增量渲染。
+- tool call 生命周期、参数、结果、diff 和错误展示。
+- 权限、AskUser 和 Plan 审批。
+- Todo、后台任务、usage、context 水位和模式展示。
+- terminal 输出展示与输入交互。
+- 断线、重连、过期游标和 Agent 崩溃提示。
+
+浏览器不得持有可直接绕过 Gateway 的文件或执行权限。
+
+## 5. 进程与会话模型
+
+### 5.1 推荐模型
+
+第一版采用“一个 Gateway 管理一个或多个 `zene acp` 进程”：
+
+- 一个 ACP 进程可管理多个 Zene session。
+- Gateway 为每个进程分配稳定的 `agentId`。
+- Web session 通过 `agentId + sessionId` 定位。
+- 不同 workspace 默认使用不同 ACP 进程，避免 cwd、sandbox 和配置边界混杂。
+- 同一 workspace 内可以复用 ACP 进程，减少启动成本。
+
+后续若发现单进程多 session 存在隔离或阻塞问题，可以切换为“一 workspace 一进程”或“一活跃 session 一进程”，HTTP API 不需要变化。
+
+### 5.2 生命周期
+
+```text
+Gateway 启动
+  → 生成启动 token
+  → 监听 loopback
+  → 浏览器打开 Gateway 首页
+  → POST 创建/附加 workspace agent
+  → Gateway 启动 zene acp
+  → ACP initialize
+  → session/new、session/load 或 session/resume
+  → 浏览器持续读取事件
+```
+
+子进程退出时，Gateway 必须产生明确的本地系统事件，包含退出码、是否可重启和 stderr 尾部摘要。Gateway 不应静默自动重放未确认的 prompt；只有具备幂等键且确认 Zene 未接收时才能自动重试。
+
+## 6. HTTP 传输设计
+
+### 6.1 基础约定
+
+- API 前缀：`/api/v1`
+- 内容类型：`application/json`
+- 字符编码：UTF-8
+- 所有写请求包含 `X-Zene-Token`
+- 所有写请求包含 `requestId`，推荐 UUID。
+- 所有响应包含 `serverTime` 和可用于诊断的 `traceId`。
+- ACP payload 保持原始 JSON-RPC 结构，不改变 method 和 params。
+
+### 6.2 核心端点
+
+#### 启动信息
+
+```http
+GET /api/v1/bootstrap
+```
+
+返回 Gateway 版本、协议版本、传输能力、认证状态、轮询建议和 Web 构建版本。不得返回明文 API key 或完整环境变量。
+
+#### 创建或附加 Agent
+
+```http
+POST /api/v1/agents
+```
+
+请求：
+
+```json
+{
+  "requestId": "uuid",
+  "workspace": "/absolute/path",
+  "sandboxProfile": "workspace"
+}
+```
+
+返回 `agentId`、进程状态和 ACP initialize 状态。路径必须经过允许目录、规范化和符号链接边界检查。
+
+#### 发送 ACP 帧
+
+```http
+POST /api/v1/agents/{agentId}/messages
+```
+
+请求：
+
+```json
+{
+  "requestId": "uuid",
+  "messages": [
+    {
+      "jsonrpc": "2.0",
+      "id": 12,
+      "method": "session/prompt",
+      "params": {
+        "sessionId": "session-id",
+        "prompt": [
+          { "type": "text", "text": "修复测试" }
+        ]
+      }
+    }
+  ]
+}
+```
+
+该接口接受 ACP request、notification，以及浏览器对 Zene 反向 request 的 JSON-RPC response。HTTP 202 只表示 Gateway 已接收，不表示 Agent 操作完成；业务结果通过事件通道返回。
+
+#### 默认长轮询
+
+```http
+GET /api/v1/agents/{agentId}/events?cursor=123&waitMs=25000&limit=200
+```
+
+返回：
+
+```json
+{
+  "events": [
+    {
+      "cursor": 124,
+      "createdAt": "2026-07-20T05:00:00Z",
+      "payload": {
+        "jsonrpc": "2.0",
+        "method": "session/update",
+        "params": {}
+      }
+    }
+  ],
+  "nextCursor": 124,
+  "hasMore": false,
+  "agentState": "running"
+}
+```
+
+行为约束：
+
+- 有新事件时立即返回。
+- 无事件时最多等待 `waitMs`，随后返回空数组。
+- `limit` 到达时设置 `hasMore=true`，客户端立即继续读取。
+- 客户端必须保存最后完整处理的 cursor，而不是最后接收的 cursor。
+- 同一浏览器标签只保持一个长轮询请求，避免重复消费和代理压力。
+
+#### 可选 SSE
+
+```http
+GET /api/v1/agents/{agentId}/events/stream?cursor=123
+Accept: text/event-stream
+```
+
+SSE 每条事件携带 `id: <cursor>`，支持 `Last-Event-ID`。Gateway 需要发送心跳，并禁用反向代理缓冲。SSE 断开后客户端立即退回长轮询，不应阻塞用户操作。
+
+#### 普通短轮询降级
+
+仍使用 events 接口，但设置 `waitMs=0`，由客户端根据状态采用退避：
+
+- Agent 活跃：250–1000ms。
+- Agent 空闲：2–5s。
+- 页面后台：5–15s。
+- 网络错误：指数退避并增加抖动，上限 30s。
+
+#### 健康检查
+
+```http
+GET /api/v1/health
+GET /api/v1/agents/{agentId}/health
+```
+
+全局健康检查只表示 Gateway 可服务；Agent 健康检查另外返回子进程、ACP initialize、事件队列和最近心跳状态。
+
+### 6.3 为什么不直接使用 REST 业务模型
+
+可以为创建 Agent、健康检查等 Gateway 自身能力使用 REST，但 Agent 操作应继续携带 ACP JSON-RPC。若为 prompt、permission、tool、plan 各设计一套 REST 模型，会形成第三套协议：
+
+```text
+Web REST 模型 ↔ Gateway 内部模型 ↔ ACP ↔ Zene 模型
+```
+
+这会增加字段漂移、版本兼容和重复测试成本。推荐保持：
+
+```text
+HTTP envelope ↔ 原始 ACP frame
+```
+
+## 7. ACP 双向请求映射
+
+ACP 不只是服务器推送通知；Zene 还会向客户端发起 request，例如 `session/request_permission`。HTTP 是客户端发起式协议，因此 Gateway 必须把反向 request 写入事件日志：
+
+```text
+Zene stdout: request id=88
+  → Gateway event cursor=301
+  → Browser polling receives request id=88
+  → User approves
+  → Browser POSTs JSON-RPC response id=88
+  → Gateway writes response to Zene stdin
+```
+
+规则：
+
+- Gateway 维护 `(agentId, jsonRpcId)` pending map。
+- 相同 id 的重复 response 必须幂等处理。
+- pending request 超时由 Zene 或协议语义决定，Gateway 只报告超时，不擅自批准。
+- 浏览器刷新后必须能通过事件日志重新获得尚未回复的 request。
+- 多标签页同时打开时，仅持有 lease 的控制端可以回复权限和 AskUser；其他标签页只读。
+
+## 8. 事件日志、重连与一致性
+
+### 8.1 事件游标
+
+Gateway 为每个 `agentId` 维护 64 位单调递增 cursor。cursor 是 HTTP 传输元数据，不写入 ACP payload。
+
+事件至少保留：
+
+- 最近 10,000 条；或
+- 最近 30 分钟；或
+- 当前所有未完成反向 request 所需事件；
+
+三者取更安全的范围。具体默认值应可配置。
+
+### 8.2 过期游标
+
+若客户端 cursor 早于最老事件，返回 HTTP 409：
+
+```json
+{
+  "error": "cursor_expired",
+  "oldestCursor": 500,
+  "latestCursor": 900,
+  "recovery": "reload_session"
+}
+```
+
+Web UI 随后调用 ACP `session/load` 重建 transcript，再从最新 cursor 继续。不要尝试凭 UI 本地缓存猜测缺失 tool state。
+
+### 8.3 幂等
+
+- Gateway 对写请求按 `requestId` 保存短期结果。
+- 重复 `requestId` 返回第一次的接收结果，不重复写入 Zene stdin。
+- `session/prompt` 的自动重试必须特别保守，防止同一用户输入执行两次。
+- JSON-RPC id 由 Web client 在单个 Agent 范围内保证唯一。
+
+### 8.4 多标签页控制权
+
+推荐使用带过期时间的 `controllerLease`：
+
+- 第一个活跃标签页获得可写 lease。
+- 其他标签页可以读取事件，但发送 prompt、cancel 或审批时收到冲突提示。
+- lease 定期续约，页面关闭或失联后自动释放。
+- 用户可以显式“接管”，旧页面收到控制权变化事件。
+
+## 9. Web UI 信息架构
+
+### 9.1 主界面
+
+建议至少包含：
+
+- **会话导航**：workspace、session、运行状态和最近活动。
+- **主 scrollback**：user、assistant、thought、tool、system event。
+- **composer**：多行输入、队列、发送、取消、steer 和模式切换。
+- **上下文状态**：模型、token usage、context 水位、permission mode。
+- **辅助面板**：Plan、Todo、后台任务、terminal 和文件 diff。
+
+### 9.2 消息与 thought
+
+- assistant message 按 `agent_message_chunk` 增量拼接。
+- thought 按 `agent_thought_chunk` 单独显示，默认折叠并明确标识。
+- 页面刷新后通过 `session/load` 重建历史；若持久化记录不含 thought，不应伪造。
+- Markdown 渲染必须进行 HTML sanitization，禁止模型输出注入脚本。
+- 代码块支持复制，后续再增加语法高亮和文件跳转。
+
+### 9.3 Tool call
+
+工具卡片按 `toolCallId` 更新：
+
+```text
+pending → in_progress → completed | failed
+```
+
+卡片应展示工具名、关键参数、持续时间、输出摘要和错误。Read/Grep 默认折叠；Bash 提供流式输出或 terminal 跳转；Edit/Write 优先展示 diff。大结果只展示摘要，并允许通过受控接口读取 spill 文件。
+
+### 9.4 权限与 AskUser
+
+- 权限 request 使用阻塞式但不锁死全页面的审批卡片。
+- 明确展示工具、参数、workspace、风险和可选项。
+- “始终允许”必须对应 ACP 返回的具体 option，不由 UI 自行扩大权限。
+- AskUser 支持单选、多选和自由文本；断线重连后仍可继续回复。
+- 同时存在多个待回复 request 时按创建时间排列。
+
+### 9.5 Plan
+
+- 显示当前模式和 Plan 状态。
+- Plan 内容作为独立可滚动面板，而不是普通聊天文本。
+- 支持批准、拒绝和附加修改意见。
+- Plan 模式下明确标示只读约束。
+- 第一版通过标准 ACP mode/update 和现有工具事件实现；标准 ACP 未表达的高级逐行批注暂不私有扩展，可转换为普通用户反馈。
+
+### 9.6 Prompt 队列与取消
+
+- Agent 运行时发送的新 prompt 明确进入 FIFO 队列。
+- UI 展示队列顺序，允许取消尚未执行的本地草稿。
+- `session/cancel` 只取消当前 turn，不隐式清空队列。
+- steer 与“取消后立即发送”必须在文案和操作上区分。
+
+### 9.7 Todo 与后台任务
+
+- Todo 面板按 ACP `plan` 更新展示状态。
+- 后台 Bash/Task 展示 running/completed/failed、启动时间和摘要。
+- kill 操作通过 Agent 工具或标准能力发起，Gateway 不直接 kill 工具子进程。
+- 若当前标准 ACP 事件不足，应优先把 Zene 内部状态映射到标准 `tool_call_update`/`plan`，而不是增加供应商字段。
+
+### 9.8 Terminal
+
+ACP terminal capability 由 Gateway 实现，Web UI 只是远程视图：
+
+- Gateway 创建并管理 PTY/进程资源。
+- 浏览器通过 HTTP 提交输入、resize、kill 和 release 意图。
+- 输出进入统一事件日志，可通过 cursor 恢复。
+- 每个 terminal 有独立资源 ID、输出 offset 和最大保留量。
+- ANSI 渲染必须使用安全解析器，禁止 OSC 52 等敏感控制序列默认生效。
+- terminal 创建、命令和 workspace 必须受 sandbox 与 permission 控制。
+
+## 10. 安全模型
+
+### 10.1 默认本地模式
+
+- 只监听 `127.0.0.1` 和可选 `::1`。
+- 启动时生成高熵随机 token。
+- token 放入启动 URL fragment 或一次性 exchange 流程，避免长期出现在访问日志。
+- Web UI 与 API 由同一 Gateway origin 提供。
+- 校验 `Origin`/`Host`，防止恶意网页对 localhost 发起跨站请求。
+- 使用严格 CSP、`frame-ancestors 'none'`、`X-Content-Type-Options: nosniff`。
+- Cookie 若被采用，必须 `HttpOnly`、`SameSite=Strict`；写请求还需 CSRF 防护。
+
+### 10.2 本地 HTTP 与 HTTPS
+
+loopback 默认使用 HTTP，原因是本地自签证书会引入生成、信任、更新和跨平台问题。Gateway 同源托管 Web UI，因此不会发生 HTTPS 页面访问 HTTP localhost 的 mixed-content 问题。
+
+只有以下场景启用 HTTPS：
+
+- 监听非 loopback 地址。
+- 通过局域网或远程主机访问。
+- 由可信反向代理终止 TLS。
+
+远程模式必须显式配置证书或反向代理，并启用强认证；不允许仅凭“隐藏端口”或固定弱 token 暴露 Agent。
+
+### 10.3 Workspace 与文件权限
+
+- 创建 Agent 时必须对 workspace 做 canonicalize。
+- 默认只允许启动命令显式给出的根目录及其子目录。
+- 拒绝通过符号链接逃逸允许目录。
+- Gateway 不提供任意路径文件 API。
+- Agent 的真实文件访问继续经过 Zene sandbox/path policy。
+- 浏览器下载工具输出时，只能通过不透明资源 ID，不能提交任意本地路径。
+
+### 10.4 Secret
+
+- LLM key 只存在于 Zene 配置或 Gateway 进程环境，不发送到浏览器。
+- bootstrap、health、错误和日志必须清理 Authorization、Cookie、env 和命令敏感参数。
+- Web localStorage 不保存长期访问 token；优先内存或受限 session storage。
+
+## 11. Gateway 模块建议
+
+建议新增独立 Rust crate，避免把 HTTP 依赖扩散到 core：
+
+```text
+apps/gateway/
+  src/
+    main.rs           # CLI 与启动
+    http.rs           # router、middleware、静态资源
+    agent_manager.rs  # zene acp 子进程生命周期
+    acp_transport.rs  # NDJSON 读写与 JSON-RPC 相关性
+    event_journal.rs  # cursor、保留、长轮询通知
+    auth.rs           # token、Origin、lease
+    terminal.rs       # ACP terminal client capability
+    diagnostics.rs    # health、受控日志
+```
+
+如果希望只发布单一二进制，也可以最终将 Gateway 作为 `zene web` 子命令编译进 `apps/cli`。内部仍应保持独立模块边界，且通过启动独立 `zene acp` 子进程维持协议隔离。第一版推荐独立 `zene-gateway` 二进制，便于故障隔离和测试。
+
+Web 项目建议从当前静态占位目录中分离：
+
+```text
+apps/web-agent/
+  src/
+  public/
+  package.json
+```
+
+构建产物可嵌入 Gateway 二进制或随 release 一起分发。开发模式允许 Gateway 代理前端 dev server，但发布模式必须同源托管。
+
+## 12. 可观测性与诊断
+
+Gateway 应提供结构化日志，但默认不记录 prompt、模型输出、文件内容和完整命令。建议字段：
+
+- `traceId`
+- `agentId`
+- `sessionId`（可截断）
+- `requestId`
+- ACP method
+- HTTP 状态码
+- 处理耗时
+- 子进程状态
+- 当前/最老 event cursor
+- pending request 数量
+
+关键指标：
+
+- 长轮询请求数、平均等待时间和超时比例。
+- SSE 活跃连接与降级次数。
+- event journal 条数、字节数和 cursor 过期次数。
+- ACP stdin 队列深度和 stdout 解析错误。
+- Agent 重启与异常退出次数。
+- permission/AskUser 等待时长。
+
+诊断包必须显式由用户触发并在导出前脱敏。
+
+## 13. 背压与资源限制
+
+- 限制单个 POST body、单条 ACP frame 和批量 message 数量。
+- Zene stdout 读取与 journal 写入不得被慢浏览器阻塞。
+- journal 使用有界内存；大 terminal/tool 输出落盘或截断。
+- 长轮询 `limit` 防止一次响应过大。
+- 每个 agent 限制并发 poll 数；异常客户端触发 429。
+- stdin 写入使用有界队列，满时返回明确的 backpressure 错误。
+- Gateway 关闭时停止接受写请求，等待已接收 frame 写入，再终止或保留 Agent。
+
+推荐初始限制：
+
+| 项目 | 默认值 |
+|------|--------|
+| POST body | 1 MiB |
+| 单次 messages | 100 |
+| 长轮询等待 | 25s |
+| 单次事件数 | 200 |
+| journal 事件数 | 10,000/agent |
+| journal 保留时间 | 30min |
+| 并发 poll | 2/agent/client |
+| stderr 尾部 | 64 KiB |
+
+限制应可配置，并在 bootstrap 中返回客户端需要知道的部分。
+
+## 14. 错误模型
+
+Gateway 错误与 ACP 错误必须区分：
+
+- HTTP 4xx/5xx：认证、路径、限流、Agent 不存在、cursor 过期或 Gateway 故障。
+- HTTP 202 + 后续 JSON-RPC error：ACP 方法执行失败。
+- 本地系统事件：子进程退出、传输损坏或 Gateway 正在关闭。
+
+推荐 Gateway 错误体：
+
+```json
+{
+  "error": "agent_not_running",
+  "message": "Zene ACP process is not running",
+  "traceId": "trace-id",
+  "retryable": true
+}
+```
+
+Web UI 不应把所有失败都显示成“网络错误”，应区分可重试传输错误、ACP 业务错误和需要用户介入的安全错误。
+
+## 15. TUI 删除与命令行边界
+
+最终删除：
+
+- `apps/cli/src/tui/`
+- TUI 启动参数与默认启动分支。
+- `ratatui`、`crossterm` 及仅为 TUI 使用的依赖。
+- TUI 专用 permission/AskUser adapter、渲染代码和测试。
+
+保留：
+
+- `zene acp`：标准集成入口。
+- `zene -p`：脚本和 CI headless 入口。
+- `zene mcp doctor`、配置检查和必要诊断命令。
+- 可选的基础 REPL，前提是其维护成本低且明确标注为调试入口；若仍复制权限、session 和渲染逻辑，也应一并移除。
+
+Web 未达到最低迁移门槛前不要先删除 TUI。最低门槛见第 17 节。
+
+## 16. 分阶段实施
+
+### 阶段 A：协议与 Gateway 骨架
+
+- 固化 Web 所需的标准 ACP capability 清单。
+- 新增 Gateway 进程管理和 NDJSON bridge。
+- 实现 bootstrap、agents、messages、health。
+- 实现有游标的长轮询和内存 event journal。
+- 实现 token、Origin 和 loopback 限制。
+- 用模拟 ACP 子进程做双向 JSON-RPC 集成测试。
+
+完成标准：浏览器或测试客户端可以 initialize、创建 session、发送 prompt、接收 streaming update 并响应 permission request。
+
+### 阶段 B：Web 最小可用界面
+
+- 会话创建/恢复。
+- Chat streaming 和 thought 折叠。
+- tool call/update 与基础 diff。
+- 权限和 AskUser。
+- cancel、prompt queue、模式和 usage。
+- 网络断开/刷新恢复。
+
+完成标准：真实项目中不依赖 TUI 完成“提出任务 → 审批 → 修改 → 测试 → 查看结果”。
+
+### 阶段 C：Agent 工作面
+
+- Plan 审阅。
+- Todo 和后台任务面板。
+- terminal bridge。
+- session 列表、关闭、恢复和 workspace 切换。
+- SSE 增强与自动降级。
+- 多标签 controller lease。
+
+完成标准：现有 TUI 能力全部覆盖，并完整展示当前 Zene 引擎已有的重要状态。
+
+### 阶段 D：可靠性与发布
+
+- Gateway 重启和 Agent 崩溃恢复。
+- journal 持久化策略评估。
+- 负载、背压、超大 tool output 测试。
+- 浏览器兼容和代理环境测试。
+- 单二进制或配套产物发布。
+- 安全文档、配置文档和升级指南。
+
+### 阶段 E：删除 TUI
+
+- 将默认交互入口切到 `zene web` 或 `zene-gateway`。
+- 删除 TUI 代码、参数、依赖、文档和 CI 路径。
+- 保留一版迁移说明。
+- 验证 headless、ACP、Gateway 和 release 构建。
+
+## 17. 测试与验收标准
+
+### 17.1 Gateway 自动化测试
+
+- NDJSON 分帧：半帧、多帧、超长帧、非法 JSON。
+- JSON-RPC request/response/notification 双向相关性。
+- 重复 `requestId` 不重复写 stdin。
+- 长轮询立即返回、等待超时、limit 和并发 poll。
+- cursor 重连、重复读取、过期恢复。
+- pending permission 在页面刷新后仍可回复。
+- Agent 正常退出、崩溃、stderr 过大和启动超时。
+- Origin、token、路径逃逸、符号链接和限流。
+- journal 背压及 terminal 大输出。
+
+### 17.2 Web 自动化测试
+
+- streaming chunk 正确合并且不重复。
+- tool card 按 `toolCallId` 更新。
+- markdown/XSS sanitization。
+- permission、AskUser 和 Plan 交互。
+- prompt queue、cancel 和 steer 的行为差异。
+- 断网、恢复、cursor 过期和 Agent 重启。
+- 长轮询、SSE 断开降级和短轮询 fallback。
+
+### 17.3 端到端场景
+
+1. 启动 Gateway，创建 workspace Agent 和 session。
+2. 请求读取、编辑并测试一个真实项目。
+3. 在 Bash permission 出现时刷新页面，恢复后批准。
+4. 执行期间提交第二个 prompt，确认进入队列。
+5. 取消当前 turn，确认队列与 session 状态符合定义。
+6. 观察 thought、tool、diff、usage 和 Plan 更新。
+7. 运行后台任务并从面板读取结果。
+8. 断开事件通道后重连，确认无丢失、无重复显示。
+9. 强制结束 Zene 子进程，确认 UI 明确报告并可恢复。
+10. 在禁止 WebSocket 的代理环境中只用 HTTP 完成全过程。
+
+### 17.4 删除 TUI 的硬性门槛
+
+只有同时满足以下条件才删除 TUI：
+
+- Web 可完成 session new/load/resume/close。
+- 支持 prompt、streaming、cancel 和队列。
+- 支持 permission 与 AskUser。
+- 支持 tool call/update 和 Edit/Write diff。
+- 展示 Plan、mode、usage/context 和关键错误。
+- 页面刷新不会丢失当前审批或破坏 session。
+- 无 SSE/WebSocket 时长轮询完整可用。
+- Gateway 默认安全绑定 loopback，并通过 Origin/token 测试。
+- 至少 Linux 和 macOS release 路径验证通过。
+
+## 18. 兼容性与版本管理
+
+Gateway bootstrap 返回：
+
+- Gateway API version。
+- 支持的传输方式。
+- ACP protocol version。
+- Zene runtime version。
+- Web build version。
+
+兼容策略：
+
+- `/api/v1` 内只做向后兼容字段增加。
+- 破坏性 HTTP envelope 变化使用 `/api/v2`。
+- ACP capability 通过 `initialize` 协商，不由 Gateway 硬编码猜测。
+- Web 发现 runtime capability 缺失时隐藏对应功能并显示明确说明。
+- Gateway 与 Web 推荐同版本发布，Gateway 与 Zene runtime 允许在声明的兼容区间内独立升级。
+
+## 19. 主要风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| HTTP 双向语义比 WebSocket 复杂 | 统一 event journal；所有反向 request 也作为事件；POST 回传 response |
+| 长轮询产生额外请求 | 25s 等待、keep-alive、活跃/空闲退避；可选 SSE |
+| 浏览器刷新导致审批丢失 | pending request 进入 journal，使用 cursor 重放 |
+| 多标签重复操作 | controller lease + 幂等 requestId |
+| 本地服务遭恶意网页攻击 | loopback token、Origin/Host、CSRF、CSP |
+| tool/terminal 输出耗尽内存 | 有界 journal、spill、截断和背压 |
+| Gateway 逐渐承载业务逻辑 | 明确模块边界；ACP payload 透明；业务测试留在 Zene |
+| 提前删除 TUI 导致不可用 | 达到第 17.4 节门槛后再删除 |
+| 本地 HTTPS 配置复杂 | loopback 同源 HTTP；远程模式才强制 TLS |
+
+## 20. 推荐的首个交付切片
+
+首个 PR 不应同时引入完整 Web UI。建议最小垂直切片：
+
+1. 新增 `zene-gateway`。
+2. Gateway 启动一个 `zene acp`。
+3. 实现 token、Origin、`POST /messages` 和 `GET /events` 长轮询。
+4. 用一个极简静态页面完成 session/new、session/prompt、消息流和 permission 回复。
+5. 增加模拟 ACP 与真实 `zene acp` 的端到端测试。
+
+这个切片可以最早验证三个关键假设：标准 ACP 是否足够、无 WebSocket 的 HTTP 双向映射是否可靠、Gateway 是否能保持足够薄。验证通过后再建设完整 Web Agent UI，并按迁移门槛移除 TUI。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

按 `docs/WEB_AGENT_GATEWAY.md` 开始落地 Headless Web Agent 方向的**阶段 A 垂直切片**：新增薄本地 HTTP Gateway，默认长轮询，不依赖 WebSocket。

## 变更

- 新增 `apps/gateway` / 二进制 `zene-gateway`
- 启动 ACP 子进程（默认 `zene acp`，测试可用 `zene-gateway-mock-acp`）
- HTTP API：
  - `GET /api/v1/bootstrap`、`GET /api/v1/health`
  - `POST /api/v1/agents`
  - `POST /api/v1/agents/{id}/messages`（`requestId` 幂等）
  - `GET /api/v1/agents/{id}/events?cursor=&waitMs=` 长轮询事件日志
- 默认 `127.0.0.1`、`X-Zene-Token`、Origin 校验
- 嵌入式最小 Web 页：session/new、prompt 流式输出、permission 回复
- mock ACP 集成测试覆盖鉴权、长轮询等待、prompt/permission 往返
- 更新 README / CHANGELOG / ROADMAP / ENGINE / AGENTS

## 使用

```bash
cargo run -p zene-cli --bin zene
cargo run -p zene-gateway -- --zene-bin ./target/debug/zene
# 打开打印的 http://127.0.0.1:8787/#token=... 
```

## 测试

- `cargo test -p zene-gateway`
- `cargo check -p zene-cli --bin zene`

## 后续

阶段 B：真实 `zene acp` smoke、独立 Web 前端、tool/diff/session UI、可选 SSE。达到文档门槛后再删除 TUI。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab3880ba-03bb-4b7f-a564-692c1685708d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab3880ba-03bb-4b7f-a564-692c1685708d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

