### PR TITLE
fix: 本地启动 Web UI 不更新（安装 gateway + 禁用缓存）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,16 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Build release binary
-        run: cargo build --release -p zene-cli --target ${{ matrix.target }} --locked
+      - name: Build release binaries
+        run: |
+          cargo build --release -p zene-cli -p zene-gateway --target ${{ matrix.target }} --locked
 
-      - name: Stage artifact
+      - name: Stage artifacts
         run: |
           mkdir -p dist
           cp "target/${{ matrix.target }}/release/zene" "dist/zene-${{ matrix.target }}"
-          chmod +x "dist/zene-${{ matrix.target }}"
+          cp "target/${{ matrix.target }}/release/zene-gateway" "dist/zene-gateway-${{ matrix.target }}"
+          chmod +x dist/*
 
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ Or manually:
 cargo install --path apps/cli --locked
 ```
 
-Pre-built binaries are published on [GitHub Releases](https://github.com/ParaTensor/zene/releases) when a version tag (`v*`) is pushed. The release workflow builds `zene-cli` for Linux and macOS (x86_64 + Apple Silicon).
+Pre-built binaries are published on [GitHub Releases](https://github.com/ParaTensor/zene/releases) when a version tag (`v*`) is pushed. Each release includes `zene` and `zene-gateway` for Linux and macOS (x86_64 + Apple Silicon). Download install (no compile):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ParaTensor/zene/main/www/install.sh | bash
+```
 
 Or run directly without installing:
 

--- a/apps/gateway/src/http.rs
+++ b/apps/gateway/src/http.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::extract::{DefaultBodyLimit, Path, Query, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, post};
@@ -108,8 +108,13 @@ pub fn router(state: AppState) -> Router {
         .with_state(Arc::new(state))
 }
 
-async fn index() -> Html<&'static str> {
-    Html(INDEX_HTML)
+async fn index() -> Response {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        axum::http::header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store"),
+    );
+    (headers, Html(INDEX_HTML)).into_response()
 }
 
 async fn bootstrap(State(state): State<Arc<AppState>>) -> impl IntoResponse {

--- a/install.sh
+++ b/install.sh
@@ -3,3 +3,4 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 cargo install --path apps/cli --locked
+cargo install --path apps/gateway --locked --bin zene-gateway

--- a/www/install.sh
+++ b/www/install.sh
@@ -30,9 +30,24 @@ esac
 
 INSTALL_DIR="$HOME/.local/bin"
 mkdir -p "$INSTALL_DIR"
-BINARY_PATH="$INSTALL_DIR/zene"
+ZENE_PATH="$INSTALL_DIR/zene"
+GATEWAY_PATH="$INSTALL_DIR/zene-gateway"
 
-# 2. Try downloading pre-built binary
+install_binary() {
+  local url="$1"
+  local dest="$2"
+  local label="$3"
+  echo "Downloading $label from: $url"
+  if curl -sfL "$url" -o "$dest"; then
+    chmod +x "$dest"
+    echo "✓ $label installed to $dest"
+    return 0
+  fi
+  echo "Could not download $label."
+  return 1
+}
+
+# 2. Try downloading pre-built binaries
 if [ -n "$TARGET" ]; then
   echo "Detected platform: $OS ($ARCH)"
   echo "Fetching latest release tag from GitHub..."
@@ -45,17 +60,16 @@ if [ -n "$TARGET" ]; then
     LATEST_TAG="v0.1.0"
   fi
   
-  DOWNLOAD_URL="https://github.com/ParaTensor/zene/releases/download/${LATEST_TAG}/zene-${TARGET}"
+  ZENE_URL="https://github.com/ParaTensor/zene/releases/download/${LATEST_TAG}/zene-${TARGET}"
+  GATEWAY_URL="https://github.com/ParaTensor/zene/releases/download/${LATEST_TAG}/zene-gateway-${TARGET}"
   
-  echo "Downloading pre-built binary from: $DOWNLOAD_URL"
-  if curl -sfL "$DOWNLOAD_URL" -o "$BINARY_PATH"; then
-    chmod +x "$BINARY_PATH"
-    echo "✓ Zene binary successfully installed to $BINARY_PATH"
-    
+  if install_binary "$ZENE_URL" "$ZENE_PATH" "zene" \
+    && install_binary "$GATEWAY_URL" "$GATEWAY_PATH" "zene-gateway"; then
     # Check macOS Quarantine attribute
     if [ "$OS" = "Darwin" ]; then
       if command -v xattr &> /dev/null; then
-        xattr -d com.apple.quarantine "$BINARY_PATH" 2>/dev/null || true
+        xattr -d com.apple.quarantine "$ZENE_PATH" 2>/dev/null || true
+        xattr -d com.apple.quarantine "$GATEWAY_PATH" 2>/dev/null || true
       fi
     fi
     
@@ -63,7 +77,7 @@ if [ -n "$TARGET" ]; then
     echo "Make sure $INSTALL_DIR is in your shell PATH."
     exit 0
   else
-    echo "Could not download pre-built binary. Falling back to source compilation..."
+    echo "Could not download pre-built binaries. Falling back to source compilation..."
   fi
 else
   echo "Unsupported pre-built platform: $OS ($ARCH). Falling back to source compilation..."
@@ -80,9 +94,11 @@ if ! command -v cargo &> /dev/null; then
 fi
 
 echo "Installing Zene from GitHub..."
-if cargo install --git https://github.com/ParaTensor/zene --locked; then
+if cargo install --git https://github.com/ParaTensor/zene --locked zene-cli \
+  && cargo install --git https://github.com/ParaTensor/zene --locked zene-gateway --bin zene-gateway; then
   # Cargo installs to ~/.cargo/bin
-  echo "✓ Zene installed to ~/.cargo/bin/zene"
+  echo "✓ zene installed to ~/.cargo/bin/zene"
+  echo "✓ zene-gateway installed to ~/.cargo/bin/zene-gateway"
   echo "=== Installation Completed ==="
   echo "Make sure ~/.cargo/bin is in your shell PATH."
 else


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

PR #21 只是设计文档，不会改界面。Web UI 编译进 **`zene-gateway`**，但：

1. GitHub Release 只发布了 `zene`，没有 `zene-gateway`
2. `www/install.sh` 也只下载 `zene`
3. 当前最新 release **v0.1.6**（7/18）早于 Web Agent 落地，本身就没有新界面

因此即使用安装方式、不编译源码，也看不到新 UI。

## 修复

- Release workflow 同时构建并发布 `zene` + `zene-gateway`
- `www/install.sh` 同时下载安装两个二进制
- 根目录 `install.sh` 源码安装时也装 gateway
- Gateway 对 `/` 返回 `Cache-Control: no-store`，避免浏览器缓存旧页面

## 使用方式（无需源码编译）

等合并并发 **新版本 tag**（如 `v0.1.7`）后：

```bash
curl -fsSL https://raw.githubusercontent.com/ParaTensor/zene/main/www/install.sh | bash
zene web --yolo --sandbox-off
```

或从 [GitHub Releases](https://github.com/ParaTensor/zene/releases) 手动下载同版本的 `zene-*` 与 `zene-gateway-*`，放到同一目录（如 `~/.local/bin`）。

**注意**：v0.1.6 及更早版本没有 Web Agent，必须等新 release。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efd39aaf-e54f-43fd-b8bf-a03c90b6ac16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efd39aaf-e54f-43fd-b8bf-a03c90b6ac16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

