### PR TITLE
feat(gateway): Web Agent 阶段 C（Plan/Todo/Terminal）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Headless Web direction: `docs/WEB_AGENT_GATEWAY.md` design for HTTP Gateway + Web Agent UI (long-polling first; SSE optional; WebSocket not required).
 - New `zene-gateway` binary (`apps/gateway`): thin local HTTP bridge over `zene acp` with token/Origin checks, `POST /api/v1/agents/{id}/messages`, cursor-based `GET /api/v1/agents/{id}/events` long polling, bootstrap/health, embedded minimal Web page, and mock-ACP integration tests.
 - Gateway phase B: optional SSE (`GET /events/stream`) with Web long-poll fallback, controller lease APIs, `apps/web-agent` UI (sessions/tool cards/usage/SSE), `--yolo`/`--sandbox-off`/`--acp-env`, and real `zene acp` + mock LLM smoke test.
+- Gateway phase C: local ACP `terminal/*` host with Web terminal panel, Plan/Todo/background-task panels, mode switch + session close UI, and terminal roundtrip tests.
 
 ### Changed
 - ACP: bridge `tool_call` / `tool_call_update` / `plan` / `usage_update` / `current_mode_update` / `available_commands_update` / `agent_thought_chunk`; replay history on `session/load`; implement `session/list`, `session/close`, `session/set_mode`, `session/resume`; optional client FS + terminal bridges; FIFO prompt queue with in-turn cancel; correlate permission `toolCallId`; accept embedded prompt context; tighten JSON-RPC error codes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4540,7 +4540,6 @@ version = "0.1.7"
 dependencies = [
  "anyhow",
  "axum",
- "bytes",
  "chrono",
  "clap",
  "futures",

--- a/apps/gateway/Cargo.toml
+++ b/apps/gateway/Cargo.toml
@@ -31,4 +31,3 @@ uuid.workspace = true
 [dev-dependencies]
 reqwest = { workspace = true, features = ["json", "stream"] }
 tempfile = "3"
-bytes = "1"

--- a/apps/gateway/src/agent.rs
+++ b/apps/gateway/src/agent.rs
@@ -13,6 +13,7 @@ use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
 use crate::event_journal::EventJournal;
+use crate::terminal::{is_terminal_request, TerminalHost, TerminalInfo};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -39,6 +40,7 @@ struct AgentRuntime {
     stdin: Option<ChildStdin>,
     child: Child,
     journal: EventJournal,
+    terminals: TerminalHost,
 }
 
 #[derive(Clone)]
@@ -110,11 +112,13 @@ impl AgentManager {
             exit_code: None,
         };
 
+        let terminals = TerminalHost::new();
         let runtime = Arc::new(Mutex::new(AgentRuntime {
             info: info.clone(),
             stdin: Some(stdin),
             child,
             journal: journal.clone(),
+            terminals: terminals.clone(),
         }));
 
         {
@@ -131,13 +135,71 @@ impl AgentManager {
                 }
                 let payload = match serde_json::from_str::<Value>(&line) {
                     Ok(value) => value,
-                    Err(err) => serde_json::json!({
-                        "type": "gateway.system",
-                        "kind": "invalid_stdout",
-                        "message": format!("invalid ACP JSON: {err}"),
-                        "raw": line,
-                    }),
+                    Err(err) => {
+                        let journal = {
+                            let guard = stdout_runtime.lock().await;
+                            guard.journal.clone()
+                        };
+                        journal
+                            .append(serde_json::json!({
+                                "type": "gateway.system",
+                                "kind": "invalid_stdout",
+                                "message": format!("invalid ACP JSON: {err}"),
+                                "raw": line,
+                            }))
+                            .await;
+                        continue;
+                    }
                 };
+
+                if is_terminal_request(&payload) {
+                    // Handle terminal requests off the stdout read loop so
+                    // wait_for_exit cannot stall other ACP frames.
+                    let runtime = stdout_runtime.clone();
+                    tokio::spawn(async move {
+                        let (journal, terminals, workspace) = {
+                            let guard = runtime.lock().await;
+                            (
+                                guard.journal.clone(),
+                                guard.terminals.clone(),
+                                guard.info.workspace.clone(),
+                            )
+                        };
+                        journal.append(payload.clone()).await;
+                        match terminals
+                            .handle_request(&payload, &journal, &workspace)
+                            .await
+                        {
+                            Ok(response) => {
+                                if let Err(err) = write_stdin_locked(&runtime, &[response]).await {
+                                    journal
+                                        .append_system(
+                                            "terminal_reply_failed",
+                                            format!("failed writing terminal response: {err}"),
+                                        )
+                                        .await;
+                                }
+                            }
+                            Err(err) => {
+                                let id = payload.get("id").cloned();
+                                let response = serde_json::json!({
+                                    "jsonrpc": "2.0",
+                                    "id": id,
+                                    "error": {
+                                        "code": -32000,
+                                        "message": format!("terminal host error: {err}")
+                                    }
+                                });
+                                let _ = write_stdin_locked(&runtime, &[response]).await;
+                                journal
+                                    .append_system("terminal_error", err.to_string())
+                                    .await;
+                            }
+                        }
+                    });
+                    continue;
+                }
+
                 let journal = {
                     let guard = stdout_runtime.lock().await;
                     guard.journal.clone()
@@ -270,6 +332,62 @@ impl AgentManager {
                 as u64,
         })
     }
+
+    pub async fn list_terminals(&self, agent_id: &str) -> Option<Vec<TerminalInfo>> {
+        let map = self.inner.read().await;
+        let runtime = map.get(agent_id)?.clone();
+        let guard = runtime.lock().await;
+        Some(guard.terminals.list(None).await)
+    }
+
+    pub async fn terminal_output(
+        &self,
+        agent_id: &str,
+        terminal_id: &str,
+        offset: usize,
+    ) -> Result<(String, usize, Option<i32>)> {
+        let map = self.inner.read().await;
+        let runtime = map
+            .get(agent_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("agent not found"))?;
+        let terminals = {
+            let guard = runtime.lock().await;
+            guard.terminals.clone()
+        };
+        let (chunk, len, code, _) = terminals.output_since(terminal_id, offset).await?;
+        Ok((chunk, len, code))
+    }
+
+    pub async fn kill_terminal(&self, agent_id: &str, terminal_id: &str) -> Result<()> {
+        let map = self.inner.read().await;
+        let runtime = map
+            .get(agent_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("agent not found"))?;
+        let terminals = {
+            let guard = runtime.lock().await;
+            guard.terminals.clone()
+        };
+        terminals.kill(terminal_id).await
+    }
+}
+
+async fn write_stdin_locked(
+    runtime: &Arc<Mutex<AgentRuntime>>,
+    messages: &[Value],
+) -> Result<()> {
+    let mut guard = runtime.lock().await;
+    let Some(stdin) = guard.stdin.as_mut() else {
+        bail!("agent stdin closed");
+    };
+    for message in messages {
+        let mut line = serde_json::to_string(message)?;
+        line.push('\n');
+        stdin.write_all(line.as_bytes()).await?;
+    }
+    stdin.flush().await?;
+    Ok(())
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/apps/gateway/src/bin/mock_acp.rs
+++ b/apps/gateway/src/bin/mock_acp.rs
@@ -10,8 +10,9 @@ fn main() {
     let mut input = stdin.lock();
     let mut stdout = io::stdout();
     let session_id = String::from("mock-session-1");
-    let mut pending_permission: HashMap<String, bool> = HashMap::new();
+    let mut pending_responses: HashMap<String, Value> = HashMap::new();
     let mut line = String::new();
+    let mut mode = "default".to_string();
 
     loop {
         line.clear();
@@ -27,10 +28,10 @@ fn main() {
             continue;
         };
 
-        // Client JSON-RPC response to our permission request.
+        // Client JSON-RPC response.
         if msg.get("method").is_none() && msg.get("id").is_some() {
             if let Some(id) = msg.get("id") {
-                pending_permission.insert(id_to_key(id), true);
+                pending_responses.insert(id_to_key(id), msg);
             }
             continue;
         }
@@ -61,7 +62,7 @@ fn main() {
                     }),
                 );
             }
-            "session/new" => {
+            "session/new" | "session/load" | "session/resume" => {
                 write_msg(
                     &mut stdout,
                     json!({
@@ -70,7 +71,7 @@ fn main() {
                         "result": {
                             "sessionId": session_id,
                             "modes": {
-                                "currentModeId": "default",
+                                "currentModeId": mode,
                                 "availableModes": [
                                     { "id": "default", "name": "Default" },
                                     { "id": "plan", "name": "Plan" }
@@ -79,13 +80,83 @@ fn main() {
                         }
                     }),
                 );
+                write_msg(
+                    &mut stdout,
+                    json!({
+                        "jsonrpc": "2.0",
+                        "method": "session/update",
+                        "params": {
+                            "sessionId": session_id,
+                            "update": {
+                                "sessionUpdate": "current_mode_update",
+                                "currentModeId": mode
+                            }
+                        }
+                    }),
+                );
+            }
+            "session/list" => {
+                write_msg(
+                    &mut stdout,
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": {
+                            "sessions": [{
+                                "sessionId": session_id,
+                                "cwd": params.get("cwd").cloned().unwrap_or(json!(".")),
+                                "title": "mock session",
+                                "updatedAt": "2026-07-20T00:00:00Z"
+                            }]
+                        }
+                    }),
+                );
+            }
+            "session/close" => {
+                write_msg(
+                    &mut stdout,
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": {}
+                    }),
+                );
+            }
+            "session/set_mode" => {
+                mode = params
+                    .get("modeId")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("default")
+                    .to_string();
+                write_msg(
+                    &mut stdout,
+                    json!({
+                        "jsonrpc": "2.0",
+                        "method": "session/update",
+                        "params": {
+                            "sessionId": session_id,
+                            "update": {
+                                "sessionUpdate": "current_mode_update",
+                                "currentModeId": mode
+                            }
+                        }
+                    }),
+                );
+                write_msg(
+                    &mut stdout,
+                    json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": {}
+                    }),
+                );
             }
             "session/prompt" => {
                 handle_prompt(
                     &mut input,
                     &mut stdout,
                     &session_id,
-                    &mut pending_permission,
+                    &mut pending_responses,
                     id,
                     &params,
                     &mut line,
@@ -115,13 +186,15 @@ fn handle_prompt(
     input: &mut impl BufRead,
     stdout: &mut impl Write,
     session_id: &str,
-    pending_permission: &mut HashMap<String, bool>,
+    pending_responses: &mut HashMap<String, Value>,
     id: Option<Value>,
     params: &Value,
     line: &mut String,
 ) {
     let prompt_text = extract_prompt_text(params);
     let want_permission = prompt_text.contains("NEED_PERMISSION");
+    let want_terminal = prompt_text.contains("TERMINAL_PING");
+    let want_todo = prompt_text.contains("NEED_TODO");
 
     write_msg(
         stdout,
@@ -137,6 +210,67 @@ fn handle_prompt(
             }
         }),
     );
+
+    if want_todo {
+        write_msg(
+            stdout,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "todo_1",
+                        "title": "TodoWrite",
+                        "kind": "think",
+                        "status": "pending",
+                        "rawInput": {
+                            "todos": [
+                                { "id": "1", "content": "Ship plan panel", "status": "in_progress" },
+                                { "id": "2", "content": "Wire terminal host", "status": "pending" }
+                            ]
+                        }
+                    }
+                }
+            }),
+        );
+        write_msg(
+            stdout,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "plan",
+                        "entries": [
+                            { "content": "Ship plan panel", "status": "in_progress", "priority": "high" },
+                            { "content": "Wire terminal host", "status": "pending", "priority": "medium" }
+                        ]
+                    }
+                }
+            }),
+        );
+        write_msg(
+            stdout,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "task_bg_1",
+                        "title": "Task",
+                        "kind": "execute",
+                        "status": "in_progress",
+                        "rawInput": { "description": "background check", "run_in_background": true }
+                    }
+                }
+            }),
+        );
+    }
 
     if want_permission {
         let perm_id = 9001;
@@ -169,42 +303,109 @@ fn handle_prompt(
                 }
             }),
         );
-
-        let key = perm_id.to_string();
-        while !pending_permission.contains_key(&key) {
-            line.clear();
-            let n = match input.read_line(line) {
-                Ok(0) => return,
-                Ok(n) => n,
-                Err(_) => return,
-            };
-            if n == 0 || line.trim().is_empty() {
-                continue;
-            }
-            if let Ok(resp) = serde_json::from_str::<Value>(line.trim()) {
-                if resp.get("method").is_none() {
-                    if let Some(rid) = resp.get("id") {
-                        pending_permission.insert(id_to_key(rid), true);
-                    }
-                }
-            }
-        }
+        let _ = wait_response(input, pending_responses, &perm_id.to_string(), line);
     }
 
-    write_msg(
-        stdout,
-        json!({
-            "jsonrpc": "2.0",
-            "method": "session/update",
-            "params": {
-                "sessionId": session_id,
-                "update": {
-                    "sessionUpdate": "agent_message_chunk",
-                    "content": { "type": "text", "text": format!("echo:{prompt_text}") }
+    if want_terminal {
+        let create_id = 9100;
+        write_msg(
+            stdout,
+            json!({
+                "jsonrpc": "2.0",
+                "id": create_id,
+                "method": "terminal/create",
+                "params": {
+                    "sessionId": session_id,
+                    "command": "printf",
+                    "args": ["gateway-terminal-ok"],
+                    "cwd": ".",
+                    "outputByteLimit": 4096
                 }
-            }
-        }),
-    );
+            }),
+        );
+        let created = match wait_response(input, pending_responses, &create_id.to_string(), line) {
+            Some(v) => v,
+            None => return,
+        };
+        let terminal_id = created
+            .pointer("/result/terminalId")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let wait_id = 9101;
+        write_msg(
+            stdout,
+            json!({
+                "jsonrpc": "2.0",
+                "id": wait_id,
+                "method": "terminal/wait_for_exit",
+                "params": { "sessionId": session_id, "terminalId": terminal_id }
+            }),
+        );
+        let _ = wait_response(input, pending_responses, &wait_id.to_string(), line);
+
+        let out_id = 9102;
+        write_msg(
+            stdout,
+            json!({
+                "jsonrpc": "2.0",
+                "id": out_id,
+                "method": "terminal/output",
+                "params": { "sessionId": session_id, "terminalId": terminal_id }
+            }),
+        );
+        let output = wait_response(input, pending_responses, &out_id.to_string(), line);
+        let text = output
+            .as_ref()
+            .and_then(|v| v.pointer("/result/output"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let rel_id = 9103;
+        write_msg(
+            stdout,
+            json!({
+                "jsonrpc": "2.0",
+                "id": rel_id,
+                "method": "terminal/release",
+                "params": { "sessionId": session_id, "terminalId": terminal_id }
+            }),
+        );
+        let _ = wait_response(input, pending_responses, &rel_id.to_string(), line);
+
+        write_msg(
+            stdout,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": { "type": "text", "text": format!("terminal:{text}") }
+                    }
+                }
+            }),
+        );
+    } else {
+        write_msg(
+            stdout,
+            json!({
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": { "type": "text", "text": format!("echo:{prompt_text}") }
+                    }
+                }
+            }),
+        );
+    }
+
     write_msg(
         stdout,
         json!({
@@ -213,6 +414,33 @@ fn handle_prompt(
             "result": { "stopReason": "end_turn" }
         }),
     );
+}
+
+fn wait_response(
+    input: &mut impl BufRead,
+    pending_responses: &mut HashMap<String, Value>,
+    key: &str,
+    line: &mut String,
+) -> Option<Value> {
+    while !pending_responses.contains_key(key) {
+        line.clear();
+        let n = match input.read_line(line) {
+            Ok(0) => return None,
+            Ok(n) => n,
+            Err(_) => return None,
+        };
+        if n == 0 || line.trim().is_empty() {
+            continue;
+        }
+        if let Ok(resp) = serde_json::from_str::<Value>(line.trim()) {
+            if resp.get("method").is_none() {
+                if let Some(rid) = resp.get("id") {
+                    pending_responses.insert(id_to_key(rid), resp);
+                }
+            }
+        }
+    }
+    pending_responses.remove(key)
 }
 
 fn extract_prompt_text(params: &Value) -> String {

--- a/apps/gateway/src/http.rs
+++ b/apps/gateway/src/http.rs
@@ -88,6 +88,15 @@ pub fn router(state: AppState) -> Router {
             post(heartbeat_lease),
         )
         .route("/api/v1/agents/{agent_id}/lease/release", post(release_lease))
+        .route("/api/v1/agents/{agent_id}/terminals", get(list_terminals))
+        .route(
+            "/api/v1/agents/{agent_id}/terminals/{terminal_id}",
+            get(get_terminal_output),
+        )
+        .route(
+            "/api/v1/agents/{agent_id}/terminals/{terminal_id}/kill",
+            post(kill_terminal),
+        )
         .layer(TraceLayer::new_for_http())
         .with_state(Arc::new(state))
 }
@@ -113,7 +122,10 @@ async fn bootstrap(State(state): State<Arc<AppState>>) -> impl IntoResponse {
             "clientIdHeader": "X-Zene-Client-Id"
         },
         "features": {
-            "controllerLease": true
+            "controllerLease": true,
+            "terminalHost": true,
+            "planPanel": true,
+            "todoPanel": true
         },
         "limits": {
             "maxPostBodyBytes": 1_048_576,
@@ -581,6 +593,98 @@ fn cursor_expired(oldest_cursor: u64, latest_cursor: u64) -> Response {
     body.latest_cursor = Some(latest_cursor);
     body.recovery = Some("reload_session".into());
     (StatusCode::CONFLICT, Json(body)).into_response()
+}
+
+async fn list_terminals(
+    State(state): State<Arc<AppState>>,
+    Path(agent_id): Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(status) = state.auth.authorize(&headers, None) {
+        return auth_error(status);
+    }
+    match state.agents.list_terminals(&agent_id).await {
+        Some(terminals) => Json(json!({
+            "terminals": terminals,
+            "meta": meta(),
+        }))
+        .into_response(),
+        None => json_error(
+            StatusCode::NOT_FOUND,
+            "agent_not_found",
+            "unknown agentId",
+            false,
+        ),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct TerminalOutputQuery {
+    offset: Option<usize>,
+    token: Option<String>,
+}
+
+async fn get_terminal_output(
+    State(state): State<Arc<AppState>>,
+    Path((agent_id, terminal_id)): Path<(String, String)>,
+    Query(query): Query<TerminalOutputQuery>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(status) = state.auth.authorize(&headers, query.token.as_deref()) {
+        return auth_error(status);
+    }
+    match state
+        .agents
+        .terminal_output(&agent_id, &terminal_id, query.offset.unwrap_or(0))
+        .await
+    {
+        Ok((chunk, next_offset, exit_code)) => Json(json!({
+            "terminalId": terminal_id,
+            "chunk": chunk,
+            "nextOffset": next_offset,
+            "exitCode": exit_code,
+            "meta": meta(),
+        }))
+        .into_response(),
+        Err(err) => json_error(
+            StatusCode::NOT_FOUND,
+            "terminal_not_found",
+            err.to_string(),
+            false,
+        ),
+    }
+}
+
+async fn kill_terminal(
+    State(state): State<Arc<AppState>>,
+    Path((agent_id, terminal_id)): Path<(String, String)>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(status) = state.auth.authorize(&headers, None) {
+        return auth_error(status);
+    }
+    let client_id = client_id_from_headers(&headers);
+    if let Err(err) = state
+        .leases
+        .authorize_write(&agent_id, client_id.as_deref())
+        .await
+    {
+        return lease_error(err);
+    }
+    match state.agents.kill_terminal(&agent_id, &terminal_id).await {
+        Ok(()) => Json(json!({
+            "killed": true,
+            "terminalId": terminal_id,
+            "meta": meta(),
+        }))
+        .into_response(),
+        Err(err) => json_error(
+            StatusCode::NOT_FOUND,
+            "terminal_not_found",
+            err.to_string(),
+            true,
+        ),
+    }
 }
 
 fn json_error(

--- a/apps/gateway/src/lib.rs
+++ b/apps/gateway/src/lib.rs
@@ -4,3 +4,4 @@ pub mod event_journal;
 pub mod http;
 pub mod lease;
 pub mod static_page;
+pub mod terminal;

--- a/apps/gateway/src/terminal.rs
+++ b/apps/gateway/src/terminal.rs
@@ -1,0 +1,461 @@
+//! Local ACP terminal host implemented by the gateway.
+//!
+//! When the Web client advertises `terminal` capability, Zene issues
+//! `terminal/create|wait_for_exit|output|kill|release` requests to the client.
+//! The gateway handles those locally and exposes a read-only Web view via events
+//! plus HTTP helpers.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Result};
+use serde::Serialize;
+use serde_json::{json, Value};
+use tokio::io::{AsyncReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::{Mutex, Notify};
+use uuid::Uuid;
+
+use crate::event_journal::EventJournal;
+
+const DEFAULT_OUTPUT_LIMIT: usize = 64 * 1024;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TerminalInfo {
+    pub terminal_id: String,
+    pub session_id: String,
+    pub command: String,
+    pub cwd: PathBuf,
+    pub status: TerminalStatus,
+    pub exit_code: Option<i32>,
+    pub output_len: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TerminalStatus {
+    Running,
+    Exited,
+    Released,
+}
+
+struct TerminalSession {
+    info: TerminalInfo,
+    output: String,
+    output_limit: usize,
+    child: Option<Child>,
+    exit_notify: Arc<Notify>,
+}
+
+#[derive(Clone, Default)]
+pub struct TerminalHost {
+    inner: Arc<Mutex<HashMap<String, TerminalSession>>>,
+}
+
+impl TerminalHost {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn list(&self, session_id: Option<&str>) -> Vec<TerminalInfo> {
+        let map = self.inner.lock().await;
+        map.values()
+            .filter(|t| session_id.is_none_or(|sid| t.info.session_id == sid))
+            .map(|t| {
+                let mut info = t.info.clone();
+                info.output_len = t.output.len();
+                info
+            })
+            .collect()
+    }
+
+    pub async fn output_since(
+        &self,
+        terminal_id: &str,
+        offset: usize,
+    ) -> Result<(String, usize, Option<i32>, TerminalStatus)> {
+        let map = self.inner.lock().await;
+        let term = map
+            .get(terminal_id)
+            .ok_or_else(|| anyhow!("unknown terminalId"))?;
+        let slice = if offset >= term.output.len() {
+            String::new()
+        } else {
+            term.output[offset..].to_string()
+        };
+        Ok((
+            slice,
+            term.output.len(),
+            term.info.exit_code,
+            term.info.status,
+        ))
+    }
+
+    pub async fn kill(&self, terminal_id: &str) -> Result<()> {
+        let mut map = self.inner.lock().await;
+        let term = map
+            .get_mut(terminal_id)
+            .ok_or_else(|| anyhow!("unknown terminalId"))?;
+        if let Some(child) = term.child.as_mut() {
+            let _ = child.kill().await;
+        }
+        Ok(())
+    }
+
+    /// Handle an inbound ACP JSON-RPC request aimed at this client.
+    pub async fn handle_request(
+        &self,
+        request: &Value,
+        journal: &EventJournal,
+        workspace: &std::path::Path,
+    ) -> Result<Value> {
+        let method = request
+            .get("method")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let id = request.get("id").cloned();
+        let params = request.get("params").cloned().unwrap_or(json!({}));
+
+        let result = match method {
+            "terminal/create" => self.create(&params, journal, workspace).await?,
+            "terminal/wait_for_exit" => self.wait_for_exit(&params).await?,
+            "terminal/output" => self.read_output(&params).await?,
+            "terminal/kill" => {
+                let tid = required_str(&params, "terminalId")?;
+                self.kill(&tid).await?;
+                journal
+                    .append(json!({
+                        "type": "gateway.terminal",
+                        "kind": "killed",
+                        "terminalId": tid,
+                        "sessionId": params.get("sessionId"),
+                    }))
+                    .await;
+                json!({})
+            }
+            "terminal/release" => {
+                let tid = required_str(&params, "terminalId")?;
+                self.release(&tid).await?;
+                journal
+                    .append(json!({
+                        "type": "gateway.terminal",
+                        "kind": "released",
+                        "terminalId": tid,
+                        "sessionId": params.get("sessionId"),
+                    }))
+                    .await;
+                json!({})
+            }
+            _ => bail!("unsupported terminal method: {method}"),
+        };
+
+        Ok(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result,
+        }))
+    }
+
+    async fn create(
+        &self,
+        params: &Value,
+        journal: &EventJournal,
+        workspace: &std::path::Path,
+    ) -> Result<Value> {
+        let session_id = required_str(params, "sessionId")?;
+        let command = required_str(params, "command")?;
+        let args = params
+            .get("args")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(str::to_string))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let cwd = params
+            .get("cwd")
+            .and_then(|v| v.as_str())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| workspace.to_path_buf());
+        let output_limit = params
+            .get("outputByteLimit")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(DEFAULT_OUTPUT_LIMIT as u64) as usize;
+
+        let terminal_id = format!("term_{}", Uuid::new_v4().simple());
+        let display_cmd = if args.is_empty() {
+            command.clone()
+        } else {
+            format!("{command} {}", args.join(" "))
+        };
+
+        let mut child = Command::new(&command)
+            .args(&args)
+            .current_dir(&cwd)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()?;
+
+        let stdout = child.stdout.take();
+        let stderr = child.stderr.take();
+        let exit_notify = Arc::new(Notify::new());
+
+        {
+            let mut map = self.inner.lock().await;
+            map.insert(
+                terminal_id.clone(),
+                TerminalSession {
+                    info: TerminalInfo {
+                        terminal_id: terminal_id.clone(),
+                        session_id: session_id.clone(),
+                        command: display_cmd.clone(),
+                        cwd: cwd.clone(),
+                        status: TerminalStatus::Running,
+                        exit_code: None,
+                        output_len: 0,
+                    },
+                    output: String::new(),
+                    output_limit,
+                    child: Some(child),
+                    exit_notify: exit_notify.clone(),
+                },
+            );
+        }
+
+        journal
+            .append(json!({
+                "type": "gateway.terminal",
+                "kind": "created",
+                "terminalId": terminal_id,
+                "sessionId": session_id,
+                "command": display_cmd,
+                "cwd": cwd,
+            }))
+            .await;
+
+        let host = self.clone();
+        let tid = terminal_id.clone();
+        let journal_out = journal.clone();
+        tokio::spawn(async move {
+            if let Some(out) = stdout {
+                pump_output(host.clone(), tid.clone(), journal_out.clone(), out, false).await;
+            }
+            if let Some(err) = stderr {
+                pump_output(host.clone(), tid.clone(), journal_out.clone(), err, true).await;
+            }
+
+            let exit_code = {
+                let mut map = host.inner.lock().await;
+                if let Some(term) = map.get_mut(&tid) {
+                    let code = if let Some(child) = term.child.as_mut() {
+                        match child.wait().await {
+                            Ok(status) => status.code(),
+                            Err(_) => None,
+                        }
+                    } else {
+                        None
+                    };
+                    term.info.exit_code = code;
+                    term.info.status = TerminalStatus::Exited;
+                    term.child = None;
+                    term.exit_notify.notify_waiters();
+                    code
+                } else {
+                    None
+                }
+            };
+            journal_out
+                .append(json!({
+                    "type": "gateway.terminal",
+                    "kind": "exited",
+                    "terminalId": tid,
+                    "exitCode": exit_code,
+                }))
+                .await;
+        });
+
+        Ok(json!({ "terminalId": terminal_id }))
+    }
+
+    async fn wait_for_exit(&self, params: &Value) -> Result<Value> {
+        let tid = required_str(params, "terminalId")?;
+        let notify = {
+            let map = self.inner.lock().await;
+            let term = map
+                .get(&tid)
+                .ok_or_else(|| anyhow!("unknown terminalId"))?;
+            if term.info.status != TerminalStatus::Running {
+                return Ok(json!({
+                    "exitCode": term.info.exit_code.unwrap_or(0),
+                }));
+            }
+            term.exit_notify.clone()
+        };
+        // Avoid hanging forever in tests / stuck processes.
+        let _ = tokio::time::timeout(Duration::from_secs(30 * 60), notify.notified()).await;
+        let map = self.inner.lock().await;
+        let term = map
+            .get(&tid)
+            .ok_or_else(|| anyhow!("unknown terminalId"))?;
+        Ok(json!({
+            "exitCode": term.info.exit_code.unwrap_or(0),
+        }))
+    }
+
+    async fn read_output(&self, params: &Value) -> Result<Value> {
+        let tid = required_str(params, "terminalId")?;
+        let map = self.inner.lock().await;
+        let term = map
+            .get(&tid)
+            .ok_or_else(|| anyhow!("unknown terminalId"))?;
+        Ok(json!({
+            "output": term.output,
+            "exitStatus": {
+                "exitCode": term.info.exit_code.unwrap_or(0)
+            },
+            "exitCode": term.info.exit_code.unwrap_or(0),
+        }))
+    }
+
+    async fn release(&self, terminal_id: &str) -> Result<()> {
+        let mut map = self.inner.lock().await;
+        if let Some(mut term) = map.remove(terminal_id) {
+            if let Some(child) = term.child.as_mut() {
+                let _ = child.kill().await;
+            }
+            // Keep a released tombstone for UI list briefly.
+            term.info.status = TerminalStatus::Released;
+            map.insert(
+                terminal_id.to_string(),
+                TerminalSession {
+                    info: term.info,
+                    output: term.output,
+                    output_limit: term.output_limit,
+                    child: None,
+                    exit_notify: term.exit_notify,
+                },
+            );
+        }
+        Ok(())
+    }
+}
+
+async fn pump_output<R: tokio::io::AsyncRead + Unpin>(
+    host: TerminalHost,
+    terminal_id: String,
+    journal: EventJournal,
+    reader: R,
+    is_stderr: bool,
+) {
+    let mut reader = BufReader::new(reader);
+    let mut buf = [0u8; 2048];
+    loop {
+        match reader.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => {
+                let chunk = String::from_utf8_lossy(&buf[..n]).to_string();
+                {
+                    let mut map = host.inner.lock().await;
+                    if let Some(term) = map.get_mut(&terminal_id) {
+                        term.output.push_str(&chunk);
+                        if term.output.len() > term.output_limit {
+                            let keep = term.output_limit / 2;
+                            term.output = term.output[term.output.len() - keep..].to_string();
+                        }
+                        term.info.output_len = term.output.len();
+                    }
+                }
+                journal
+                    .append(json!({
+                        "type": "gateway.terminal",
+                        "kind": "output",
+                        "terminalId": terminal_id,
+                        "stream": if is_stderr { "stderr" } else { "stdout" },
+                        "chunk": chunk,
+                    }))
+                    .await;
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+fn required_str(params: &Value, key: &str) -> Result<String> {
+    params
+        .get(key)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("{key} required"))
+}
+
+pub fn is_terminal_request(payload: &Value) -> bool {
+    payload.get("id").is_some()
+        && payload
+            .get("method")
+            .and_then(|m| m.as_str())
+            .is_some_and(|m| m.starts_with("terminal/"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn create_wait_output_release() {
+        let host = TerminalHost::new();
+        let journal = EventJournal::new();
+        let dir = tempdir().unwrap();
+        let create = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "terminal/create",
+            "params": {
+                "sessionId": "s1",
+                "command": "printf",
+                "args": ["hello-term"],
+                "cwd": dir.path(),
+                "outputByteLimit": 4096
+            }
+        });
+        let created = host
+            .handle_request(&create, &journal, dir.path())
+            .await
+            .unwrap();
+        let tid = created["result"]["terminalId"].as_str().unwrap().to_string();
+
+        let wait = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "terminal/wait_for_exit",
+            "params": { "sessionId": "s1", "terminalId": tid }
+        });
+        let waited = host
+            .handle_request(&wait, &journal, dir.path())
+            .await
+            .unwrap();
+        assert_eq!(waited["result"]["exitCode"], 0);
+
+        let output = json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "terminal/output",
+            "params": { "sessionId": "s1", "terminalId": tid }
+        });
+        let out = host
+            .handle_request(&output, &journal, dir.path())
+            .await
+            .unwrap();
+        assert!(out["result"]["output"]
+            .as_str()
+            .unwrap()
+            .contains("hello-term"));
+    }
+}

--- a/apps/gateway/tests/gateway_http.rs
+++ b/apps/gateway/tests/gateway_http.rs
@@ -96,6 +96,8 @@ async fn bootstrap_advertises_sse_and_lease() {
     assert_eq!(boot["transports"]["sse"], true);
     assert_eq!(boot["transports"]["websocket"], false);
     assert_eq!(boot["features"]["controllerLease"], true);
+    assert_eq!(boot["features"]["terminalHost"], true);
+    assert_eq!(boot["features"]["planPanel"], true);
 }
 
 #[tokio::test]
@@ -423,6 +425,127 @@ async fn sse_streams_acp_events() {
         }
     }
     panic!("SSE did not deliver initialize result; buf={buf}");
+}
+
+#[tokio::test]
+async fn terminal_host_handles_acp_terminal_roundtrip() {
+    let token = "secret";
+    let (addr, client) = start_server(token).await;
+    let dir = tempdir().unwrap();
+
+    let created: Value = client
+        .post(format!("http://{addr}/api/v1/agents"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "term-create",
+            "workspace": dir.path()
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let agent_id = created["agent"]["agentId"].as_str().unwrap().to_string();
+    let mut cursor = 0u64;
+
+    client
+        .post(format!("http://{addr}/api/v1/agents/{agent_id}/messages"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "term-init",
+            "messages": [{
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": 1,
+                    "clientCapabilities": { "terminal": true },
+                    "clientInfo": { "name": "term-test", "version": "0" }
+                }
+            }]
+        }))
+        .send()
+        .await
+        .unwrap();
+    wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p.get("id") == Some(&json!(1))
+    })
+    .await;
+
+    client
+        .post(format!("http://{addr}/api/v1/agents/{agent_id}/messages"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "term-new",
+            "messages": [{
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": { "cwd": dir.path(), "mcpServers": [] }
+            }]
+        }))
+        .send()
+        .await
+        .unwrap();
+    let session = wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p.get("id") == Some(&json!(2))
+    })
+    .await;
+    let session_id = session["result"]["sessionId"].as_str().unwrap().to_string();
+
+    client
+        .post(format!("http://{addr}/api/v1/agents/{agent_id}/messages"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "term-prompt",
+            "messages": [{
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{ "type": "text", "text": "TERMINAL_PING" }]
+                }
+            }]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let created_event = wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p.get("type") == Some(&json!("gateway.terminal")) && p.get("kind") == Some(&json!("created"))
+    })
+    .await;
+    let terminal_id = created_event["terminalId"].as_str().unwrap().to_string();
+
+    let assistant = wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p.get("method") == Some(&json!("session/update"))
+            && p["params"]["update"]["sessionUpdate"] == "agent_message_chunk"
+            && p["params"]["update"]["content"]["text"]
+                .as_str()
+                .is_some_and(|t| t.contains("gateway-terminal-ok"))
+    })
+    .await;
+    assert!(assistant["params"]["update"]["content"]["text"]
+        .as_str()
+        .unwrap()
+        .contains("gateway-terminal-ok"));
+
+    let listed: Value = client
+        .get(format!("http://{addr}/api/v1/agents/{agent_id}/terminals"))
+        .header("X-Zene-Token", token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(listed["terminals"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|t| t["terminalId"] == terminal_id));
 }
 
 #[tokio::test]

--- a/apps/web-agent/README.md
+++ b/apps/web-agent/README.md
@@ -2,8 +2,8 @@
 
 Static Web Agent UI served by `zene-gateway`.
 
-Phase B keeps this as a zero-build HTML/JS page embedded into the gateway
-binary via `include_str!`. Later phases may introduce a bundler under the same
-directory without changing the Gateway/ACP contract.
+This is a zero-build HTML/JS page embedded into the gateway binary via
+`include_str!`. Phase C panels include Plan, Todos, background tasks,
+terminals, mode switching, and session close.
 
 Open via the URL printed by `zene-gateway` (includes `#token=...`).

--- a/apps/web-agent/index.html
+++ b/apps/web-agent/index.html
@@ -6,106 +6,97 @@
   <title>Zene Web Agent</title>
   <style>
     :root {
-      --bg0: #efe6d8;
-      --bg1: #f7f1e7;
-      --ink: #1d1914;
-      --muted: #6a5f52;
-      --panel: rgba(255,252,246,.94);
-      --line: #d8ccba;
-      --accent: #0f6a5b;
-      --accent-ink: #f4fffb;
-      --warn: #8a4b12;
-      --danger: #8b2430;
-      --ok: #1f6b3a;
+      --bg0: #efe6d8; --bg1: #f7f1e7; --ink: #1d1914; --muted: #6a5f52;
+      --panel: rgba(255,252,246,.94); --line: #d8ccba; --accent: #0f6a5b;
+      --accent-ink: #f4fffb; --warn: #8a4b12; --danger: #8b2430; --ok: #1f6b3a;
       --tool: #2f5f7a;
       --mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       --sans: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
     }
     * { box-sizing: border-box; }
     body {
-      margin: 0; color: var(--ink); font-family: var(--sans);
-      min-height: 100vh;
+      margin: 0; color: var(--ink); font-family: var(--sans); min-height: 100vh;
       background:
         radial-gradient(circle at 0% 0%, rgba(15,106,91,.14), transparent 42%),
         linear-gradient(155deg, var(--bg1), var(--bg0) 55%, #f3eee5);
     }
     .layout {
       display: grid;
-      grid-template-columns: 260px minmax(0, 1fr);
-      gap: 14px;
-      max-width: 1200px;
-      margin: 0 auto;
-      padding: 18px;
-      min-height: 100vh;
+      grid-template-columns: 270px minmax(0, 1fr) 300px;
+      gap: 12px; max-width: 1400px; margin: 0 auto; padding: 16px; min-height: 100vh;
     }
-    @media (max-width: 860px) {
+    @media (max-width: 1100px) {
       .layout { grid-template-columns: 1fr; }
-      aside { order: 2; }
     }
-    h1 { margin: 0; font-size: 1.55rem; }
-    .sub { margin: 4px 0 0; color: var(--muted); font-size: .92rem; }
+    h1 { margin: 0; font-size: 1.45rem; }
+    .sub { margin: 4px 0 0; color: var(--muted); font-size: .9rem; }
     .card {
       background: var(--panel); border: 1px solid var(--line);
-      border-radius: 12px; padding: 12px 14px;
+      border-radius: 12px; padding: 12px 14px; margin-bottom: 12px;
     }
-    aside .card { margin-bottom: 12px; }
-    label { display:block; font-size:.8rem; color:var(--muted); margin-bottom:4px; }
-    input, textarea, button, select {
-      font: inherit;
-    }
+    label { display:block; font-size:.78rem; color:var(--muted); margin-bottom:4px; }
+    input, textarea, button, select { font: inherit; }
     input, textarea, select {
       width: 100%; border: 1px solid var(--line); border-radius: 8px;
-      padding: 9px 11px; background: #fffdf8; color: var(--ink);
+      padding: 8px 10px; background: #fffdf8; color: var(--ink);
     }
-    textarea { min-height: 96px; resize: vertical; }
+    textarea { min-height: 90px; resize: vertical; }
     button {
-      border: 0; border-radius: 8px; padding: 8px 12px;
+      border: 0; border-radius: 8px; padding: 7px 11px;
       background: var(--accent); color: var(--accent-ink); cursor: pointer;
     }
     button.secondary { background: transparent; color: var(--ink); border: 1px solid var(--line); }
     button.danger { background: var(--danger); color: #fff; }
+    button.active { outline: 2px solid var(--accent); }
     button:disabled { opacity: .55; cursor: not-allowed; }
     .row { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
-    .status { font-family: var(--mono); font-size: .75rem; color: var(--muted); }
+    .status { font-family: var(--mono); font-size: .72rem; color: var(--muted); }
     .ok { color: var(--ok); } .err { color: var(--danger); }
     #log {
-      min-height: 420px; max-height: calc(100vh - 290px); overflow: auto;
-      font-family: var(--mono); font-size: .82rem; line-height: 1.45;
+      min-height: 360px; max-height: calc(100vh - 280px); overflow: auto;
+      font-family: var(--mono); font-size: .8rem; line-height: 1.45;
     }
     .msg { margin: 0 0 10px; white-space: pre-wrap; word-break: break-word; }
     .msg.user { color: var(--accent); }
     .msg.assistant { color: var(--ink); }
     .msg.thought { color: var(--muted); font-style: italic; }
     .msg.system { color: var(--warn); }
-    .tool-card {
-      border: 1px solid var(--line); border-radius: 10px; padding: 10px;
-      margin: 0 0 10px; background: rgba(255,255,255,.55); color: var(--tool);
+    .tool-card, .panel-item {
+      border: 1px solid var(--line); border-radius: 10px; padding: 8px 10px;
+      margin: 0 0 8px; background: rgba(255,255,255,.55);
     }
-    .tool-card .title { font-weight: 700; margin-bottom: 4px; }
-    .tool-card .meta { color: var(--muted); font-size: .75rem; margin-bottom: 6px; }
-    .tool-card pre {
+    .tool-card { color: var(--tool); }
+    .tool-card .title, .panel-item .title { font-weight: 700; margin-bottom: 3px; }
+    .tool-card .meta, .panel-item .meta { color: var(--muted); font-size: .72rem; margin-bottom: 4px; }
+    .tool-card pre, .term-out {
       margin: 0; white-space: pre-wrap; word-break: break-word;
-      max-height: 180px; overflow: auto; color: var(--ink);
+      max-height: 140px; overflow: auto; color: var(--ink);
+      font-family: var(--mono); font-size: .75rem;
     }
-    .diff-add { color: #1f6b3a; }
-    .diff-del { color: #8b2430; }
-    .pending {
-      border-left: 3px solid var(--warn); padding-left: 10px; margin: 10px 0;
-    }
+    .diff-add { color: #1f6b3a; } .diff-del { color: #8b2430; }
+    .pending { border-left: 3px solid var(--warn); padding-left: 10px; margin: 10px 0; }
     .session-item {
       width: 100%; text-align: left; margin: 0 0 6px;
       background: #fffdf8; color: var(--ink); border: 1px solid var(--line);
     }
     .session-item.active { border-color: var(--accent); }
     .usage {
-      display:grid; grid-template-columns: repeat(3, 1fr); gap: 8px;
-      font-family: var(--mono); font-size: .75rem;
+      display:grid; grid-template-columns: repeat(3, 1fr); gap: 6px;
+      font-family: var(--mono); font-size: .72rem;
     }
     .usage div {
       background: #fffdf8; border: 1px solid var(--line);
-      border-radius: 8px; padding: 8px;
+      border-radius: 8px; padding: 7px;
     }
-    .usage span { display:block; color: var(--muted); font-size: .7rem; }
+    .usage span { display:block; color: var(--muted); font-size: .68rem; }
+    .banner {
+      border: 1px dashed var(--warn); color: var(--warn);
+      border-radius: 8px; padding: 8px; margin-bottom: 10px; font-size: .85rem;
+    }
+    .panel-list { max-height: 180px; overflow: auto; }
+    .todo-pending { opacity: .75; }
+    .todo-completed { text-decoration: line-through; color: var(--muted); }
+    .todo-in_progress { color: var(--accent); font-weight: 700; }
   </style>
 </head>
 <body>
@@ -122,19 +113,28 @@
         <input id="token" placeholder="from launch URL hash" />
         <div class="row" style="margin-top:10px">
           <button id="btnStart">Connect</button>
-          <button id="btnNew" class="secondary" disabled>New session</button>
+          <button id="btnNew" class="secondary" disabled>New</button>
+          <button id="btnClose" class="secondary" disabled>Close</button>
         </div>
         <div class="row" style="margin-top:8px">
-          <button id="btnRefreshSessions" class="secondary" disabled>Refresh list</button>
+          <button id="btnRefreshSessions" class="secondary" disabled>Sessions</button>
           <button id="btnTakeover" class="secondary" disabled>Take control</button>
         </div>
         <p id="status" class="status" style="margin:10px 0 0">idle</p>
       </div>
       <div class="card">
         <div class="row" style="justify-content:space-between">
-          <strong>Sessions</strong>
+          <strong>Mode</strong>
           <span id="transport" class="status">transport: —</span>
         </div>
+        <div class="row" style="margin-top:8px">
+          <button id="btnModeDefault" class="secondary" disabled>default</button>
+          <button id="btnModePlan" class="secondary" disabled>plan</button>
+        </div>
+        <p id="modeLine" class="status" style="margin:8px 0 0">mode: —</p>
+      </div>
+      <div class="card">
+        <strong>Sessions</strong>
         <div id="sessions" style="margin-top:8px"></div>
       </div>
       <div class="card">
@@ -144,15 +144,17 @@
           <div><span>completion</span><b id="uCompletion">—</b></div>
           <div><span>total / ctx</span><b id="uTotal">—</b></div>
         </div>
-        <p id="modeLine" class="status" style="margin:8px 0 0">mode: —</p>
       </div>
     </aside>
 
     <main>
+      <div id="planBanner" class="banner" style="display:none">
+        Plan mode active — writes outside the plan file are blocked until you exit plan mode.
+      </div>
       <section class="card">
         <div id="log"></div>
       </section>
-      <section class="card" style="margin-top:12px">
+      <section class="card">
         <label for="prompt">Prompt</label>
         <textarea id="prompt" placeholder="Ask Zene to inspect or change code…"></textarea>
         <div class="row" style="margin-top:10px">
@@ -162,6 +164,36 @@
         </div>
       </section>
     </main>
+
+    <aside>
+      <div class="card">
+        <strong>Plan</strong>
+        <div id="planPanel" class="panel-list" style="margin-top:8px">
+          <p class="status">no plan yet</p>
+        </div>
+      </div>
+      <div class="card">
+        <strong>Todos</strong>
+        <div id="todoPanel" class="panel-list" style="margin-top:8px">
+          <p class="status">no todos</p>
+        </div>
+      </div>
+      <div class="card">
+        <strong>Background tasks</strong>
+        <div id="taskPanel" class="panel-list" style="margin-top:8px">
+          <p class="status">no tasks</p>
+        </div>
+      </div>
+      <div class="card">
+        <div class="row" style="justify-content:space-between">
+          <strong>Terminals</strong>
+          <button id="btnRefreshTerms" class="secondary" disabled>Refresh</button>
+        </div>
+        <div id="termPanel" class="panel-list" style="margin-top:8px">
+          <p class="status">no terminals</p>
+        </div>
+      </div>
+    </aside>
   </div>
 
   <script>
@@ -179,6 +211,11 @@
       assistantBuf: "",
       thoughtBuf: "",
       tools: new Map(),
+      planEntries: [],
+      todos: [],
+      tasks: new Map(),
+      terminals: new Map(),
+      mode: "default",
       preferSse: true,
     };
     localStorage.setItem("zene.clientId", state.clientId);
@@ -193,6 +230,13 @@
     function setTransport(name) {
       state.transport = name;
       el("transport").textContent = "transport: " + name;
+    }
+    function setMode(mode) {
+      state.mode = mode || "default";
+      el("modeLine").textContent = "mode: " + state.mode;
+      el("planBanner").style.display = state.mode === "plan" ? "block" : "none";
+      el("btnModeDefault").classList.toggle("active", state.mode === "default");
+      el("btnModePlan").classList.toggle("active", state.mode === "plan");
     }
     function uuid() {
       return crypto.randomUUID ? crypto.randomUUID() : ("req-" + Date.now() + Math.random());
@@ -217,8 +261,7 @@
       if (!res.ok) {
         const msg = (body && (body.message || body.error)) || res.statusText;
         const err = new Error(msg);
-        err.body = body;
-        err.status = res.status;
+        err.body = body; err.status = res.status;
         throw err;
       }
       return body;
@@ -261,42 +304,132 @@
         node.textContent = "thought: " + state.thoughtBuf;
       }
     }
+    function renderPlan() {
+      const root = el("planPanel");
+      if (!state.planEntries.length) {
+        root.innerHTML = `<p class="status">no plan yet</p>`;
+        return;
+      }
+      root.innerHTML = "";
+      for (const entry of state.planEntries) {
+        const item = document.createElement("div");
+        item.className = "panel-item";
+        const status = entry.status || "pending";
+        item.innerHTML = `<div class="title todo-${status}">${entry.content || JSON.stringify(entry)}</div>
+          <div class="meta">${status}${entry.priority ? " · " + entry.priority : ""}</div>`;
+        root.appendChild(item);
+      }
+    }
+    function renderTodos() {
+      const root = el("todoPanel");
+      if (!state.todos.length) {
+        root.innerHTML = `<p class="status">no todos</p>`;
+        return;
+      }
+      root.innerHTML = "";
+      for (const todo of state.todos) {
+        const item = document.createElement("div");
+        item.className = "panel-item";
+        const status = todo.status || "pending";
+        item.innerHTML = `<div class="title todo-${status}">${todo.content || todo.id || "?"}</div>
+          <div class="meta">${status}</div>`;
+        root.appendChild(item);
+      }
+    }
+    function renderTasks() {
+      const root = el("taskPanel");
+      const tasks = [...state.tasks.values()];
+      if (!tasks.length) {
+        root.innerHTML = `<p class="status">no tasks</p>`;
+        return;
+      }
+      root.innerHTML = "";
+      for (const task of tasks) {
+        const item = document.createElement("div");
+        item.className = "panel-item";
+        item.innerHTML = `<div class="title">${task.title}</div>
+          <div class="meta">${task.status} · ${task.id}</div>`;
+        root.appendChild(item);
+      }
+    }
+    function renderTerminals() {
+      const root = el("termPanel");
+      const terms = [...state.terminals.values()];
+      if (!terms.length) {
+        root.innerHTML = `<p class="status">no terminals</p>`;
+        return;
+      }
+      root.innerHTML = "";
+      for (const term of terms) {
+        const item = document.createElement("div");
+        item.className = "panel-item";
+        const kill = document.createElement("button");
+        kill.className = "danger";
+        kill.textContent = "Kill";
+        kill.disabled = term.status === "exited" || term.status === "released";
+        kill.onclick = () => killTerminal(term.terminalId);
+        item.innerHTML = `<div class="title">${term.command || term.terminalId}</div>
+          <div class="meta">${term.status || "?"} · ${term.terminalId}</div>
+          <pre class="term-out"></pre>`;
+        item.querySelector(".term-out").textContent = term.output || "";
+        item.appendChild(kill);
+        root.appendChild(item);
+      }
+    }
     function upsertToolCard(update) {
       const id = update.toolCallId || "tool";
       let card = state.tools.get(id);
       if (!card) {
         card = document.createElement("div");
         card.className = "tool-card";
-        card.dataset.id = id;
         card.innerHTML = `<div class="title"></div><div class="meta"></div><pre></pre>`;
         logEl.appendChild(card);
         state.tools.set(id, card);
       }
-      card.querySelector(".title").textContent =
-        `${update.sessionUpdate || "tool"} · ${update.title || update.kind || id}`;
+      const title = update.title || update.kind || id;
+      card.querySelector(".title").textContent = `${update.sessionUpdate || "tool"} · ${title}`;
       card.querySelector(".meta").textContent =
         `id=${id} status=${update.status || "?"} kind=${update.kind || "?"}`;
       const parts = [];
-      if (update.rawInput) parts.push(typeof update.rawInput === "string" ? update.rawInput : JSON.stringify(update.rawInput, null, 2));
+      if (update.rawInput) {
+        parts.push(typeof update.rawInput === "string" ? update.rawInput : JSON.stringify(update.rawInput, null, 2));
+        if (update.rawInput.todos) {
+          state.todos = update.rawInput.todos;
+          renderTodos();
+        }
+        if (update.rawInput.run_in_background || /Task|Bash/i.test(title)) {
+          state.tasks.set(id, {
+            id, title, status: update.status || "in_progress",
+          });
+          renderTasks();
+        }
+      }
       if (update.content) {
         const content = Array.isArray(update.content) ? update.content : [update.content];
         for (const c of content) {
           if (!c) continue;
-          if (c.type === "diff" && (c.path || c.oldText || c.newText)) {
+          if (c.type === "diff") {
             parts.push(`diff ${c.path || ""}`);
             if (c.oldText) parts.push(String(c.oldText).split("\n").map((l) => `- ${l}`).join("\n"));
             if (c.newText) parts.push(String(c.newText).split("\n").map((l) => `+ ${l}`).join("\n"));
           } else if (c.text) {
             parts.push(c.text);
+            const m = String(c.text).match(/task_id["']?\s*[:=]\s*["']?([A-Za-z0-9_-]+)/);
+            if (m) {
+              state.tasks.set(m[1], { id: m[1], title, status: update.status || "running" });
+              renderTasks();
+            }
           } else {
             parts.push(JSON.stringify(c));
           }
         }
       }
-      if (update._meta) parts.push(JSON.stringify(update._meta));
+      if (update.status && state.tasks.has(id)) {
+        state.tasks.get(id).status = update.status;
+        renderTasks();
+      }
       const pre = card.querySelector("pre");
       pre.textContent = parts.join("\n");
-      // crude diff coloring
       pre.innerHTML = pre.textContent.split("\n").map((line) => {
         const esc = line.replace(/[&<>]/g, (ch) => ({"&":"&amp;","<":"&lt;",">":"&gt;"}[ch]));
         if (line.startsWith("+")) return `<span class="diff-add">${esc}</span>`;
@@ -318,9 +451,7 @@
       const params = payload.params || {};
       const box = document.createElement("div");
       box.className = "pending";
-      const title = document.createElement("div");
-      title.textContent = `Permission: ${(params.toolCall && (params.toolCall.title || params.toolCall.toolCallId)) || "tool"}`;
-      box.appendChild(title);
+      box.innerHTML = `<div>Permission: ${(params.toolCall && (params.toolCall.title || params.toolCall.toolCallId)) || "tool"}</div>`;
       const row = document.createElement("div");
       row.className = "row";
       row.style.marginTop = "8px";
@@ -337,8 +468,7 @@
         btn.onclick = async () => {
           row.querySelectorAll("button").forEach((b) => b.disabled = true);
           await postMessages([{
-            jsonrpc: "2.0",
-            id: payload.id,
+            jsonrpc: "2.0", id: payload.id,
             result: { outcome: { outcome: "selected", optionId: opt.optionId } },
           }]);
           appendLog("system", `permission -> ${opt.optionId}`);
@@ -349,10 +479,37 @@
       logEl.appendChild(box);
       logEl.scrollTop = logEl.scrollHeight;
     }
+    function handleTerminalEvent(payload) {
+      const id = payload.terminalId || "term";
+      let term = state.terminals.get(id) || {
+        terminalId: id, command: "", status: "running", output: "",
+      };
+      if (payload.kind === "created") {
+        term.command = payload.command || id;
+        term.status = "running";
+        appendLog("system", `[terminal] created ${id}: ${term.command}`);
+      } else if (payload.kind === "output") {
+        term.output = (term.output || "") + (payload.chunk || "");
+        if (term.output.length > 20000) term.output = term.output.slice(-12000);
+      } else if (payload.kind === "exited") {
+        term.status = "exited";
+        appendLog("system", `[terminal] exited ${id} code=${payload.exitCode}`);
+      } else if (payload.kind === "released") {
+        term.status = "released";
+      } else if (payload.kind === "killed") {
+        term.status = "exited";
+      }
+      state.terminals.set(id, term);
+      renderTerminals();
+    }
     function handlePayload(payload) {
       if (!payload || typeof payload !== "object") return;
       if (payload.type === "gateway.system") {
         appendLog("system", `[gateway:${payload.kind}] ${payload.message || ""}`);
+        return;
+      }
+      if (payload.type === "gateway.terminal") {
+        handleTerminalEvent(payload);
         return;
       }
       if (payload.method === "session/update") {
@@ -361,27 +518,28 @@
         if (sid) state.sessionId = sid;
         switch (update.sessionUpdate) {
           case "agent_message_chunk":
-            renderChunk("assistant", update.content && update.content.text);
-            break;
+            renderChunk("assistant", update.content && update.content.text); break;
           case "agent_thought_chunk":
-            renderChunk("thought", update.content && update.content.text);
-            break;
+            renderChunk("thought", update.content && update.content.text); break;
           case "user_message_chunk":
-            appendLog("user", "user: " + ((update.content && update.content.text) || ""));
-            break;
+            appendLog("user", "user: " + ((update.content && update.content.text) || "")); break;
           case "tool_call":
           case "tool_call_update":
-            finalizeStreams();
-            upsertToolCard(update);
-            break;
+            finalizeStreams(); upsertToolCard(update); break;
           case "usage_update":
-            updateUsage(update);
-            break;
+            updateUsage(update); break;
           case "current_mode_update":
-            el("modeLine").textContent = "mode: " + (update.currentModeId || update.modeId || "?");
-            break;
+            setMode(update.currentModeId || update.modeId); break;
           case "plan":
-            appendLog("system", "plan: " + JSON.stringify(update.entries || update));
+            state.planEntries = update.entries || [];
+            // TodoWrite maps onto plan updates; keep todos in sync when shapes match.
+            if (state.planEntries.length) {
+              state.todos = state.planEntries.map((e, i) => ({
+                id: String(i + 1), content: e.content, status: e.status || "pending",
+              }));
+              renderTodos();
+            }
+            renderPlan();
             break;
           case "available_commands_update":
             break;
@@ -391,14 +549,17 @@
         return;
       }
       if (payload.method === "session/request_permission") {
-        handlePermission(payload);
+        handlePermission(payload); return;
+      }
+      if (payload.method && String(payload.method).startsWith("terminal/")) {
+        appendLog("system", `[acp] ${payload.method}`);
         return;
       }
       if (Object.prototype.hasOwnProperty.call(payload, "result") || Object.prototype.hasOwnProperty.call(payload, "error")) {
         if (payload.result && payload.result.sessionId) {
           state.sessionId = payload.result.sessionId;
           if (payload.result.modes && payload.result.modes.currentModeId) {
-            el("modeLine").textContent = "mode: " + payload.result.modes.currentModeId;
+            setMode(payload.result.modes.currentModeId);
           }
           appendLog("system", `session ready: ${state.sessionId}`);
           renderSessions();
@@ -446,9 +607,7 @@
     function startSse() {
       stopEventPump();
       setTransport("sse");
-      const qs = new URLSearchParams({
-        cursor: String(state.cursor), token: state.token,
-      });
+      const qs = new URLSearchParams({ cursor: String(state.cursor), token: state.token });
       const es = new EventSource(`/api/v1/agents/${state.agentId}/events/stream?${qs}`);
       state.eventSource = es;
       es.addEventListener("acp", (ev) => {
@@ -460,10 +619,7 @@
           appendLog("system", "sse parse error: " + err.message);
         }
       });
-      es.addEventListener("cursor_expired", () => {
-        appendLog("system", "cursor expired; falling back to long-poll after reload hint");
-        startLongPoll();
-      });
+      es.addEventListener("cursor_expired", () => startLongPoll());
       es.onerror = () => {
         appendLog("system", "sse disconnected; falling back to long-poll");
         startLongPoll();
@@ -473,10 +629,7 @@
       if (state.preferSse) {
         try {
           const boot = await api("/api/v1/bootstrap");
-          if (boot.transports && boot.transports.sse) {
-            startSse();
-            return;
-          }
+          if (boot.transports && boot.transports.sse) { startSse(); return; }
         } catch (_) {}
       }
       startLongPoll();
@@ -507,14 +660,14 @@
           const btn = document.createElement("button");
           btn.className = "session-item" + (s.sessionId === state.sessionId ? " active" : "");
           btn.textContent = `${s.title || s.sessionId}\n${s.updatedAt || ""}`;
-          btn.onclick = () => loadSession(s.sessionId, false);
+          btn.onclick = () => loadSession(s.sessionId);
           root.appendChild(btn);
         }
         return;
       }
-      if (state.sessionId) {
-        root.innerHTML = `<p class="status">active: ${state.sessionId}</p>`;
-      }
+      root.innerHTML = state.sessionId
+        ? `<p class="status">active: ${state.sessionId}</p>`
+        : `<p class="status">none</p>`;
     }
     async function refreshSessions() {
       await postMessages([rpcRequest("session/list", { cwd: el("workspace").value.trim() })]);
@@ -526,17 +679,54 @@
       })]);
       el("btnSend").disabled = false;
       el("btnCancel").disabled = false;
+      el("btnClose").disabled = false;
     }
-    async function loadSession(sessionId, resumeOnly) {
+    async function loadSession(sessionId) {
       finalizeStreams();
       state.tools.clear();
       logEl.innerHTML = "";
-      appendLog("system", (resumeOnly ? "resume " : "load ") + sessionId);
-      await postMessages([rpcRequest(resumeOnly ? "session/resume" : "session/load", {
+      appendLog("system", "load " + sessionId);
+      await postMessages([rpcRequest("session/load", {
         sessionId, cwd: el("workspace").value.trim(),
       })]);
       el("btnSend").disabled = false;
       el("btnCancel").disabled = false;
+      el("btnClose").disabled = false;
+    }
+    async function closeSession() {
+      if (!state.sessionId) return;
+      await postMessages([rpcRequest("session/close", { sessionId: state.sessionId })]);
+      appendLog("system", "session closed");
+      state.sessionId = null;
+      el("btnSend").disabled = true;
+      el("btnCancel").disabled = true;
+      renderSessions();
+    }
+    async function setSessionMode(modeId) {
+      if (!state.sessionId) return;
+      await postMessages([rpcRequest("session/set_mode", {
+        sessionId: state.sessionId, modeId,
+      })]);
+    }
+    async function refreshTerminals() {
+      if (!state.agentId) return;
+      const body = await api(`/api/v1/agents/${state.agentId}/terminals`);
+      for (const t of body.terminals || []) {
+        const prev = state.terminals.get(t.terminalId) || {};
+        state.terminals.set(t.terminalId, Object.assign({}, prev, {
+          terminalId: t.terminalId,
+          command: t.command,
+          status: t.status,
+        }));
+      }
+      renderTerminals();
+    }
+    async function killTerminal(terminalId) {
+      await api(`/api/v1/agents/${state.agentId}/terminals/${terminalId}/kill`, {
+        method: "POST",
+        body: "{}",
+      });
+      await refreshTerminals();
     }
     async function startAgent() {
       state.token = el("token").value.trim() || tokenFromHash();
@@ -560,13 +750,12 @@
           fs: { readTextFile: true, writeTextFile: true },
           terminal: true,
         },
-        clientInfo: { name: "zene-web-agent", version: "0.2.0" },
+        clientInfo: { name: "zene-web-agent", version: "0.3.0" },
       })]);
       await createSession();
       await refreshSessions();
-      el("btnNew").disabled = false;
-      el("btnRefreshSessions").disabled = false;
-      el("btnTakeover").disabled = false;
+      ["btnNew","btnRefreshSessions","btnTakeover","btnModeDefault","btnModePlan","btnRefreshTerms"]
+        .forEach((id) => el(id).disabled = false);
       setStatus("ready", "ok");
     }
     async function sendPrompt() {
@@ -591,8 +780,12 @@
 
     el("btnStart").onclick = () => startAgent().catch((e) => setStatus(e.message, "err"));
     el("btnNew").onclick = () => createSession().catch((e) => setStatus(e.message, "err"));
+    el("btnClose").onclick = () => closeSession().catch((e) => setStatus(e.message, "err"));
     el("btnRefreshSessions").onclick = () => refreshSessions().catch((e) => setStatus(e.message, "err"));
     el("btnTakeover").onclick = () => acquireLease(true).catch((e) => setStatus(e.message, "err"));
+    el("btnModeDefault").onclick = () => setSessionMode("default").catch((e) => setStatus(e.message, "err"));
+    el("btnModePlan").onclick = () => setSessionMode("plan").catch((e) => setStatus(e.message, "err"));
+    el("btnRefreshTerms").onclick = () => refreshTerminals().catch((e) => setStatus(e.message, "err"));
     el("btnSend").onclick = () => sendPrompt().catch((e) => setStatus(e.message, "err"));
     el("btnCancel").onclick = () => cancelTurn().catch((e) => setStatus(e.message, "err"));
     el("btnClear").onclick = () => { logEl.innerHTML = ""; state.tools.clear(); };

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -180,6 +180,7 @@ Stdout is reserved for protocol frames; logs go to stderr.
 - `GET /api/v1/agents/{id}/events?cursor=&waitMs=` long-polls a cursored event journal fed by child stdout
 - `GET /api/v1/agents/{id}/events/stream` is optional SSE; clients must fall back to long-polling
 - Controller lease (`/lease`, heartbeat, release) serializes multi-tab writes via `X-Zene-Client-Id`
+- When the Web client advertises `terminal`, the gateway hosts ACP `terminal/*` locally and mirrors output as `gateway.terminal` events
 - WebSocket is intentionally not required
 - The gateway does not own Agent loop / tools / sessions — those stay in Zene
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -416,6 +416,6 @@ TUI、record/replay、安装分发。
 | P5 MCP/扩展 | [x] | stdio + HTTP MCP、`zene mcp doctor` |
 | P6 集成/产品化 | [x] | `zene -p` headless + `--output-format json`；`zene acp`（resume/queue/thought/terminal + modes/FS/tool updates） |
 | P7 沙箱产品化 | [x] | 可配置 Keel profile、egress allowlist、凭据 deny、SpaceFs、auto_allow_bash |
-| P8 Web Agent | [~] | 阶段 A+B：`zene-gateway` 长轮询/SSE/lease + `apps/web-agent` + 真实 ACP smoke；见 `docs/WEB_AGENT_GATEWAY.md` |
+| P8 Web Agent | [~] | 阶段 A–C：gateway 长轮询/SSE/lease/terminal host + Plan/Todo/Task Web 面板；见 `docs/WEB_AGENT_GATEWAY.md` |
 
-*最后更新：2026-07-20（Web Agent Gateway 阶段 B）*
+*最后更新：2026-07-20（Web Agent Gateway 阶段 C）*

--- a/docs/WEB_AGENT_GATEWAY.md
+++ b/docs/WEB_AGENT_GATEWAY.md
@@ -772,10 +772,15 @@ Gateway bootstrap 返回：
 - [x] SSE 可选通道（`/events/stream`）与 Web 自动降级到长轮询
 - [x] 多标签页 controller lease（acquire/heartbeat/release + 写保护）
 
-### 下一刀（阶段 C）
+### 阶段 C（已落地）
 
-- [ ] Plan 审阅面板与模式切换 UI
-- [ ] Todo / 后台任务面板
-- [ ] terminal bridge 的 Web 视图
+- [x] Plan 审阅面板与模式切换 UI（`session/set_mode`）
+- [x] Todo / 后台任务面板（基于 `plan` / tool_call 更新）
+- [x] Gateway 本地 `terminal/*` host + Web 终端面板 / HTTP 查询与 kill
+- [x] session close 与 sessions 列表刷新
+
+### 下一刀（阶段 D / E）
+
 - [ ] journal 持久化与 Gateway 重启恢复
+- [ ] 负载、背压、超大 tool/terminal output  hardening
 - [ ] 达到删除 TUI 硬性门槛后移除 ratatui


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概述

PR #23 合并后继续阶段 C：补齐 Agent 工作面（Plan / Todo / 后台任务 / Terminal），Gateway 本地实现 ACP `terminal/*`。

## 变更

- **Terminal host**：Gateway 拦截并处理 `terminal/create|wait_for_exit|output|kill|release`，输出镜像为 `gateway.terminal` 事件
- **HTTP**：`GET /terminals`、`GET /terminals/{id}`、`POST /terminals/{id}/kill`
- **Web UI**：Plan 面板、Todo/任务面板、Terminal 面板、mode 切换、session close
- **测试**：terminal 单元测试 + mock ACP `TERMINAL_PING` 往返；原有 gateway / smoke 测试保持通过

## 测试

`cargo test -p zene-gateway`

## 后续

阶段 D：journal 持久化与重启恢复、背压 hardening；达到门槛后再删 TUI。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab3880ba-03bb-4b7f-a564-692c1685708d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab3880ba-03bb-4b7f-a564-692c1685708d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

