### PR TITLE
feat(web-agent): focus UI on conversation

### DIFF
--- a/apps/web-agent/index.html
+++ b/apps/web-agent/index.html
@@ -6,111 +6,344 @@
   <title>Zene Web Agent</title>
   <style>
     :root {
-      --bg0: #efe6d8; --bg1: #f7f1e7; --ink: #1d1914; --muted: #6a5f52;
-      --panel: rgba(255,252,246,.94); --line: #d8ccba; --accent: #0f6a5b;
-      --accent-ink: #f4fffb; --warn: #8a4b12; --danger: #8b2430; --ok: #1f6b3a;
-      --tool: #2f5f7a;
+      --canvas: #fbfaf7; --surface: #ffffff; --surface-soft: #f5f5f1;
+      --ink: #18332d; --muted: #75817d; --line: #e5e8e4; --accent: #075e4b;
+      --accent-soft: #e9f2ee; --accent-ink: #ffffff; --warn: #a86108;
+      --danger: #b23a45; --ok: #25815c; --tool: #315d6d;
+      --shadow: 0 16px 44px rgba(27, 52, 44, .08);
       --mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      --sans: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+      --sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --display: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
     }
     * { box-sizing: border-box; }
+    html, body { height: 100%; }
     body {
-      margin: 0; color: var(--ink); font-family: var(--sans); min-height: 100vh;
-      background:
-        radial-gradient(circle at 0% 0%, rgba(15,106,91,.14), transparent 42%),
-        linear-gradient(155deg, var(--bg1), var(--bg0) 55%, #f3eee5);
+      margin: 0; color: var(--ink); font-family: var(--sans); background: var(--canvas);
+      overflow: hidden;
     }
-    .layout {
-      display: grid;
-      grid-template-columns: 270px minmax(0, 1fr) 300px;
-      gap: 12px; max-width: 1400px; margin: 0 auto; padding: 16px; min-height: 100vh;
+    button, input, textarea, select { font: inherit; }
+    button { cursor: pointer; }
+    button:focus-visible, input:focus-visible, textarea:focus-visible, summary:focus-visible {
+      outline: 3px solid rgba(7, 94, 75, .18); outline-offset: 2px;
     }
-    @media (max-width: 1100px) {
-      .layout { grid-template-columns: 1fr; }
+    .app-shell { display: grid; grid-template-rows: 58px 1fr; height: 100%; }
+    .topbar {
+      display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center;
+      gap: 20px; padding: 0 18px; background: rgba(255,255,255,.88);
+      border-bottom: 1px solid var(--line); backdrop-filter: blur(14px); z-index: 20;
     }
-    h1 { margin: 0; font-size: 1.45rem; }
-    .sub { margin: 4px 0 0; color: var(--muted); font-size: .9rem; }
-    .card {
-      background: var(--panel); border: 1px solid var(--line);
-      border-radius: 12px; padding: 12px 14px; margin-bottom: 12px;
+    .brand { display: flex; align-items: center; gap: 10px; min-width: 190px; }
+    .brand-mark {
+      display: grid; place-items: center; width: 30px; height: 30px; border-radius: 9px;
+      background: var(--accent); color: #fff; font: 700 17px var(--display);
+      box-shadow: 0 5px 14px rgba(7,94,75,.2);
     }
-    label { display:block; font-size:.78rem; color:var(--muted); margin-bottom:4px; }
-    input, textarea, button, select { font: inherit; }
-    input, textarea, select {
-      width: 100%; border: 1px solid var(--line); border-radius: 8px;
-      padding: 8px 10px; background: #fffdf8; color: var(--ink);
+    .brand-name { font: 600 19px var(--display); letter-spacing: -.02em; }
+    .conversation-title { min-width: 0; display: flex; align-items: center; gap: 10px; }
+    .conversation-title strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .state-pill {
+      border-radius: 999px; padding: 4px 8px; background: var(--surface-soft);
+      color: var(--muted); font-size: 10px; font-weight: 700; letter-spacing: .05em;
+      text-transform: uppercase;
     }
-    textarea { min-height: 90px; resize: vertical; }
+    .top-actions { display: flex; align-items: center; gap: 8px; }
+    .connection-state { display: flex; align-items: center; gap: 7px; color: var(--muted); font-size: 12px; }
+    .connection-dot { width: 7px; height: 7px; border-radius: 50%; background: #aeb6b2; }
+    .connection-dot.ok { background: var(--ok); box-shadow: 0 0 0 4px rgba(37,129,92,.1); }
+    .connection-dot.err { background: var(--danger); }
+    .icon-button {
+      display: grid; place-items: center; width: 34px; height: 34px; padding: 0;
+      border: 1px solid transparent; border-radius: 9px; background: transparent;
+      color: var(--muted); font-size: 18px;
+    }
+    .icon-button:hover, .icon-button.active { color: var(--accent); background: var(--accent-soft); }
+    .workspace-shell {
+      min-height: 0; display: grid; grid-template-columns: 58px minmax(0, 1fr) 320px;
+    }
+    .rail {
+      padding: 14px 10px; border-right: 1px solid var(--line); background: var(--surface);
+      display: flex; flex-direction: column; align-items: center; gap: 8px;
+    }
+    .rail .icon-button:last-child { margin-top: auto; }
+    .conversation {
+      min-width: 0; min-height: 0; display: grid; grid-template-rows: auto minmax(0, 1fr) auto;
+      background: var(--surface);
+    }
+    .conversation-head {
+      padding: 20px clamp(24px, 6vw, 80px) 8px; max-width: 1040px; width: 100%;
+      margin: 0 auto;
+    }
+    .conversation-head h1 { margin: 0; font: 500 24px var(--display); }
+    .conversation-head p { margin: 5px 0 0; color: var(--muted); font-size: 13px; }
+    #log {
+      width: 100%; max-width: 1040px; margin: 0 auto; padding: 18px clamp(24px, 6vw, 80px) 40px;
+      overflow: auto; scroll-behavior: smooth; line-height: 1.62;
+    }
+    .empty-state {
+      height: 100%; min-height: 260px; display: grid; place-content: center; text-align: center;
+      color: var(--muted);
+    }
+    .empty-state .empty-mark {
+      display: grid; place-items: center; width: 48px; height: 48px; margin: 0 auto 14px;
+      border-radius: 15px; background: var(--accent-soft); color: var(--accent);
+      font: 600 25px var(--display);
+    }
+    .empty-state strong { color: var(--ink); font: 500 23px var(--display); }
+    .empty-state p { margin: 8px 0 0; font-size: 13px; }
+    .msg { position: relative; margin: 0 0 22px; white-space: pre-wrap; word-break: break-word; }
+    .msg::before {
+      display: inline-grid; place-items: center; width: 27px; height: 27px; margin-right: 10px;
+      border-radius: 8px; vertical-align: top; font: 600 13px var(--display);
+    }
+    .msg.user {
+      width: fit-content; max-width: 78%; margin-left: auto; padding: 11px 15px;
+      border-radius: 16px 16px 4px 16px; background: var(--accent); color: #fff;
+    }
+    .msg.user::before { display: none; }
+    .msg.assistant { color: var(--ink); padding-left: 38px; }
+    .msg.assistant::before {
+      content: "Z"; position: absolute; left: 0; top: 0; background: var(--accent-soft); color: var(--accent);
+    }
+    .msg.thought {
+      margin-left: 38px; padding: 0 0 0 13px; border-left: 2px solid var(--line);
+      color: var(--muted); font-size: 13px; font-style: italic;
+    }
+    .msg.thought::before { display: none; }
+    .msg.system {
+      margin: 8px 0; color: var(--muted); font: 11px var(--mono); text-align: center;
+    }
+    .msg.system::before { display: none; }
+    .composer-wrap {
+      padding: 10px clamp(24px, 6vw, 80px) 22px;
+      background: linear-gradient(transparent, var(--surface) 24%);
+    }
+    .composer {
+      max-width: 880px; margin: 0 auto; padding: 12px 12px 10px 16px;
+      border: 1px solid var(--line); border-radius: 16px; background: var(--surface);
+      box-shadow: 0 12px 34px rgba(24,51,45,.1);
+    }
+    .composer textarea {
+      display: block; width: 100%; min-height: 50px; max-height: 180px; resize: none;
+      padding: 4px 2px 8px; border: 0; outline: 0; background: transparent;
+      color: var(--ink); line-height: 1.5;
+    }
+    .composer textarea::placeholder { color: #a7afac; }
+    .composer-actions { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+    .composer-actions .row { justify-content: flex-end; }
+    .keyboard-hint { color: var(--muted); font-size: 11px; }
     button {
-      border: 0; border-radius: 8px; padding: 7px 11px;
-      background: var(--accent); color: var(--accent-ink); cursor: pointer;
+      border: 0; border-radius: 9px; padding: 8px 12px;
+      background: var(--accent); color: var(--accent-ink); font-weight: 600;
     }
     button.secondary { background: transparent; color: var(--ink); border: 1px solid var(--line); }
-    button.danger { background: var(--danger); color: #fff; }
-    button.active { outline: 2px solid var(--accent); }
-    button:disabled { opacity: .55; cursor: not-allowed; }
-    .row { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
-    .status { font-family: var(--mono); font-size: .72rem; color: var(--muted); }
-    .ok { color: var(--ok); } .err { color: var(--danger); }
-    #log {
-      min-height: 360px; max-height: calc(100vh - 280px); overflow: auto;
-      font-family: var(--mono); font-size: .8rem; line-height: 1.45;
+    button.secondary:hover { background: var(--surface-soft); }
+    button.danger { background: #fff; color: var(--danger); border: 1px solid #efc8cc; }
+    button.active { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
+    button:disabled { opacity: .4; cursor: not-allowed; }
+    .row { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+    .inspector {
+      min-width: 0; overflow: auto; padding: 16px; border-left: 1px solid var(--line);
+      background: var(--canvas); transition: margin .2s ease, opacity .2s ease;
     }
-    .msg { margin: 0 0 10px; white-space: pre-wrap; word-break: break-word; }
-    .msg.user { color: var(--accent); }
-    .msg.assistant { color: var(--ink); }
-    .msg.thought { color: var(--muted); font-style: italic; }
-    .msg.system { color: var(--warn); }
-    .tool-card, .panel-item {
-      border: 1px solid var(--line); border-radius: 10px; padding: 8px 10px;
-      margin: 0 0 8px; background: rgba(255,255,255,.55);
+    .inspector.hidden { margin-right: -320px; opacity: 0; pointer-events: none; }
+    .workspace-shell:has(.inspector.hidden) { grid-template-columns: 58px minmax(0, 1fr) 0; }
+    .inspector-head, .drawer-head {
+      display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px;
     }
-    .tool-card { color: var(--tool); }
-    .tool-card .title, .panel-item .title { font-weight: 700; margin-bottom: 3px; }
-    .tool-card .meta, .panel-item .meta { color: var(--muted); font-size: .72rem; margin-bottom: 4px; }
+    .inspector h2, .drawer h2 { margin: 0; font: 500 20px var(--display); }
+    details.panel {
+      margin-bottom: 8px; border: 1px solid var(--line); border-radius: 12px; background: var(--surface);
+    }
+    details.panel > summary {
+      display: flex; align-items: center; justify-content: space-between; padding: 12px 13px;
+      cursor: pointer; list-style: none; font-weight: 650; font-size: 13px;
+    }
+    details.panel > summary::-webkit-details-marker { display: none; }
+    details.panel > summary::after { content: "⌄"; color: var(--muted); transition: transform .15s; }
+    details.panel[open] > summary::after { transform: rotate(180deg); }
+    .panel-list { max-height: 270px; overflow: auto; padding: 0 10px 10px; }
+    .panel-item {
+      border-top: 1px solid var(--line); padding: 9px 2px; background: transparent;
+    }
+    .panel-item .title { margin-bottom: 3px; font-size: 12px; }
+    .panel-item .meta { color: var(--muted); font: 10px var(--mono); }
+    .tool-card {
+      margin: 0 0 14px 38px; border: 1px solid var(--line); border-radius: 12px;
+      padding: 10px 12px; background: var(--canvas); color: var(--tool); font-size: 12px;
+    }
+    .tool-card .title { font-weight: 700; }
+    .tool-card .meta { margin: 3px 0 7px; color: var(--muted); font: 10px var(--mono); }
     .tool-card pre, .term-out {
-      margin: 0; white-space: pre-wrap; word-break: break-word;
-      max-height: 140px; overflow: auto; color: var(--ink);
-      font-family: var(--mono); font-size: .75rem;
+      margin: 0; white-space: pre-wrap; word-break: break-word; max-height: 180px; overflow: auto;
+      color: var(--ink); font: 11px/1.5 var(--mono);
     }
     .diff-add { color: #1f6b3a; } .diff-del { color: #8b2430; }
-    .pending { border-left: 3px solid var(--warn); padding-left: 10px; margin: 10px 0; }
+    .pending {
+      margin: 14px 0 18px 38px; padding: 14px; border: 1px solid #e5c795;
+      border-radius: 12px; background: #fffaf0; color: var(--ink);
+    }
+    .drawer {
+      position: fixed; top: 0; right: 0; z-index: 40; width: min(420px, 92vw); height: 100%;
+      padding: 20px; overflow: auto; background: var(--surface); box-shadow: var(--shadow);
+      transform: translateX(105%); transition: transform .22s ease;
+    }
+    .drawer.open { transform: translateX(0); }
+    .drawer-backdrop {
+      position: fixed; inset: 0; z-index: 35; border: 0; border-radius: 0; padding: 0;
+      background: rgba(17, 34, 29, .24); opacity: 0; pointer-events: none; transition: opacity .2s;
+    }
+    .drawer-backdrop.open { opacity: 1; pointer-events: auto; }
+    .settings-section { padding: 14px 0; border-top: 1px solid var(--line); }
+    .settings-section > strong { display: block; margin-bottom: 10px; }
+    label { display: block; margin-bottom: 5px; color: var(--muted); font-size: 11px; font-weight: 650; }
+    input, select {
+      width: 100%; padding: 9px 10px; border: 1px solid var(--line); border-radius: 9px;
+      background: var(--canvas); color: var(--ink);
+    }
+    .status { color: var(--muted); font: 10px var(--mono); }
+    .ok { color: var(--ok); } .err { color: var(--danger); }
     .session-item {
-      width: 100%; text-align: left; margin: 0 0 6px;
-      background: #fffdf8; color: var(--ink); border: 1px solid var(--line);
+      width: 100%; text-align: left; margin: 0 0 4px; white-space: pre-line;
+      background: var(--canvas); color: var(--ink); border: 1px solid var(--line);
     }
     .session-item.active { border-color: var(--accent); }
-    .usage {
-      display:grid; grid-template-columns: repeat(3, 1fr); gap: 6px;
-      font-family: var(--mono); font-size: .72rem;
-    }
-    .usage div {
-      background: #fffdf8; border: 1px solid var(--line);
-      border-radius: 8px; padding: 7px;
-    }
-    .usage span { display:block; color: var(--muted); font-size: .68rem; }
+    .usage { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }
+    .usage div { border-radius: 9px; padding: 8px; background: var(--canvas); font: 11px var(--mono); }
+    .usage span { display: block; margin-bottom: 4px; color: var(--muted); font-size: 9px; }
     .banner {
-      border: 1px dashed var(--warn); color: var(--warn);
-      border-radius: 8px; padding: 8px; margin-bottom: 10px; font-size: .85rem;
+      border-left: 3px solid var(--warn); margin: 10px 0 0; padding: 7px 10px;
+      background: #fffaf0; color: var(--warn); border-radius: 4px 9px 9px 4px; font-size: 12px;
     }
-    .panel-list { max-height: 180px; overflow: auto; }
-    .todo-pending { opacity: .75; }
+    .todo-pending { opacity: .7; }
     .todo-completed { text-decoration: line-through; color: var(--muted); }
     .todo-in_progress { color: var(--accent); font-weight: 700; }
+    @media (max-width: 900px) {
+      .workspace-shell { grid-template-columns: 52px minmax(0, 1fr) 0; }
+      .inspector { position: fixed; right: 0; top: 58px; z-index: 30; width: min(340px, 90vw); height: calc(100% - 58px); box-shadow: var(--shadow); }
+      .inspector.hidden { margin: 0; transform: translateX(105%); }
+      .brand { min-width: auto; } .brand-name { display: none; }
+      .conversation-title .state-pill, .connection-state span { display: none; }
+      .conversation-head { padding-top: 15px; }
+    }
+    @media (max-width: 560px) {
+      .topbar { gap: 10px; padding: 0 10px; }
+      .workspace-shell { grid-template-columns: 1fr 0; }
+      .rail { display: none; }
+      .conversation-head, #log, .composer-wrap { padding-left: 16px; padding-right: 16px; }
+      .keyboard-hint { display: none; }
+      .msg.user { max-width: 90%; }
+    }
   </style>
 </head>
 <body>
-  <div class="layout">
-    <aside>
-      <div class="card">
-        <h1>Zene</h1>
-        <p class="sub">HTTP ACP Web Agent</p>
+  <div class="app-shell">
+    <header class="topbar">
+      <div class="brand">
+        <div class="brand-mark">Z</div>
+        <span class="brand-name">Zene</span>
       </div>
-      <div class="card">
+      <div class="conversation-title">
+        <strong id="conversationTitle">New conversation</strong>
+        <span id="modeBadge" class="state-pill">default</span>
+      </div>
+      <div class="top-actions">
+        <div class="connection-state" title="Gateway connection">
+          <i id="connectionDot" class="connection-dot"></i>
+          <span id="connectionLabel">Offline</span>
+        </div>
+        <button id="btnInspectorTop" class="icon-button active" title="Toggle activity panel" aria-label="Toggle activity panel">◫</button>
+        <button id="btnSettingsTop" class="icon-button" title="Open settings" aria-label="Open settings">⚙</button>
+      </div>
+    </header>
+
+    <div class="workspace-shell">
+      <nav class="rail" aria-label="Primary">
+        <button class="icon-button active" title="Conversation" aria-label="Conversation">◉</button>
+        <button id="btnSessionsRail" class="icon-button" title="Sessions" aria-label="Open sessions">▤</button>
+        <button id="btnInspectorRail" class="icon-button" title="Activity" aria-label="Toggle activity panel">◫</button>
+        <button id="btnSettingsRail" class="icon-button" title="Settings" aria-label="Open settings">⚙</button>
+      </nav>
+
+      <main class="conversation">
+        <div class="conversation-head">
+          <h1>Conversation</h1>
+          <p>Ask Zene to inspect, explain, or change your code.</p>
+          <div id="planBanner" class="banner" style="display:none">
+            Plan mode is active. File writes stay blocked until you return to default mode.
+          </div>
+        </div>
+        <div id="log" aria-live="polite">
+          <div id="emptyState" class="empty-state">
+            <div>
+              <div class="empty-mark">Z</div>
+              <strong>What are we building?</strong>
+              <p>Connect a workspace, then start a conversation.</p>
+            </div>
+          </div>
+        </div>
+        <div class="composer-wrap">
+          <div class="composer">
+            <textarea id="prompt" rows="2" placeholder="Message Zene…" aria-label="Message Zene"></textarea>
+            <div class="composer-actions">
+              <span class="keyboard-hint">Enter to send · Shift + Enter for a new line</span>
+              <div class="row">
+                <button id="btnClear" class="icon-button" title="Clear conversation" aria-label="Clear conversation">↺</button>
+                <button id="btnCancel" class="secondary" disabled>Cancel</button>
+                <button id="btnSend" disabled>Send</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      <aside id="inspector" class="inspector" aria-label="Activity panel">
+        <div class="inspector-head">
+          <h2>Activity</h2>
+          <button id="btnInspectorClose" class="icon-button" title="Close activity panel" aria-label="Close activity panel">×</button>
+        </div>
+        <details class="panel" open>
+          <summary>Plan</summary>
+          <div id="planPanel" class="panel-list">
+            <p class="status">No plan yet</p>
+          </div>
+        </details>
+        <details class="panel" open>
+          <summary>Todos</summary>
+          <div id="todoPanel" class="panel-list">
+            <p class="status">No todos</p>
+          </div>
+        </details>
+        <details class="panel">
+          <summary>Background tasks</summary>
+          <div id="taskPanel" class="panel-list">
+            <p class="status">No tasks</p>
+          </div>
+        </details>
+        <details class="panel">
+          <summary>Terminals</summary>
+          <div class="panel-list">
+            <button id="btnRefreshTerms" class="secondary" disabled style="margin-bottom:8px">Refresh terminals</button>
+            <div id="termPanel">
+              <p class="status">No terminals</p>
+            </div>
+          </div>
+        </details>
+      </aside>
+    </div>
+  </div>
+
+  <button id="drawerBackdrop" class="drawer-backdrop" aria-label="Close settings"></button>
+  <aside id="settingsDrawer" class="drawer" aria-label="Settings">
+    <div class="drawer-head">
+      <h2>Workspace</h2>
+      <button id="btnSettingsClose" class="icon-button" title="Close settings" aria-label="Close settings">×</button>
+    </div>
+    <section class="settings-section">
+      <strong>Connection</strong>
         <label for="workspace">Workspace</label>
         <input id="workspace" placeholder="/absolute/path/to/project" />
         <label for="token" style="margin-top:8px">Token</label>
-        <input id="token" placeholder="from launch URL hash" />
+        <input id="token" type="password" placeholder="Loaded from launch URL" />
         <div class="row" style="margin-top:10px">
           <button id="btnStart">Connect</button>
           <button id="btnNew" class="secondary" disabled>New</button>
@@ -121,80 +354,31 @@
           <button id="btnTakeover" class="secondary" disabled>Take control</button>
         </div>
         <p id="status" class="status" style="margin:10px 0 0">idle</p>
+    </section>
+    <section class="settings-section">
+      <div class="row" style="justify-content:space-between">
+        <strong>Agent mode</strong>
+        <span id="transport" class="status">transport: —</span>
       </div>
-      <div class="card">
-        <div class="row" style="justify-content:space-between">
-          <strong>Mode</strong>
-          <span id="transport" class="status">transport: —</span>
-        </div>
         <div class="row" style="margin-top:8px">
           <button id="btnModeDefault" class="secondary" disabled>default</button>
           <button id="btnModePlan" class="secondary" disabled>plan</button>
         </div>
         <p id="modeLine" class="status" style="margin:8px 0 0">mode: —</p>
-      </div>
-      <div class="card">
-        <strong>Sessions</strong>
+    </section>
+    <section id="sessionsSection" class="settings-section">
+      <strong>Sessions</strong>
         <div id="sessions" style="margin-top:8px"></div>
-      </div>
-      <div class="card">
-        <strong>Usage / context</strong>
+    </section>
+    <section class="settings-section">
+      <strong>Usage / context</strong>
         <div class="usage" style="margin-top:8px">
           <div><span>prompt</span><b id="uPrompt">—</b></div>
           <div><span>completion</span><b id="uCompletion">—</b></div>
           <div><span>total / ctx</span><b id="uTotal">—</b></div>
         </div>
-      </div>
-    </aside>
-
-    <main>
-      <div id="planBanner" class="banner" style="display:none">
-        Plan mode active — writes outside the plan file are blocked until you exit plan mode.
-      </div>
-      <section class="card">
-        <div id="log"></div>
-      </section>
-      <section class="card">
-        <label for="prompt">Prompt</label>
-        <textarea id="prompt" placeholder="Ask Zene to inspect or change code…"></textarea>
-        <div class="row" style="margin-top:10px">
-          <button id="btnSend" disabled>Send</button>
-          <button id="btnCancel" class="secondary" disabled>Cancel</button>
-          <button id="btnClear" class="secondary">Clear log</button>
-        </div>
-      </section>
-    </main>
-
-    <aside>
-      <div class="card">
-        <strong>Plan</strong>
-        <div id="planPanel" class="panel-list" style="margin-top:8px">
-          <p class="status">no plan yet</p>
-        </div>
-      </div>
-      <div class="card">
-        <strong>Todos</strong>
-        <div id="todoPanel" class="panel-list" style="margin-top:8px">
-          <p class="status">no todos</p>
-        </div>
-      </div>
-      <div class="card">
-        <strong>Background tasks</strong>
-        <div id="taskPanel" class="panel-list" style="margin-top:8px">
-          <p class="status">no tasks</p>
-        </div>
-      </div>
-      <div class="card">
-        <div class="row" style="justify-content:space-between">
-          <strong>Terminals</strong>
-          <button id="btnRefreshTerms" class="secondary" disabled>Refresh</button>
-        </div>
-        <div id="termPanel" class="panel-list" style="margin-top:8px">
-          <p class="status">no terminals</p>
-        </div>
-      </div>
-    </aside>
-  </div>
+    </section>
+  </aside>
 
   <script>
     const state = {
@@ -223,9 +407,39 @@
     const el = (id) => document.getElementById(id);
     const logEl = el("log");
 
+    function setDrawer(open, focusSessions = false) {
+      el("settingsDrawer").classList.toggle("open", open);
+      el("drawerBackdrop").classList.toggle("open", open);
+      el("settingsDrawer").setAttribute("aria-hidden", String(!open));
+      if (open) {
+        const target = focusSessions ? el("sessionsSection") : el("workspace");
+        setTimeout(() => {
+          if (focusSessions) target.scrollIntoView({ block: "start" });
+          else target.focus();
+        }, 160);
+      }
+    }
+    function setInspector(open) {
+      el("inspector").classList.toggle("hidden", !open);
+      ["btnInspectorTop", "btnInspectorRail"].forEach((id) => {
+        el(id).classList.toggle("active", open);
+        el(id).setAttribute("aria-pressed", String(open));
+      });
+    }
+    function ensureConversationStarted() {
+      const empty = el("emptyState");
+      if (empty) empty.remove();
+    }
+    function showEmptyState() {
+      logEl.innerHTML = `<div id="emptyState" class="empty-state"><div>
+        <div class="empty-mark">Z</div><strong>Conversation cleared</strong>
+        <p>Send a message whenever you are ready.</p></div></div>`;
+    }
     function setStatus(text, cls) {
       el("status").textContent = text;
       el("status").className = "status " + (cls || "");
+      el("connectionLabel").textContent = cls === "ok" ? "Connected" : (cls === "err" ? "Error" : text);
+      el("connectionDot").className = "connection-dot " + (cls || "");
     }
     function setTransport(name) {
       state.transport = name;
@@ -234,6 +448,7 @@
     function setMode(mode) {
       state.mode = mode || "default";
       el("modeLine").textContent = "mode: " + state.mode;
+      el("modeBadge").textContent = state.mode;
       el("planBanner").style.display = state.mode === "plan" ? "block" : "none";
       el("btnModeDefault").classList.toggle("active", state.mode === "default");
       el("btnModePlan").classList.toggle("active", state.mode === "plan");
@@ -267,6 +482,7 @@
       return body;
     }
     function appendLog(kind, text) {
+      ensureConversationStarted();
       const div = document.createElement("div");
       div.className = "msg " + kind;
       div.textContent = text;
@@ -296,12 +512,12 @@
         state.assistantBuf += text;
         let node = logEl.querySelector(".live-assistant");
         if (!node) { node = appendLog("assistant", ""); node.classList.add("live-assistant"); }
-        node.textContent = "assistant: " + state.assistantBuf;
+        node.textContent = state.assistantBuf;
       } else {
         state.thoughtBuf += text;
         let node = logEl.querySelector(".live-thought");
         if (!node) { node = appendLog("thought", ""); node.classList.add("live-thought"); }
-        node.textContent = "thought: " + state.thoughtBuf;
+        node.textContent = state.thoughtBuf;
       }
     }
     function renderPlan() {
@@ -380,6 +596,7 @@
       const id = update.toolCallId || "tool";
       let card = state.tools.get(id);
       if (!card) {
+        ensureConversationStarted();
         card = document.createElement("div");
         card.className = "tool-card";
         card.innerHTML = `<div class="title"></div><div class="meta"></div><pre></pre>`;
@@ -455,8 +672,10 @@
         return;
       }
       const box = document.createElement("div");
+      ensureConversationStarted();
       box.className = "pending";
-      box.innerHTML = `<div>Permission: ${(params.toolCall && (params.toolCall.title || params.toolCall.toolCallId)) || "tool"}</div>`;
+      box.innerHTML = `<div><strong>Permission requested</strong></div>
+        <div style="margin-top:5px">${(params.toolCall && (params.toolCall.title || params.toolCall.toolCallId)) || "Tool access"}</div>`;
       const row = document.createElement("div");
       row.className = "row";
       row.style.marginTop = "8px";
@@ -490,6 +709,7 @@
       const raw = (params.toolCall && params.toolCall.rawInput) || {};
       const question = raw.question || (params.toolCall && params.toolCall.title) || "Question";
       const box = document.createElement("div");
+      ensureConversationStarted();
       box.className = "pending";
       box.innerHTML = `<div><strong>Ask user</strong></div><div style="margin-top:6px"></div>`;
       box.querySelector("div:last-child").textContent = question;
@@ -568,7 +788,7 @@
           case "agent_thought_chunk":
             renderChunk("thought", update.content && update.content.text); break;
           case "user_message_chunk":
-            appendLog("user", "user: " + ((update.content && update.content.text) || "")); break;
+            appendLog("user", ((update.content && update.content.text) || "")); break;
           case "tool_call":
           case "tool_call_update":
             finalizeStreams(); upsertToolCard(update); break;
@@ -802,6 +1022,7 @@
       const workspace = el("workspace").value.trim();
       if (!state.token) return setStatus("token required", "err");
       if (!workspace) return setStatus("workspace required", "err");
+      localStorage.setItem("zene.workspace", workspace);
       setStatus("starting…");
       const created = await api("/api/v1/agents", {
         method: "POST",
@@ -825,13 +1046,19 @@
       ["btnNew","btnRefreshSessions","btnTakeover","btnModeDefault","btnModePlan","btnRefreshTerms"]
         .forEach((id) => el(id).disabled = false);
       setStatus("ready", "ok");
+      setDrawer(false);
+      el("prompt").focus();
     }
     async function sendPrompt() {
       const text = el("prompt").value.trim();
       if (!text || !state.sessionId) return;
       finalizeStreams();
-      appendLog("user", "user: " + text);
+      if (el("conversationTitle").textContent === "New conversation") {
+        el("conversationTitle").textContent = text.length > 52 ? text.slice(0, 52) + "…" : text;
+      }
+      appendLog("user", text);
       el("prompt").value = "";
+      el("prompt").style.height = "";
       await postMessages([rpcRequest("session/prompt", {
         sessionId: state.sessionId,
         prompt: [{ type: "text", text }],
@@ -856,9 +1083,33 @@
     el("btnRefreshTerms").onclick = () => refreshTerminals().catch((e) => setStatus(e.message, "err"));
     el("btnSend").onclick = () => sendPrompt().catch((e) => setStatus(e.message, "err"));
     el("btnCancel").onclick = () => cancelTurn().catch((e) => setStatus(e.message, "err"));
-    el("btnClear").onclick = () => { logEl.innerHTML = ""; state.tools.clear(); };
+    el("btnClear").onclick = () => { showEmptyState(); state.tools.clear(); };
+    el("btnSettingsTop").onclick = () => setDrawer(true);
+    el("btnSettingsRail").onclick = () => setDrawer(true);
+    el("btnSettingsClose").onclick = () => setDrawer(false);
+    el("drawerBackdrop").onclick = () => setDrawer(false);
+    el("btnSessionsRail").onclick = () => setDrawer(true, true);
+    el("btnInspectorTop").onclick = () => setInspector(el("inspector").classList.contains("hidden"));
+    el("btnInspectorRail").onclick = () => setInspector(el("inspector").classList.contains("hidden"));
+    el("btnInspectorClose").onclick = () => setInspector(false);
+    el("prompt").addEventListener("input", (event) => {
+      event.target.style.height = "auto";
+      event.target.style.height = Math.min(event.target.scrollHeight, 180) + "px";
+    });
+    el("prompt").addEventListener("keydown", (event) => {
+      if (event.key === "Enter" && !event.shiftKey && !event.isComposing) {
+        event.preventDefault();
+        if (!el("btnSend").disabled) el("btnSend").click();
+      }
+    });
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") setDrawer(false);
+    });
     el("token").value = tokenFromHash();
+    el("workspace").value = localStorage.getItem("zene.workspace") || "";
+    setInspector(window.innerWidth > 900);
     setStatus(el("token").value ? "token loaded" : "waiting for token");
+    setDrawer(true);
   </script>
 </body>
 </html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- rebuild the Web Agent shell around the conversation
- move connection, mode, sessions, and usage into a settings drawer
- add collapsible activity panels for plans, todos, tasks, and terminals
- improve responsive behavior, message presentation, composer keyboard handling, and connection feedback

## Validation

- `cargo test -p zene-gateway` — 18 passed, 0 failed
- HTML parsed with 43 unique IDs and extracted JavaScript passed `node --check`
- browser walkthrough verified connect, prompt/response, activity toggling, collapsible panels, settings drawer, and narrow viewport

[conversation_first_web_agent_demo.mp4](https://cursor.com/agents/bc-5336eb66-7815-4ba3-a98e-e922c19e9c0e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconversation_first_web_agent_demo.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5336eb66-7815-4ba3-a98e-e922c19e9c0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5336eb66-7815-4ba3-a98e-e922c19e9c0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

