### PR TITLE
feat(gateway): phase D journal persist, restart/attach, and zene web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - New `zene-gateway` binary (`apps/gateway`): thin local HTTP bridge over `zene acp` with token/Origin checks, `POST /api/v1/agents/{id}/messages`, cursor-based `GET /api/v1/agents/{id}/events` long polling, bootstrap/health, embedded minimal Web page, and mock-ACP integration tests.
 - Gateway phase B: optional SSE (`GET /events/stream`) with Web long-poll fallback, controller lease APIs, `apps/web-agent` UI (sessions/tool cards/usage/SSE), `--yolo`/`--sandbox-off`/`--acp-env`, and real `zene acp` + mock LLM smoke test.
 - Gateway phase C: local ACP `terminal/*` host with Web terminal panel, Plan/Todo/background-task panels, mode switch + session close UI, and terminal roundtrip tests.
+- Gateway phase D: on-disk event journal + agent meta, `restart`/`attach` recovery, poll backpressure and payload limits, `zene web` launcher, and `docs/GATEWAY_OPS.md`.
 
 ### Changed
 - ACP: bridge `tool_call` / `tool_call_update` / `plan` / `usage_update` / `current_mode_update` / `available_commands_update` / `agent_thought_chunk`; replay history on `session/load`; implement `session/list`, `session/close`, `session/set_mode`, `session/resume`; optional client FS + terminal bridges; FIFO prompt queue with in-turn cancel; correlate permission `toolCallId`; accept embedded prompt context; tighten JSON-RPC error codes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4542,6 +4542,7 @@ dependencies = [
  "axum",
  "chrono",
  "clap",
+ "dirs",
  "futures",
  "reqwest 0.12.28",
  "serde",

--- a/README.md
+++ b/README.md
@@ -127,16 +127,18 @@ zene --yolo            # auto-approve Write / Edit / Bash
 zene --sandbox strict  # Keel profile: off | workspace | read-only | strict | custom
 zene --tui             # ratatui chat UI (PageUp/PageDown scroll)
 zene acp               # Agent Client Protocol over stdio (for editors / gateway)
+zene web --yolo --sandbox-off   # launch local Web Agent UI (zene-gateway)
 ```
 
-Headless Web UI (phase A vertical slice):
+Headless Web UI:
 
 ```bash
-cargo run -p zene-gateway -- --zene-bin ./target/debug/zene --yolo --sandbox-off
+cargo run -p zene-cli -- web --yolo --sandbox-off
+# or: cargo run -p zene-gateway -- --zene-bin ./target/debug/zene --yolo --sandbox-off
 # open the printed http://127.0.0.1:8787/#token=... URL
 ```
 
-`zene-gateway` is a thin local HTTP bridge: the Web UI prefers SSE and falls back to long-polling; the gateway speaks ACP NDJSON to a `zene acp` child process. UI sources live in `apps/web-agent/`. See [docs/WEB_AGENT_GATEWAY.md](docs/WEB_AGENT_GATEWAY.md).
+`zene-gateway` is a thin local HTTP bridge: the Web UI prefers SSE and falls back to long-polling; the gateway speaks ACP NDJSON to a `zene acp` child process. Journals persist under `~/.zene/gateway` for restart/attach recovery. UI sources live in `apps/web-agent/`. See [docs/WEB_AGENT_GATEWAY.md](docs/WEB_AGENT_GATEWAY.md) and [docs/GATEWAY_OPS.md](docs/GATEWAY_OPS.md).
 
 ## Architecture
 

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -111,6 +111,12 @@ enum Commands {
     },
     /// Speak Agent Client Protocol (ACP) over stdio JSON-RPC
     Acp,
+    /// Launch the local Web Agent UI via `zene-gateway`
+    Web {
+        /// Extra arguments forwarded to `zene-gateway` (e.g. `--port 8787 --yolo`)
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        gateway_args: Vec<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -230,6 +236,10 @@ async fn main() -> Result<()> {
         }
         Some(Commands::Acp) => {
             acp::run_acp(workdir, cli.yolo).await?;
+            return Ok(());
+        }
+        Some(Commands::Web { gateway_args }) => {
+            run_web_gateway(gateway_args)?;
             return Ok(());
         }
         None => {}
@@ -395,4 +405,45 @@ async fn run_mcp_doctor(workdir: &std::path::Path) -> Result<()> {
         println!("  - {}", def.name);
     }
     Ok(())
+}
+
+fn run_web_gateway(gateway_args: Vec<String>) -> Result<()> {
+    let gateway = resolve_gateway_bin();
+    let mut cmd = std::process::Command::new(&gateway);
+    if !gateway_args
+        .iter()
+        .any(|arg| arg == "--zene-bin" || arg.starts_with("--zene-bin="))
+    {
+        if let Ok(zene) = std::env::current_exe() {
+            cmd.arg("--zene-bin").arg(zene);
+        }
+    }
+    cmd.args(&gateway_args);
+    let status = cmd
+        .status()
+        .with_context(|| format!("failed to launch {}", gateway.display()))?;
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+    Ok(())
+}
+
+fn resolve_gateway_bin() -> PathBuf {
+    if let Ok(path) = std::env::var("ZENE_GATEWAY_BIN") {
+        return PathBuf::from(path);
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        let sibling = exe.with_file_name("zene-gateway");
+        if sibling.exists() {
+            return sibling;
+        }
+        #[cfg(windows)]
+        {
+            let sibling = exe.with_file_name("zene-gateway.exe");
+            if sibling.exists() {
+                return sibling;
+            }
+        }
+    }
+    PathBuf::from("zene-gateway")
 }

--- a/apps/gateway/Cargo.toml
+++ b/apps/gateway/Cargo.toml
@@ -18,6 +18,7 @@ anyhow.workspace = true
 axum.workspace = true
 chrono.workspace = true
 clap.workspace = true
+dirs.workspace = true
 futures.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true

--- a/apps/gateway/src/agent.rs
+++ b/apps/gateway/src/agent.rs
@@ -13,7 +13,10 @@ use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
 use crate::event_journal::EventJournal;
+use crate::store::{AgentMeta, DataStore};
 use crate::terminal::{is_terminal_request, TerminalHost, TerminalInfo};
+
+const DEFAULT_MAX_MESSAGE_BYTES: usize = 1_048_576;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -33,6 +36,8 @@ pub struct AgentInfo {
     pub pid: Option<u32>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub journal_path: Option<PathBuf>,
 }
 
 struct AgentRuntime {
@@ -49,6 +54,8 @@ pub struct AgentManager {
     command: PathBuf,
     command_args: Vec<String>,
     env: Vec<(String, String)>,
+    store: Option<DataStore>,
+    max_message_bytes: usize,
 }
 
 impl AgentManager {
@@ -58,6 +65,8 @@ impl AgentManager {
             command,
             command_args,
             env: Vec::new(),
+            store: None,
+            max_message_bytes: DEFAULT_MAX_MESSAGE_BYTES,
         }
     }
 
@@ -66,11 +75,113 @@ impl AgentManager {
         self
     }
 
+    pub fn with_store(mut self, store: DataStore) -> Self {
+        self.store = Some(store);
+        self
+    }
+
+    pub fn store(&self) -> Option<&DataStore> {
+        self.store.as_ref()
+    }
+
     pub async fn create(&self, workspace: PathBuf) -> Result<AgentInfo> {
         let workspace = canonicalize_workspace(&workspace)?;
         let agent_id = format!("agent_{}", Uuid::new_v4().simple());
-        let journal = EventJournal::new();
+        let journal = if let Some(store) = &self.store {
+            let now = chrono::Utc::now();
+            store.write_meta(&AgentMeta {
+                agent_id: agent_id.clone(),
+                workspace: workspace.clone(),
+                created_at: now,
+                updated_at: now,
+            })?;
+            EventJournal::with_persist(store.journal_path(&agent_id))
+        } else {
+            EventJournal::new()
+        };
+        self.spawn_agent(agent_id, workspace, journal, "agent_started")
+            .await
+    }
 
+    pub async fn restart(&self, agent_id: &str) -> Result<AgentInfo> {
+        let (workspace, journal) = {
+            let mut map = self.inner.write().await;
+            let runtime = map
+                .remove(agent_id)
+                .ok_or_else(|| anyhow!("agent not found"))?;
+            let mut guard = runtime.lock().await;
+            let workspace = guard.info.workspace.clone();
+            let journal = guard.journal.clone();
+            let _ = guard.child.start_kill();
+            guard.stdin = None;
+            drop(guard);
+            (workspace, journal)
+        };
+        journal
+            .append_system("agent_restarting", "respawning ACP child; journal retained")
+            .await;
+        if let Some(store) = &self.store {
+            if let Ok(mut meta) = store.read_meta(agent_id) {
+                meta.updated_at = chrono::Utc::now();
+                let _ = store.write_meta(&meta);
+            }
+        }
+        self.spawn_agent(agent_id.to_string(), workspace, journal, "agent_restarted")
+            .await
+    }
+
+    pub async fn attach(&self, agent_id: &str) -> Result<AgentInfo> {
+        if self.get(agent_id).await.is_some() {
+            bail!("agent already attached in this gateway process");
+        }
+        let store = self
+            .store
+            .as_ref()
+            .ok_or_else(|| anyhow!("persistence is disabled"))?;
+        let meta = store.read_meta(agent_id)?;
+        let workspace = canonicalize_workspace(&meta.workspace)?;
+        let journal = EventJournal::load_from_file(&store.journal_path(agent_id))?;
+        journal
+            .append_system(
+                "agent_attach",
+                "reattaching persisted agent journal after gateway restart",
+            )
+            .await;
+        self.spawn_agent(agent_id.to_string(), workspace, journal, "agent_started")
+            .await
+    }
+
+    pub async fn list_persisted(&self) -> Result<Vec<AgentMeta>> {
+        let Some(store) = &self.store else {
+            return Ok(Vec::new());
+        };
+        let mut out = Vec::new();
+        for id in store.list_agent_ids()? {
+            if let Ok(meta) = store.read_meta(&id) {
+                out.push(meta);
+            }
+        }
+        Ok(out)
+    }
+
+    pub async fn list_live(&self) -> Vec<AgentInfo> {
+        let map = self.inner.read().await;
+        let mut out = Vec::new();
+        for runtime in map.values() {
+            let guard = runtime.lock().await;
+            out.push(guard.info.clone());
+        }
+        out.sort_by(|a, b| a.agent_id.cmp(&b.agent_id));
+        out
+    }
+
+    async fn spawn_agent(
+        &self,
+        agent_id: String,
+        workspace: PathBuf,
+        journal: EventJournal,
+        start_kind: &str,
+    ) -> Result<AgentInfo> {
         let mut command = Command::new(&self.command);
         command
             .args(&self.command_args)
@@ -105,11 +216,12 @@ impl AgentManager {
 
         let info = AgentInfo {
             agent_id: agent_id.clone(),
-            workspace,
+            workspace: workspace.clone(),
             state: AgentState::Running,
             pid: child.id(),
             created_at: chrono::Utc::now(),
             exit_code: None,
+            journal_path: journal.persist_path().await,
         };
 
         let terminals = TerminalHost::new();
@@ -118,7 +230,7 @@ impl AgentManager {
             stdin: Some(stdin),
             child,
             journal: journal.clone(),
-            terminals: terminals.clone(),
+            terminals,
         }));
 
         {
@@ -153,8 +265,6 @@ impl AgentManager {
                 };
 
                 if is_terminal_request(&payload) {
-                    // Handle terminal requests off the stdout read loop so
-                    // wait_for_exit cannot stall other ACP frames.
                     let runtime = stdout_runtime.clone();
                     tokio::spawn(async move {
                         let (journal, terminals, workspace) = {
@@ -208,63 +318,13 @@ impl AgentManager {
             }
         });
 
-        let stderr_agent = agent_id.clone();
-        tokio::spawn(async move {
-            let mut lines = BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                tracing::warn!(agent_id = %stderr_agent, "acp stderr: {line}");
-            }
-        });
-
-        let wait_runtime = runtime.clone();
-        let wait_agent = agent_id.clone();
-        tokio::spawn(async move {
-            let exit = loop {
-                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-                let mut guard = wait_runtime.lock().await;
-                match guard.child.try_wait() {
-                    Ok(Some(status)) => break Ok(status),
-                    Ok(None) => {}
-                    Err(err) => break Err(err),
-                }
-            };
-
-            let mut guard = wait_runtime.lock().await;
-            match exit {
-                Ok(status) => {
-                    guard.info.state = if status.success() {
-                        AgentState::Exited
-                    } else {
-                        AgentState::Failed
-                    };
-                    guard.info.exit_code = status.code();
-                    guard.stdin = None;
-                    let code = status.code();
-                    let journal = guard.journal.clone();
-                    drop(guard);
-                    journal
-                        .append_system(
-                            "process_exit",
-                            format!("ACP process {wait_agent} exited with code {code:?}"),
-                        )
-                        .await;
-                }
-                Err(err) => {
-                    guard.info.state = AgentState::Failed;
-                    guard.stdin = None;
-                    let journal = guard.journal.clone();
-                    drop(guard);
-                    journal
-                        .append_system("process_wait_error", format!("failed to wait: {err}"))
-                        .await;
-                }
-            }
-        });
+        spawn_stderr_pump(agent_id.clone(), stderr);
+        spawn_wait_pump(runtime.clone(), agent_id.clone());
 
         journal
             .append_system(
-                "agent_started",
-                format!("ACP process started for {}", info.workspace.display()),
+                start_kind,
+                format!("ACP process ready for {}", workspace.display()),
             )
             .await;
 
@@ -286,6 +346,17 @@ impl AgentManager {
     }
 
     pub async fn write_messages(&self, agent_id: &str, messages: &[Value]) -> Result<usize> {
+        for message in messages {
+            let raw = serde_json::to_vec(message)?;
+            if raw.len() > self.max_message_bytes {
+                bail!(
+                    "message exceeds max size {} bytes (got {})",
+                    self.max_message_bytes,
+                    raw.len()
+                );
+            }
+        }
+
         let map = self.inner.read().await;
         let runtime = map
             .get(agent_id)
@@ -318,7 +389,7 @@ impl AgentManager {
         let map = self.inner.read().await;
         let runtime = map.get(agent_id)?.clone();
         let guard = runtime.lock().await;
-        let (oldest, latest, count) = guard.journal.snapshot_meta().await;
+        let (oldest, latest, count, bytes) = guard.journal.snapshot_meta().await;
         Some(AgentHealth {
             agent_id: guard.info.agent_id.clone(),
             state: guard.info.state,
@@ -328,8 +399,11 @@ impl AgentManager {
             oldest_cursor: oldest,
             latest_cursor: latest,
             event_count: count,
-            uptime_ms: (chrono::Utc::now() - guard.info.created_at).num_milliseconds().max(0)
-                as u64,
+            journal_bytes: bytes,
+            uptime_ms: (chrono::Utc::now() - guard.info.created_at)
+                .num_milliseconds()
+                .max(0) as u64,
+            restartable: matches!(guard.info.state, AgentState::Exited | AgentState::Failed),
         })
     }
 
@@ -373,6 +447,66 @@ impl AgentManager {
     }
 }
 
+fn spawn_stderr_pump(agent_id: String, stderr: impl tokio::io::AsyncRead + Unpin + Send + 'static) {
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(stderr).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            tracing::warn!(agent_id = %agent_id, "acp stderr: {line}");
+        }
+    });
+}
+
+fn spawn_wait_pump(runtime: Arc<Mutex<AgentRuntime>>, agent_id: String) {
+    tokio::spawn(async move {
+        let exit = loop {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            let mut guard = runtime.lock().await;
+            match guard.child.try_wait() {
+                Ok(Some(status)) => break Ok(status),
+                Ok(None) => {}
+                Err(err) => break Err(err),
+            }
+        };
+
+        let mut guard = runtime.lock().await;
+        // Ignore wait updates after restart replaced this runtime.
+        if guard.info.agent_id != agent_id {
+            return;
+        }
+        match exit {
+            Ok(status) => {
+                guard.info.state = if status.success() {
+                    AgentState::Exited
+                } else {
+                    AgentState::Failed
+                };
+                guard.info.exit_code = status.code();
+                guard.stdin = None;
+                let code = status.code();
+                let journal = guard.journal.clone();
+                drop(guard);
+                journal
+                    .append_system(
+                        "process_exit",
+                        format!(
+                            "ACP process {agent_id} exited with code {code:?}; POST .../restart to respawn"
+                        ),
+                    )
+                    .await;
+            }
+            Err(err) => {
+                guard.info.state = AgentState::Failed;
+                guard.stdin = None;
+                let journal = guard.journal.clone();
+                drop(guard);
+                journal
+                    .append_system("process_wait_error", format!("failed to wait: {err}"))
+                    .await;
+            }
+        }
+    });
+}
+
 async fn write_stdin_locked(
     runtime: &Arc<Mutex<AgentRuntime>>,
     messages: &[Value],
@@ -401,7 +535,9 @@ pub struct AgentHealth {
     pub oldest_cursor: Option<u64>,
     pub latest_cursor: u64,
     pub event_count: usize,
+    pub journal_bytes: usize,
     pub uptime_ms: u64,
+    pub restartable: bool,
 }
 
 pub fn resolve_zene_bin(explicit: Option<PathBuf>) -> PathBuf {

--- a/apps/gateway/src/event_journal.rs
+++ b/apps/gateway/src/event_journal.rs
@@ -1,16 +1,22 @@
 use std::collections::VecDeque;
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::{Notify, RwLock};
 
 const DEFAULT_MAX_EVENTS: usize = 10_000;
+const DEFAULT_MAX_BYTES: usize = 32 * 1024 * 1024;
 const DEFAULT_RETENTION: Duration = Duration::from_secs(30 * 60);
+const DEFAULT_MAX_PAYLOAD_BYTES: usize = 256 * 1024;
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JournalEvent {
     pub cursor: u64,
@@ -22,6 +28,7 @@ pub struct JournalEvent {
 struct StoredEvent {
     event: JournalEvent,
     stored_at: Instant,
+    approx_bytes: usize,
 }
 
 #[derive(Debug)]
@@ -29,7 +36,11 @@ struct JournalInner {
     next_cursor: u64,
     events: VecDeque<StoredEvent>,
     max_events: usize,
+    max_bytes: usize,
+    max_payload_bytes: usize,
     retention: Duration,
+    total_bytes: usize,
+    persist_path: Option<PathBuf>,
 }
 
 impl JournalInner {
@@ -37,8 +48,12 @@ impl JournalInner {
         let cutoff = Instant::now()
             .checked_sub(self.retention)
             .unwrap_or_else(Instant::now);
-        while self.events.len() > self.max_events {
-            self.events.pop_front();
+        while self.events.len() > self.max_events || self.total_bytes > self.max_bytes {
+            if let Some(removed) = self.events.pop_front() {
+                self.total_bytes = self.total_bytes.saturating_sub(removed.approx_bytes);
+            } else {
+                break;
+            }
         }
         while self
             .events
@@ -46,11 +61,11 @@ impl JournalInner {
             .is_some_and(|event| event.stored_at < cutoff)
             && self.events.len() > 1
         {
-            // Keep at least the newest event when pruning by age so nextCursor remains meaningful.
-            if self.events.len() == 1 {
+            if let Some(removed) = self.events.pop_front() {
+                self.total_bytes = self.total_bytes.saturating_sub(removed.approx_bytes);
+            } else {
                 break;
             }
-            self.events.pop_front();
         }
     }
 
@@ -60,6 +75,24 @@ impl JournalInner {
 
     fn latest_cursor(&self) -> u64 {
         self.next_cursor.saturating_sub(1)
+    }
+
+    fn persist_event(&self, event: &JournalEvent) -> Result<()> {
+        let Some(path) = &self.persist_path else {
+            return Ok(());
+        };
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("create journal dir {}", parent.display()))?;
+        }
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .with_context(|| format!("open journal {}", path.display()))?;
+        serde_json::to_writer(&mut file, event)?;
+        file.write_all(b"\n")?;
+        Ok(())
     }
 }
 
@@ -71,29 +104,105 @@ pub struct EventJournal {
 
 impl EventJournal {
     pub fn new() -> Self {
+        Self::with_limits(
+            DEFAULT_MAX_EVENTS,
+            DEFAULT_MAX_BYTES,
+            DEFAULT_MAX_PAYLOAD_BYTES,
+            None,
+        )
+    }
+
+    pub fn with_persist(path: PathBuf) -> Self {
+        Self::with_limits(
+            DEFAULT_MAX_EVENTS,
+            DEFAULT_MAX_BYTES,
+            DEFAULT_MAX_PAYLOAD_BYTES,
+            Some(path),
+        )
+    }
+
+    pub fn with_limits(
+        max_events: usize,
+        max_bytes: usize,
+        max_payload_bytes: usize,
+        persist_path: Option<PathBuf>,
+    ) -> Self {
         Self {
             inner: Arc::new(RwLock::new(JournalInner {
                 next_cursor: 1,
                 events: VecDeque::new(),
-                max_events: DEFAULT_MAX_EVENTS,
+                max_events,
+                max_bytes,
+                max_payload_bytes,
                 retention: DEFAULT_RETENTION,
+                total_bytes: 0,
+                persist_path,
             })),
             notify: Arc::new(Notify::new()),
         }
     }
 
+    pub fn load_from_file(path: &Path) -> Result<Self> {
+        let mut inner = JournalInner {
+            next_cursor: 1,
+            events: VecDeque::new(),
+            max_events: DEFAULT_MAX_EVENTS,
+            max_bytes: DEFAULT_MAX_BYTES,
+            max_payload_bytes: DEFAULT_MAX_PAYLOAD_BYTES,
+            retention: DEFAULT_RETENTION,
+            total_bytes: 0,
+            persist_path: Some(path.to_path_buf()),
+        };
+        if path.exists() {
+            let file = File::open(path).with_context(|| format!("open {}", path.display()))?;
+            let reader = BufReader::new(file);
+            for line in reader.lines() {
+                let line = line?;
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let event: JournalEvent = serde_json::from_str(&line)
+                    .with_context(|| format!("parse journal line in {}", path.display()))?;
+                let approx_bytes = approx_event_bytes(&event);
+                inner.next_cursor = inner.next_cursor.max(event.cursor.saturating_add(1));
+                inner.total_bytes = inner.total_bytes.saturating_add(approx_bytes);
+                inner.events.push_back(StoredEvent {
+                    event,
+                    stored_at: Instant::now(),
+                    approx_bytes,
+                });
+            }
+            inner.prune();
+        }
+        Ok(Self {
+            inner: Arc::new(RwLock::new(inner)),
+            notify: Arc::new(Notify::new()),
+        })
+    }
+
     pub async fn append(&self, payload: Value) -> u64 {
+        let payload = truncate_payload(payload, {
+            let inner = self.inner.read().await;
+            inner.max_payload_bytes
+        });
         let cursor = {
             let mut inner = self.inner.write().await;
             let cursor = inner.next_cursor;
             inner.next_cursor += 1;
+            let event = JournalEvent {
+                cursor,
+                created_at: Utc::now(),
+                payload,
+            };
+            if let Err(err) = inner.persist_event(&event) {
+                tracing::warn!("journal persist failed: {err}");
+            }
+            let approx_bytes = approx_event_bytes(&event);
+            inner.total_bytes = inner.total_bytes.saturating_add(approx_bytes);
             inner.events.push_back(StoredEvent {
-                event: JournalEvent {
-                    cursor,
-                    created_at: Utc::now(),
-                    payload,
-                },
+                event,
                 stored_at: Instant::now(),
+                approx_bytes,
             });
             inner.prune();
             cursor
@@ -111,13 +220,18 @@ impl EventJournal {
         .await
     }
 
-    pub async fn snapshot_meta(&self) -> (Option<u64>, u64, usize) {
+    pub async fn snapshot_meta(&self) -> (Option<u64>, u64, usize, usize) {
         let inner = self.inner.read().await;
         (
             inner.oldest_cursor(),
             inner.latest_cursor(),
             inner.events.len(),
+            inner.total_bytes,
         )
+    }
+
+    pub async fn persist_path(&self) -> Option<PathBuf> {
+        self.inner.read().await.persist_path.clone()
     }
 
     pub async fn read_after(
@@ -127,7 +241,6 @@ impl EventJournal {
     ) -> Result<(Vec<JournalEvent>, u64, bool), CursorExpired> {
         let inner = self.inner.read().await;
         if let Some(oldest) = inner.oldest_cursor() {
-            // Client missed events between cursor+1 and oldest-1.
             if oldest > cursor.saturating_add(1) {
                 return Err(CursorExpired {
                     oldest_cursor: oldest,
@@ -174,6 +287,26 @@ impl EventJournal {
     }
 }
 
+fn approx_event_bytes(event: &JournalEvent) -> usize {
+    serde_json::to_vec(event).map(|v| v.len()).unwrap_or(256)
+}
+
+fn truncate_payload(payload: Value, max_bytes: usize) -> Value {
+    let Ok(raw) = serde_json::to_vec(&payload) else {
+        return payload;
+    };
+    if raw.len() <= max_bytes {
+        return payload;
+    }
+    serde_json::json!({
+        "type": "gateway.system",
+        "kind": "payload_truncated",
+        "message": format!("original payload {} bytes exceeded limit {}", raw.len(), max_bytes),
+        "originalType": payload.get("type").cloned().unwrap_or(Value::Null),
+        "originalMethod": payload.get("method").cloned().unwrap_or(Value::Null),
+    })
+}
+
 #[derive(Debug, Clone)]
 pub struct CursorExpired {
     pub oldest_cursor: u64,
@@ -184,6 +317,7 @@ pub struct CursorExpired {
 mod tests {
     use super::*;
     use serde_json::json;
+    use tempfile::tempdir;
 
     #[tokio::test]
     async fn append_and_read_after_cursor() {
@@ -197,11 +331,6 @@ mod tests {
         assert_eq!(events.len(), 2);
         assert_eq!(next, 2);
         assert!(!has_more);
-
-        let (events, next, _) = journal.read_after(1, 10).await.unwrap();
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].cursor, 2);
-        assert_eq!(next, 2);
     }
 
     #[tokio::test]
@@ -218,5 +347,29 @@ mod tests {
             .unwrap();
         handle.await.unwrap();
         assert_eq!(events.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn persists_and_reloads() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("journal.jsonl");
+        let journal = EventJournal::with_persist(path.clone());
+        journal.append(json!({"n": 1})).await;
+        journal.append(json!({"n": 2})).await;
+
+        let reloaded = EventJournal::load_from_file(&path).unwrap();
+        let (events, next, _) = reloaded.read_after(0, 10).await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(next, 2);
+        assert_eq!(events[1].payload["n"], 2);
+    }
+
+    #[tokio::test]
+    async fn truncates_huge_payloads() {
+        let journal = EventJournal::with_limits(100, 1024 * 1024, 64, None);
+        let huge = "x".repeat(10_000);
+        journal.append(json!({ "blob": huge })).await;
+        let (events, _, _) = journal.read_after(0, 10).await.unwrap();
+        assert_eq!(events[0].payload["kind"], "payload_truncated");
     }
 }

--- a/apps/gateway/src/http.rs
+++ b/apps/gateway/src/http.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::extract::{Path, Query, State};
+use axum::extract::{DefaultBodyLimit, Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{Html, IntoResponse, Response};
@@ -20,13 +20,17 @@ use crate::agent::AgentManager;
 use crate::auth::{AuthState, ErrorBody};
 use crate::event_journal::CursorExpired;
 use crate::lease::{LeaseError, LeaseManager};
+use crate::poll_guard::PollGuard;
 use crate::static_page::INDEX_HTML;
+
+const MAX_BODY_BYTES: usize = 1_048_576;
 
 #[derive(Clone)]
 pub struct AppState {
     pub auth: AuthState,
     pub agents: AgentManager,
     pub leases: LeaseManager,
+    pub polls: PollGuard,
     pub started_at: chrono::DateTime<chrono::Utc>,
     pub version: &'static str,
 }
@@ -77,11 +81,13 @@ pub fn router(state: AppState) -> Router {
         .route("/", get(index))
         .route("/api/v1/bootstrap", get(bootstrap))
         .route("/api/v1/health", get(health))
-        .route("/api/v1/agents", post(create_agent))
+        .route("/api/v1/agents", get(list_agents).post(create_agent))
         .route("/api/v1/agents/{agent_id}/messages", post(post_messages))
         .route("/api/v1/agents/{agent_id}/events", get(get_events))
         .route("/api/v1/agents/{agent_id}/events/stream", get(stream_events))
         .route("/api/v1/agents/{agent_id}/health", get(agent_health))
+        .route("/api/v1/agents/{agent_id}/restart", post(restart_agent))
+        .route("/api/v1/agents/{agent_id}/attach", post(attach_agent))
         .route("/api/v1/agents/{agent_id}/lease", get(get_lease).post(acquire_lease))
         .route(
             "/api/v1/agents/{agent_id}/lease/heartbeat",
@@ -97,6 +103,7 @@ pub fn router(state: AppState) -> Router {
             "/api/v1/agents/{agent_id}/terminals/{terminal_id}/kill",
             post(kill_terminal),
         )
+        .layer(DefaultBodyLimit::max(MAX_BODY_BYTES))
         .layer(TraceLayer::new_for_http())
         .with_state(Arc::new(state))
 }
@@ -125,14 +132,18 @@ async fn bootstrap(State(state): State<Arc<AppState>>) -> impl IntoResponse {
             "controllerLease": true,
             "terminalHost": true,
             "planPanel": true,
-            "todoPanel": true
+            "todoPanel": true,
+            "journalPersist": state.agents.store().is_some(),
+            "agentRestart": true,
+            "agentAttach": state.agents.store().is_some()
         },
         "limits": {
-            "maxPostBodyBytes": 1_048_576,
+            "maxPostBodyBytes": MAX_BODY_BYTES,
             "maxMessagesPerPost": 100,
             "defaultWaitMs": 25_000,
             "maxWaitMs": 30_000,
             "maxEventsPerPoll": 200,
+            "maxConcurrentPollsPerAgent": 2,
             "leaseTtlMs": 30_000
         },
         "bind": {
@@ -151,6 +162,30 @@ async fn health(State(state): State<Arc<AppState>>) -> impl IntoResponse {
         "uptimeMs": (chrono::Utc::now() - state.started_at).num_milliseconds().max(0),
         "serverTime": chrono::Utc::now(),
     }))
+}
+
+async fn list_agents(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(status) = state.auth.authorize(&headers, None) {
+        return auth_error(status);
+    }
+    let live = state.agents.list_live().await;
+    match state.agents.list_persisted().await {
+        Ok(persisted) => Json(json!({
+            "agents": live,
+            "persisted": persisted,
+            "meta": meta(),
+        }))
+        .into_response(),
+        Err(err) => json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "list_agents_failed",
+            err.to_string(),
+            true,
+        ),
+    }
 }
 
 async fn create_agent(
@@ -263,11 +298,20 @@ async fn post_messages(
             (StatusCode::ACCEPTED, Json(payload)).into_response()
         }
         Err(err) => {
-            let retryable = err.to_string().contains("not running");
+            let msg = err.to_string();
+            if msg.contains("exceeds max size") {
+                return json_error(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    "message_too_large",
+                    msg,
+                    false,
+                );
+            }
+            let retryable = msg.contains("not running");
             json_error(
                 StatusCode::CONFLICT,
                 "agent_not_running",
-                err.to_string(),
+                msg,
                 retryable,
             )
         }
@@ -297,6 +341,14 @@ async fn get_events(
             "agent_not_found",
             "unknown agentId",
             false,
+        );
+    };
+    let Some(_permit) = state.polls.try_acquire(&agent_id).await else {
+        return json_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            "too_many_polls",
+            "too many concurrent event consumers for this agent",
+            true,
         );
     };
 
@@ -348,10 +400,19 @@ async fn stream_events(
             false,
         );
     };
+    let Some(permit) = state.polls.try_acquire(&agent_id).await else {
+        return json_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            "too_many_polls",
+            "too many concurrent event consumers for this agent",
+            true,
+        );
+    };
 
     let mut cursor = query.cursor.unwrap_or(0);
     let (tx, rx) = mpsc::channel::<Result<Event, Infallible>>(32);
     tokio::spawn(async move {
+        let _permit = permit;
         loop {
             match journal
                 .wait_for_events(cursor, 100, Duration::from_secs(20))
@@ -428,6 +489,60 @@ async fn agent_health(
             "agent_not_found",
             "unknown agentId",
             false,
+        ),
+    }
+}
+
+async fn restart_agent(
+    State(state): State<Arc<AppState>>,
+    Path(agent_id): Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(status) = state.auth.authorize(&headers, None) {
+        return auth_error(status);
+    }
+    let client_id = client_id_from_headers(&headers);
+    if let Err(err) = state
+        .leases
+        .authorize_write(&agent_id, client_id.as_deref())
+        .await
+    {
+        return lease_error(err);
+    }
+    match state.agents.restart(&agent_id).await {
+        Ok(agent) => Json(json!({
+            "agent": agent,
+            "meta": meta(),
+        }))
+        .into_response(),
+        Err(err) => json_error(
+            StatusCode::CONFLICT,
+            "agent_restart_failed",
+            err.to_string(),
+            true,
+        ),
+    }
+}
+
+async fn attach_agent(
+    State(state): State<Arc<AppState>>,
+    Path(agent_id): Path<String>,
+    headers: HeaderMap,
+) -> Response {
+    if let Err(status) = state.auth.authorize(&headers, None) {
+        return auth_error(status);
+    }
+    match state.agents.attach(&agent_id).await {
+        Ok(agent) => Json(json!({
+            "agent": agent,
+            "meta": meta(),
+        }))
+        .into_response(),
+        Err(err) => json_error(
+            StatusCode::BAD_REQUEST,
+            "agent_attach_failed",
+            err.to_string(),
+            true,
         ),
     }
 }

--- a/apps/gateway/src/lib.rs
+++ b/apps/gateway/src/lib.rs
@@ -3,5 +3,7 @@ pub mod auth;
 pub mod event_journal;
 pub mod http;
 pub mod lease;
+pub mod poll_guard;
 pub mod static_page;
+pub mod store;
 pub mod terminal;

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -7,6 +7,8 @@ use zene_gateway::agent::{resolve_zene_bin, AgentManager};
 use zene_gateway::auth::AuthState;
 use zene_gateway::http::{self, AppState};
 use zene_gateway::lease::LeaseManager;
+use zene_gateway::poll_guard::PollGuard;
+use zene_gateway::store::{default_data_dir, DataStore};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -51,6 +53,14 @@ struct Cli {
     #[arg(long = "acp-env")]
     acp_env: Vec<String>,
 
+    /// Directory for persisted agent journals/meta (`$ZENE_GATEWAY_DATA` or `~/.zene/gateway`).
+    #[arg(long)]
+    data_dir: Option<PathBuf>,
+
+    /// Disable on-disk journal persistence.
+    #[arg(long, default_value_t = false)]
+    no_persist: bool,
+
     /// Allow non-loopback binds. Required for any bind outside 127.0.0.1/::1.
     #[arg(long, default_value_t = false)]
     allow_remote: bool,
@@ -69,7 +79,13 @@ async fn main() -> Result<()> {
     let token = cli.token.clone().unwrap_or_else(AuthState::generate_token);
     let (command, args) = resolve_acp_command(&cli)?;
     let env = parse_acp_env(&cli.acp_env)?;
-    let agents = AgentManager::new(command.clone(), args.clone()).with_env(env);
+    let mut agents = AgentManager::new(command.clone(), args.clone()).with_env(env);
+    if !cli.no_persist {
+        let data_dir = cli.data_dir.clone().unwrap_or_else(default_data_dir);
+        let store = DataStore::new(data_dir.clone())?;
+        eprintln!("gateway data dir: {}", store.root().display());
+        agents = agents.with_store(store);
+    }
 
     let listener = tokio::net::TcpListener::bind((cli.bind.as_str(), cli.port))
         .await
@@ -80,6 +96,7 @@ async fn main() -> Result<()> {
         auth,
         agents,
         leases: LeaseManager::new(),
+        polls: PollGuard::new(2),
         started_at: chrono::Utc::now(),
         version: env!("CARGO_PKG_VERSION"),
     };

--- a/apps/gateway/src/poll_guard.rs
+++ b/apps/gateway/src/poll_guard.rs
@@ -1,0 +1,51 @@
+//! Limits concurrent long-poll / SSE consumers per agent.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+pub struct PollGuard {
+    inner: Arc<Mutex<HashMap<String, usize>>>,
+    max_per_agent: usize,
+}
+
+pub struct PollPermit {
+    guard: PollGuard,
+    agent_id: String,
+}
+
+impl PollGuard {
+    pub fn new(max_per_agent: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+            max_per_agent: max_per_agent.max(1),
+        }
+    }
+
+    pub async fn try_acquire(&self, agent_id: &str) -> Option<PollPermit> {
+        let mut map = self.inner.lock().ok()?;
+        let count = map.entry(agent_id.to_string()).or_insert(0);
+        if *count >= self.max_per_agent {
+            return None;
+        }
+        *count += 1;
+        Some(PollPermit {
+            guard: self.clone(),
+            agent_id: agent_id.to_string(),
+        })
+    }
+}
+
+impl Drop for PollPermit {
+    fn drop(&mut self) {
+        let Ok(mut map) = self.guard.inner.lock() else {
+            return;
+        };
+        if let Some(count) = map.get_mut(&self.agent_id) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                map.remove(&self.agent_id);
+            }
+        }
+    }
+}

--- a/apps/gateway/src/store.rs
+++ b/apps/gateway/src/store.rs
@@ -1,0 +1,93 @@
+//! On-disk layout for gateway agent journals and metadata.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentMeta {
+    pub agent_id: String,
+    pub workspace: PathBuf,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DataStore {
+    root: PathBuf,
+}
+
+impl DataStore {
+    pub fn new(root: PathBuf) -> Result<Self> {
+        fs::create_dir_all(&root)
+            .with_context(|| format!("create gateway data dir {}", root.display()))?;
+        Ok(Self { root })
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn agent_dir(&self, agent_id: &str) -> PathBuf {
+        self.root.join("agents").join(agent_id)
+    }
+
+    pub fn journal_path(&self, agent_id: &str) -> PathBuf {
+        self.agent_dir(agent_id).join("journal.jsonl")
+    }
+
+    pub fn meta_path(&self, agent_id: &str) -> PathBuf {
+        self.agent_dir(agent_id).join("meta.json")
+    }
+
+    pub fn write_meta(&self, meta: &AgentMeta) -> Result<()> {
+        let dir = self.agent_dir(&meta.agent_id);
+        fs::create_dir_all(&dir)?;
+        let path = self.meta_path(&meta.agent_id);
+        let body = serde_json::to_vec_pretty(meta)?;
+        fs::write(&path, body).with_context(|| format!("write {}", path.display()))?;
+        Ok(())
+    }
+
+    pub fn read_meta(&self, agent_id: &str) -> Result<AgentMeta> {
+        let path = self.meta_path(agent_id);
+        if !path.exists() {
+            bail!("unknown persisted agentId: {agent_id}");
+        }
+        let raw = fs::read_to_string(&path)?;
+        Ok(serde_json::from_str(&raw)?)
+    }
+
+    pub fn list_agent_ids(&self) -> Result<Vec<String>> {
+        let agents = self.root.join("agents");
+        if !agents.exists() {
+            return Ok(Vec::new());
+        }
+        let mut ids = Vec::new();
+        for entry in fs::read_dir(agents)? {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                if let Some(name) = entry.file_name().to_str() {
+                    if self.meta_path(name).exists() {
+                        ids.push(name.to_string());
+                    }
+                }
+            }
+        }
+        ids.sort();
+        Ok(ids)
+    }
+}
+
+pub fn default_data_dir() -> PathBuf {
+    if let Ok(path) = std::env::var("ZENE_GATEWAY_DATA") {
+        return PathBuf::from(path);
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".zene")
+        .join("gateway")
+}

--- a/apps/gateway/tests/gateway_http.rs
+++ b/apps/gateway/tests/gateway_http.rs
@@ -8,29 +8,44 @@ use zene_gateway::agent::AgentManager;
 use zene_gateway::auth::AuthState;
 use zene_gateway::http::{self, AppState};
 use zene_gateway::lease::LeaseManager;
+use zene_gateway::poll_guard::PollGuard;
+use zene_gateway::store::DataStore;
 
 fn mock_acp_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_zene-gateway-mock-acp"))
 }
 
-async fn start_server(token: &str) -> (SocketAddr, reqwest::Client) {
+async fn start_server_with(
+    token: &str,
+    store: Option<DataStore>,
+    max_polls: usize,
+) -> (SocketAddr, reqwest::Client, tokio::task::JoinHandle<()>) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind");
     let addr = listener.local_addr().expect("addr");
-    let agents = AgentManager::new(mock_acp_bin(), Vec::new());
+    let mut agents = AgentManager::new(mock_acp_bin(), Vec::new());
+    if let Some(store) = store {
+        agents = agents.with_store(store);
+    }
     let state = AppState {
         auth: AuthState::new(token.to_string(), "127.0.0.1".into(), addr.port()),
         agents,
         leases: LeaseManager::new(),
+        polls: PollGuard::new(max_polls),
         started_at: chrono::Utc::now(),
         version: "test",
     };
     let app = http::router(state);
-    tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         axum::serve(listener, app).await.expect("serve");
     });
     let client = reqwest::Client::new();
+    (addr, client, handle)
+}
+
+async fn start_server(token: &str) -> (SocketAddr, reqwest::Client) {
+    let (addr, client, _handle) = start_server_with(token, None, 2).await;
     (addr, client)
 }
 
@@ -98,6 +113,8 @@ async fn bootstrap_advertises_sse_and_lease() {
     assert_eq!(boot["features"]["controllerLease"], true);
     assert_eq!(boot["features"]["terminalHost"], true);
     assert_eq!(boot["features"]["planPanel"], true);
+    assert_eq!(boot["features"]["agentRestart"], true);
+    assert_eq!(boot["limits"]["maxConcurrentPollsPerAgent"], 2);
 }
 
 #[tokio::test]
@@ -618,4 +635,243 @@ async fn controller_lease_blocks_other_client_writes() {
         .await
         .unwrap();
     assert_eq!(stolen["lease"]["clientId"], "other");
+}
+
+#[tokio::test]
+async fn persists_journal_and_supports_attach_after_gateway_restart() {
+    let data = tempdir().unwrap();
+    let store = DataStore::new(data.path().to_path_buf()).unwrap();
+    let token = "secret";
+    let (addr, client, handle) = start_server_with(token, Some(store.clone()), 2).await;
+    let workspace = tempdir().unwrap();
+
+    let created: Value = client
+        .post(format!("http://{addr}/api/v1/agents"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "persist-1",
+            "workspace": workspace.path()
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let agent_id = created["agent"]["agentId"].as_str().unwrap().to_string();
+    assert!(created["agent"]["journalPath"].as_str().is_some());
+
+    let mut cursor = 0u64;
+    let _ = wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p["kind"] == "agent_started"
+    })
+    .await;
+
+    let listed: Value = client
+        .get(format!("http://{addr}/api/v1/agents"))
+        .header("X-Zene-Token", token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(listed["persisted"].as_array().unwrap().len(), 1);
+    assert_eq!(listed["persisted"][0]["agentId"], agent_id);
+
+    // Simulate gateway process restart: stop first process, reopen same data dir.
+    handle.abort();
+    let (addr2, client2, _handle2) = start_server_with(token, Some(store), 2).await;
+    let attached: Value = client2
+        .post(format!("http://{addr2}/api/v1/agents/{agent_id}/attach"))
+        .headers(auth_json(token))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(attached["agent"]["agentId"], agent_id);
+
+    let events: Value = client2
+        .get(format!(
+            "http://{addr2}/api/v1/agents/{agent_id}/events?cursor=0&waitMs=0&limit=50"
+        ))
+        .header("X-Zene-Token", token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let kinds: Vec<&str> = events["events"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|e| e["payload"]["kind"].as_str())
+        .collect();
+    assert!(kinds.contains(&"agent_started"));
+    assert!(kinds.iter().any(|k| *k == "agent_attach"));
+}
+
+#[tokio::test]
+async fn restart_keeps_journal_and_respawns_child() {
+    let token = "secret";
+    let (addr, client) = start_server(token).await;
+    let workspace = tempdir().unwrap();
+
+    let created: Value = client
+        .post(format!("http://{addr}/api/v1/agents"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "restart-1",
+            "workspace": workspace.path()
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let agent_id = created["agent"]["agentId"].as_str().unwrap().to_string();
+    let mut cursor = 0u64;
+    let _ = wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p["kind"] == "agent_started"
+    })
+    .await;
+
+    let restarted: Value = client
+        .post(format!("http://{addr}/api/v1/agents/{agent_id}/restart"))
+        .headers(auth_json(token))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(restarted["agent"]["agentId"], agent_id);
+    assert_eq!(restarted["agent"]["state"], "running");
+
+    let payload = wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p["kind"] == "agent_restarted" || p["kind"] == "agent_restarting"
+    })
+    .await;
+    assert!(
+        payload["kind"] == "agent_restarted" || payload["kind"] == "agent_restarting",
+        "{payload}"
+    );
+}
+
+#[tokio::test]
+async fn rejects_too_many_concurrent_polls() {
+    let token = "secret";
+    let (addr, client, _handle) = start_server_with(token, None, 1).await;
+    let workspace = tempdir().unwrap();
+
+    let created: Value = client
+        .post(format!("http://{addr}/api/v1/agents"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "poll-1",
+            "workspace": workspace.path()
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let agent_id = created["agent"]["agentId"].as_str().unwrap().to_string();
+
+    // Drain existing events so the next long-poll actually waits and holds a permit.
+    let mut cursor = 0u64;
+    let _ = wait_for_payload(&client, addr, token, &agent_id, &mut cursor, |p| {
+        p["kind"] == "agent_started"
+    })
+    .await;
+    let drain: Value = client
+        .get(format!(
+            "http://{addr}/api/v1/agents/{agent_id}/events?cursor={cursor}&waitMs=0&limit=50"
+        ))
+        .header("X-Zene-Token", token)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    cursor = drain["nextCursor"].as_u64().unwrap_or(cursor);
+
+    let url = format!(
+        "http://{addr}/api/v1/agents/{agent_id}/events?cursor={cursor}&waitMs=3000&limit=1"
+    );
+    let client_hang = client.clone();
+    let token_hang = token.to_string();
+    let hang = tokio::spawn(async move {
+        client_hang
+            .get(url)
+            .header("X-Zene-Token", token_hang)
+            .send()
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let denied = client
+        .get(format!(
+            "http://{addr}/api/v1/agents/{agent_id}/events?cursor={cursor}&waitMs=0&limit=1"
+        ))
+        .header("X-Zene-Token", token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(denied.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
+    let body: Value = denied.json().await.unwrap();
+    assert_eq!(body["error"], "too_many_polls");
+
+    let _ = hang.await;
+}
+
+#[tokio::test]
+async fn rejects_oversized_message_payload() {
+    let token = "secret";
+    let (addr, client) = start_server(token).await;
+    let workspace = tempdir().unwrap();
+
+    let created: Value = client
+        .post(format!("http://{addr}/api/v1/agents"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "big-1",
+            "workspace": workspace.path()
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let agent_id = created["agent"]["agentId"].as_str().unwrap().to_string();
+
+    let huge = "x".repeat(1_100_000);
+    let denied = client
+        .post(format!("http://{addr}/api/v1/agents/{agent_id}/messages"))
+        .headers(auth_json(token))
+        .json(&json!({
+            "requestId": "big-msg",
+            "messages": [{
+                "jsonrpc": "2.0",
+                "method": "session/prompt",
+                "params": { "text": huge }
+            }]
+        }))
+        .send()
+        .await
+        .unwrap();
+    // Body limit (1 MiB) or per-message size check both reject oversized posts.
+    assert!(
+        denied.status() == reqwest::StatusCode::PAYLOAD_TOO_LARGE
+            || denied.status() == reqwest::StatusCode::BAD_REQUEST,
+        "unexpected status {}",
+        denied.status()
+    );
 }

--- a/apps/gateway/tests/zene_acp_smoke.rs
+++ b/apps/gateway/tests/zene_acp_smoke.rs
@@ -254,6 +254,7 @@ async fn gateway_with_real_zene_acp_writes_file() {
         auth: AuthState::new(token.into(), "127.0.0.1".into(), addr.port()),
         agents,
         leases: LeaseManager::new(),
+        polls: zene_gateway::poll_guard::PollGuard::new(2),
         started_at: chrono::Utc::now(),
         version: "test",
     };

--- a/docs/GATEWAY_OPS.md
+++ b/docs/GATEWAY_OPS.md
@@ -1,0 +1,82 @@
+# Zene Gateway 运维指南
+
+本地 HTTP Gateway（`zene-gateway` / `zene web`）把浏览器 Web Agent UI 接到 `zene acp`。本文覆盖配置、安全与升级。
+
+## 启动
+
+推荐入口：
+
+```bash
+# 与 zene 同目录安装时
+zene web --yolo --sandbox-off
+
+# 或直接
+zene-gateway --zene-bin "$(which zene)" --yolo --sandbox-off
+```
+
+`zene web` 会自动把当前 `zene` 可执行文件传给 gateway（可用 `ZENE_GATEWAY_BIN` 覆盖 gateway 路径）。默认监听 `127.0.0.1:8787`，启动时打印带 token 的 URL。
+
+常用参数：
+
+| 参数 | 含义 |
+|------|------|
+| `--bind` / `--port` | 监听地址；非 loopback 必须加 `--allow-remote` |
+| `--token` | 共享访问令牌；省略则每次生成 |
+| `--data-dir` | journal/meta 目录；默认 `$ZENE_GATEWAY_DATA` 或 `~/.zene/gateway` |
+| `--no-persist` | 关闭落盘（进程退出后不可 attach） |
+| `--yolo` / `--sandbox-off` | 传给 `zene acp` 子进程 |
+| `--acp-env KEY=VALUE` | 子进程环境变量（如模型 API） |
+| `--acp-command` / `--acp-arg` | 覆盖 ACP 命令（测试用） |
+
+## 持久化与恢复
+
+默认启用 journal 持久化：
+
+```text
+~/.zene/gateway/agents/<agentId>/
+  meta.json       # workspace、时间戳
+  journal.jsonl   # 事件游标日志（含系统事件与 ACP 帧）
+```
+
+恢复策略：
+
+- **Agent 子进程崩溃**：journal 保留；`POST /api/v1/agents/{id}/restart` 重新拉起 ACP，不静默重放未确认 prompt。
+- **Gateway 进程重启**：内存中的 live agent 丢失；`GET /api/v1/agents` 的 `persisted` 列出可恢复项，再 `POST .../attach` 重挂 journal 并启动新 ACP 子进程。
+- **页面刷新**：用 cursor 长轮询/SSE 续读即可，无需 attach。
+
+## 背压与限制
+
+| 限制 | 默认 |
+|------|------|
+| POST body | 1 MiB |
+| 单条 ACP message | 1 MiB |
+| 单次 POST messages 条数 | 100 |
+| journal 事件数 / 字节 | 约 1 万条 / 32 MiB（超限淘汰旧事件） |
+| 单条 journal payload | 256 KiB（超限记 `payload_truncated`） |
+| 每 agent 并发 poll/SSE | 2（超额 429 `too_many_polls`） |
+| 长轮询 waitMs | 默认 25s，上限 30s |
+
+超大 tool/terminal 输出会先在 journal 层截断，避免拖垮 Gateway 内存。
+
+## 安全
+
+- 默认只绑 loopback；远程绑定需 `--allow-remote`，生产环境应另加 TLS、反向代理与更强认证。
+- 写请求需要 `X-Zene-Token`（或 `Authorization: Bearer` / query `token`）。
+- 带 `Origin` 的浏览器请求必须来自本机允许源。
+- 多标签写保护：controller lease；非持有者写操作返回冲突。
+- 不要把 API key 放进浏览器；通过 `--acp-env` 或本机环境注入给 `zene acp`。
+
+## 升级
+
+1. 升级 `zene` 与 `zene-gateway`（建议同版本）。
+2. `/api/v1` 内只做向后兼容字段增加；破坏性 envelope 变化会走 `/api/v2`。
+3. journal 文件为 JSONL；升级后旧 journal 仍可 attach，但 cursor 过期时客户端应从 `oldestCursor` 重新同步。
+4. 升级窗口内可先 `--no-persist` 做一次性验证，再切回默认落盘。
+
+## 健康检查
+
+- `GET /api/v1/health`：进程存活
+- `GET /api/v1/bootstrap`：传输能力、特性开关、限制
+- `GET /api/v1/agents/{id}/health`：子进程状态、journal 游标、是否可 restart
+
+设计细节见 [WEB_AGENT_GATEWAY.md](./WEB_AGENT_GATEWAY.md)。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -416,6 +416,6 @@ TUI、record/replay、安装分发。
 | P5 MCP/扩展 | [x] | stdio + HTTP MCP、`zene mcp doctor` |
 | P6 集成/产品化 | [x] | `zene -p` headless + `--output-format json`；`zene acp`（resume/queue/thought/terminal + modes/FS/tool updates） |
 | P7 沙箱产品化 | [x] | 可配置 Keel profile、egress allowlist、凭据 deny、SpaceFs、auto_allow_bash |
-| P8 Web Agent | [~] | 阶段 A–C：gateway 长轮询/SSE/lease/terminal host + Plan/Todo/Task Web 面板；见 `docs/WEB_AGENT_GATEWAY.md` |
+| P8 Web Agent | [~] | 阶段 A–D：gateway 长轮询/SSE/lease/terminal/persist/restart + `zene web`；见 `docs/WEB_AGENT_GATEWAY.md` |
 
-*最后更新：2026-07-20（Web Agent Gateway 阶段 C）*
+*最后更新：2026-07-20（Web Agent Gateway 阶段 D）*

--- a/docs/WEB_AGENT_GATEWAY.md
+++ b/docs/WEB_AGENT_GATEWAY.md
@@ -779,8 +779,14 @@ Gateway bootstrap 返回：
 - [x] Gateway 本地 `terminal/*` host + Web 终端面板 / HTTP 查询与 kill
 - [x] session close 与 sessions 列表刷新
 
-### 下一刀（阶段 D / E）
+### 阶段 D（已落地）
 
-- [ ] journal 持久化与 Gateway 重启恢复
-- [ ] 负载、背压、超大 tool/terminal output  hardening
+- [x] journal 落盘（`~/.zene/gateway` / `--data-dir` / `--no-persist`）
+- [x] Agent 崩溃 `restart` 与 Gateway 重启后 `attach`（不静默重放 prompt）
+- [x] 背压：并发 poll 上限、POST/message 大小限制、超大 payload 截断
+- [x] `zene web` 入口与 [GATEWAY_OPS.md](./GATEWAY_OPS.md) 运维文档
+
+### 下一刀（阶段 E）
+
 - [ ] 达到删除 TUI 硬性门槛后移除 ratatui
+- [ ] 默认交互入口切到 Web Agent


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #24（阶段 C）已合并。本 PR 落地 Web Agent Gateway **阶段 D：可靠性与发布**。

## 变更
- Journal 落盘到 `~/.zene/gateway`（可用 `--data-dir` / `ZENE_GATEWAY_DATA` / `--no-persist`）
- `POST .../restart`：子进程崩溃后保留 journal 并重拉 ACP（不静默重放 prompt）
- `POST .../attach` + `GET /agents` 的 `persisted`：Gateway 重启后重挂
- 背压：每 agent 最多 2 个并发 poll/SSE、POST/message 大小限制、超大 payload 截断
- CLI：`zene web` 启动 gateway；文档：`docs/GATEWAY_OPS.md`

## 测试
`cargo test -p zene-gateway`（含 persist/attach、restart、429 too_many_polls、超大 body、真实 ACP smoke）

## 非目标
阶段 E（删除 TUI）未包含。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab3880ba-03bb-4b7f-a564-692c1685708d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab3880ba-03bb-4b7f-a564-692c1685708d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

