### PR TITLE
fix: silence unused-code warnings in core and CLI

### DIFF
--- a/apps/cli/src/acp/transport.rs
+++ b/apps/cli/src/acp/transport.rs
@@ -5,7 +5,7 @@ use anyhow::{anyhow, Result};
 use serde_json::{json, Value};
 use tokio::sync::oneshot;
 
-struct PendingResponse {
+pub(crate) struct PendingResponse {
     tx: oneshot::Sender<Result<Value, Value>>,
 }
 

--- a/apps/cli/src/model_config.rs
+++ b/apps/cli/src/model_config.rs
@@ -143,34 +143,11 @@ pub fn current_provider(config: &ZeneConfig) -> Option<&'static ProviderPreset> 
     provider_index_for_config(config).map(|i| &PROVIDER_PRESETS[i])
 }
 
-pub fn is_provider_configured(config: &ZeneConfig) -> bool {
-    provider_index_for_config(config).is_some()
-}
-
 pub fn is_provider_ready(config: &ZeneConfig) -> bool {
     let Some(index) = provider_index_for_config(config) else {
         return false;
     };
     has_api_key_for_provider(config, &PROVIDER_PRESETS[index])
-}
-
-pub fn model_index_for_provider(provider: &ProviderPreset, model_id: &str) -> usize {
-    preset_models(provider)
-        .iter()
-        .position(|v| v.model_id == model_id)
-        .unwrap_or(0)
-}
-
-pub fn default_model_for_provider(provider: &ProviderPreset, current_model: &str) -> String {
-    let models = preset_models(provider);
-    if models.iter().any(|v| v.model_id == current_model) {
-        current_model.to_string()
-    } else {
-        models
-            .first()
-            .map(|v| v.model_id.to_string())
-            .unwrap_or_default()
-    }
 }
 
 pub fn find_model_variant(model_id: &str) -> Option<(&'static ProviderPreset, ModelVariant)> {
@@ -182,45 +159,6 @@ pub fn find_model_variant(model_id: &str) -> Option<(&'static ProviderPreset, Mo
         }
     }
     None
-}
-
-pub fn is_known_model(model_id: &str) -> bool {
-    find_model_variant(model_id).is_some()
-}
-
-pub fn selection_for_model(model_id: &str) -> (usize, usize) {
-    for (provider_index, provider) in PROVIDER_PRESETS.iter().enumerate() {
-        for (model_index, variant) in preset_models(provider).into_iter().enumerate() {
-            if variant.model_id == model_id {
-                return (provider_index, model_index);
-            }
-        }
-    }
-    (0, 0)
-}
-
-pub fn selection_for_model_with_base_url(model_id: &str, base_url: &str) -> (usize, usize) {
-    let (provider_index, model_index) = selection_for_model(model_id);
-    if is_known_model(model_id) {
-        return (provider_index, model_index);
-    }
-    if base_url.contains("11434") {
-        if let Some(ollama_index) = PROVIDER_PRESETS
-            .iter()
-            .position(|p| p.endpoint_id.is_none())
-        {
-            return (ollama_index, 0);
-        }
-    }
-    if base_url.contains("deepseek") {
-        if let Some(i) = PROVIDER_PRESETS
-            .iter()
-            .position(|p| p.endpoint_id == Some("deepseek:cn"))
-        {
-            return (i, 0);
-        }
-    }
-    (provider_index, model_index)
 }
 
 pub fn resolve_model_args(raw_model: &str, parts: &[&str]) -> ResolvedModel {
@@ -326,12 +264,6 @@ pub fn has_api_key_for_openai_provider(config: &ZeneConfig, base_url: &str) -> b
         .any(|var| std::env::var(var).is_ok_and(|k| !k.is_empty()))
 }
 
-pub fn model_requires_key(model_id: &str) -> bool {
-    find_model_variant(model_id)
-        .map(|(provider, _)| provider.requires_key)
-        .unwrap_or(true)
-}
-
 pub fn lookup_registry_model(endpoint_id: &str, model_id: &str) -> Option<Model> {
     get_model_for_endpoint(endpoint_id, model_id)
 }
@@ -420,12 +352,10 @@ mod tests {
 
     #[test]
     fn selection_finds_deepseek_v4_flash() {
-        let (pi, mi) = selection_for_model("deepseek-v4-flash");
-        assert_eq!(PROVIDER_PRESETS[pi].display_name, "DeepSeek");
-        assert_eq!(
-            preset_models(&PROVIDER_PRESETS[pi])[mi].model_id,
-            "deepseek-v4-flash"
-        );
+        let (provider, variant) =
+            find_model_variant("deepseek-v4-flash").expect("deepseek-v4-flash preset");
+        assert_eq!(provider.display_name, "DeepSeek");
+        assert_eq!(variant.model_id, "deepseek-v4-flash");
     }
 
     #[test]

--- a/crates/core/src/compaction.rs
+++ b/crates/core/src/compaction.rs
@@ -373,7 +373,6 @@ pub async fn summarize_prefix(
 
     if let Some(cache) = prefire {
         if cache.split_idx > 0 && cache.split_idx < body.len() {
-            let pass1_prefix = &body[..cache.split_idx];
             let tail = &body[cache.split_idx..];
             info!(
                 split_idx = cache.split_idx,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -952,7 +952,6 @@ impl Agent {
                         note1,
                         fingerprint,
                         split_idx,
-                        prefix_end: prefix_start + split_idx,
                     })
                 }
                 Err(err) => {

--- a/crates/core/src/memory.rs
+++ b/crates/core/src/memory.rs
@@ -155,7 +155,7 @@ pub fn load_recent_memory(workdir: &Path) -> Option<String> {
     }
 
     let daily_dir = root.join("daily");
-    if let Ok(mut entries) = fs::read_dir(&daily_dir) {
+    if let Ok(entries) = fs::read_dir(&daily_dir) {
         let mut files: Vec<PathBuf> = entries
             .filter_map(|e| e.ok().map(|e| e.path()))
             .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("md"))

--- a/crates/core/src/prefire.rs
+++ b/crates/core/src/prefire.rs
@@ -14,9 +14,6 @@ pub struct PrefireCache {
     pub note1: String,
     pub fingerprint: u64,
     pub split_idx: usize,
-    /// Absolute index into session.messages where the pass1 prefix ended
-    /// (including any leading system message offset handled by caller).
-    pub prefix_end: usize,
 }
 
 pub struct PrefireState {
@@ -65,10 +62,6 @@ impl PrefireState {
         let mut g = self.inner.lock();
         g.cache = Some(cache);
         g.handle = None;
-    }
-
-    pub fn take_cache(&self) -> Option<PrefireCache> {
-        self.inner.lock().cache.take()
     }
 
     pub fn peek_cache(&self) -> Option<PrefireCache> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
修复编译时的 unused / private_interfaces warning。

## 变更
- `compaction`：去掉未使用的 `pass1_prefix`
- `memory`：去掉多余的 `mut`
- `prefire`：删除未读字段 `prefix_end` 与未用方法 `take_cache`
- ACP `PendingResponse` 提升为 `pub(crate)`，匹配 `SharedState`
- 清理 TUI 删除后遗留的 `model_config` 死代码

## 验证
`cargo check -p zene-core -p zene-cli` 无 warning；`cargo test -p zene-core --lib` 通过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab3880ba-03bb-4b7f-a564-692c1685708d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab3880ba-03bb-4b7f-a564-692c1685708d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

