### PR TITLE
fix: Cargo bin 覆盖导致 Web UI 不更新

### DIFF
--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -414,16 +414,16 @@ async fn run_mcp_doctor(workdir: &std::path::Path) -> Result<()> {
 
 fn run_web_gateway(gateway_args: Vec<String>) -> Result<()> {
     let gateway = resolve_gateway_bin();
+    let zene_bin = resolve_web_zene_bin(&gateway);
     eprintln!("zene launcher: {}", std::env::current_exe().map(|p| p.display().to_string()).unwrap_or_else(|_| "?".into()));
+    eprintln!("zene binary: {}", zene_bin.display());
     eprintln!("zene-gateway: {}", gateway.display());
     let mut cmd = std::process::Command::new(&gateway);
     if !gateway_args
         .iter()
         .any(|arg| arg == "--zene-bin" || arg.starts_with("--zene-bin="))
     {
-        if let Ok(zene) = std::env::current_exe() {
-            cmd.arg("--zene-bin").arg(zene);
-        }
+        cmd.arg("--zene-bin").arg(&zene_bin);
     }
     cmd.args(&gateway_args);
     let status = cmd
@@ -439,8 +439,8 @@ fn resolve_gateway_bin() -> PathBuf {
     if let Ok(path) = std::env::var("ZENE_GATEWAY_BIN") {
         return PathBuf::from(path);
     }
-    if let Some(local_gateway) = local_release_gateway() {
-        if local_gateway.exists() && cargo_shadowed_launcher() {
+    if let Some(local_gateway) = local_release_bin("zene-gateway") {
+        if local_gateway.exists() && should_prefer_local_release() {
             return local_gateway;
         }
     }
@@ -460,19 +460,41 @@ fn resolve_gateway_bin() -> PathBuf {
     PathBuf::from("zene-gateway")
 }
 
-fn local_release_gateway() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(|home| {
-        PathBuf::from(home)
-            .join(".local")
-            .join("bin")
-            .join("zene-gateway")
-    })
+fn resolve_web_zene_bin(gateway: &std::path::Path) -> PathBuf {
+    if let Ok(path) = std::env::var("ZENE_BIN") {
+        return PathBuf::from(path);
+    }
+    if let Some(parent) = gateway.parent() {
+        let paired = parent.join("zene");
+        if paired.exists() {
+            return paired;
+        }
+        #[cfg(windows)]
+        {
+            let paired = parent.join("zene.exe");
+            if paired.exists() {
+                return paired;
+            }
+        }
+    }
+    if let Some(local_zene) = local_release_bin("zene") {
+        if local_zene.exists() && should_prefer_local_release() {
+            return local_zene;
+        }
+    }
+    std::env::current_exe().unwrap_or_else(|_| PathBuf::from("zene"))
 }
 
-fn cargo_shadowed_launcher() -> bool {
-    std::env::current_exe().ok().is_some_and(|exe| {
-        exe.parent()
-            .is_some_and(|dir| dir.file_name().is_some_and(|name| name == "bin")
-                && dir.parent().is_some_and(|parent| parent.file_name().is_some_and(|name| name == ".cargo")))
-    })
+fn local_release_bin(name: &str) -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".local/bin").join(name))
+}
+
+fn should_prefer_local_release() -> bool {
+    let Ok(launcher) = std::env::current_exe() else {
+        return false;
+    };
+    let Some(local_zene) = local_release_bin("zene") else {
+        return false;
+    };
+    local_zene.exists() && launcher != local_zene
 }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -414,6 +414,8 @@ async fn run_mcp_doctor(workdir: &std::path::Path) -> Result<()> {
 
 fn run_web_gateway(gateway_args: Vec<String>) -> Result<()> {
     let gateway = resolve_gateway_bin();
+    eprintln!("zene launcher: {}", std::env::current_exe().map(|p| p.display().to_string()).unwrap_or_else(|_| "?".into()));
+    eprintln!("zene-gateway: {}", gateway.display());
     let mut cmd = std::process::Command::new(&gateway);
     if !gateway_args
         .iter()
@@ -437,6 +439,11 @@ fn resolve_gateway_bin() -> PathBuf {
     if let Ok(path) = std::env::var("ZENE_GATEWAY_BIN") {
         return PathBuf::from(path);
     }
+    if let Some(local_gateway) = local_release_gateway() {
+        if local_gateway.exists() && cargo_shadowed_launcher() {
+            return local_gateway;
+        }
+    }
     if let Ok(exe) = std::env::current_exe() {
         let sibling = exe.with_file_name("zene-gateway");
         if sibling.exists() {
@@ -451,4 +458,21 @@ fn resolve_gateway_bin() -> PathBuf {
         }
     }
     PathBuf::from("zene-gateway")
+}
+
+fn local_release_gateway() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(|home| {
+        PathBuf::from(home)
+            .join(".local")
+            .join("bin")
+            .join("zene-gateway")
+    })
+}
+
+fn cargo_shadowed_launcher() -> bool {
+    std::env::current_exe().ok().is_some_and(|exe| {
+        exe.parent()
+            .is_some_and(|dir| dir.file_name().is_some_and(|name| name == "bin")
+                && dir.parent().is_some_and(|parent| parent.file_name().is_some_and(|name| name == ".cargo")))
+    })
 }

--- a/apps/gateway/src/main.rs
+++ b/apps/gateway/src/main.rs
@@ -107,7 +107,8 @@ async fn main() -> Result<()> {
         addr.port(),
         token
     );
-    eprintln!("zene-gateway listening on {addr}");
+    eprintln!("zene-gateway {} listening on {addr}", env!("CARGO_PKG_VERSION"));
+    eprintln!("gateway binary: {}", std::env::current_exe().map(|p| p.display().to_string()).unwrap_or_else(|_| "?".into()));
     eprintln!("open {url}");
     eprintln!("acp command: {} {:?}", command.display(), args);
 

--- a/www/install.sh
+++ b/www/install.sh
@@ -63,7 +63,7 @@ if [ -n "$TARGET" ]; then
   ZENE_URL="https://github.com/ParaTensor/zene/releases/download/${LATEST_TAG}/zene-${TARGET}"
   GATEWAY_URL="https://github.com/ParaTensor/zene/releases/download/${LATEST_TAG}/zene-gateway-${TARGET}"
   
-  if install_binary "$ZENE_URL" "$ZENE_PATH" "zene" \
+    if install_binary "$ZENE_URL" "$ZENE_PATH" "zene" \
     && install_binary "$GATEWAY_URL" "$GATEWAY_PATH" "zene-gateway"; then
     # Check macOS Quarantine attribute
     if [ "$OS" = "Darwin" ]; then
@@ -72,9 +72,19 @@ if [ -n "$TARGET" ]; then
         xattr -d com.apple.quarantine "$GATEWAY_PATH" 2>/dev/null || true
       fi
     fi
+
+    LEGACY_DIR="$HOME/.cargo/bin"
+    for legacy in "$LEGACY_DIR/zene" "$LEGACY_DIR/zene-gateway"; do
+      if [ -f "$legacy" ]; then
+        echo "⚠ Removing older Cargo install: $legacy"
+        rm -f "$legacy"
+      fi
+    done
     
     echo "=== Installation Completed ==="
-    echo "Make sure $INSTALL_DIR is in your shell PATH."
+    echo "Installed to $INSTALL_DIR"
+    echo "Run: $ZENE_PATH web --yolo --sandbox-off"
+    echo "Ensure $INSTALL_DIR is before ~/.cargo/bin in your PATH."
     exit 0
   else
     echo "Could not download pre-built binaries. Falling back to source compilation..."

--- a/www/install.sh
+++ b/www/install.sh
@@ -80,11 +80,24 @@ if [ -n "$TARGET" ]; then
         rm -f "$legacy"
       fi
     done
+
+    SHELL_RC=""
+    case "${SHELL:-}" in
+      */zsh) SHELL_RC="$HOME/.zshrc" ;;
+      */bash) SHELL_RC="$HOME/.bashrc" ;;
+    esac
+    PATH_HINT='export PATH="$HOME/.local/bin:$PATH"'
+    if [ -n "$SHELL_RC" ] && ! grep -qF '.local/bin' "$SHELL_RC" 2>/dev/null; then
+      echo "" >> "$SHELL_RC"
+      echo "# Zene release binaries" >> "$SHELL_RC"
+      echo "$PATH_HINT" >> "$SHELL_RC"
+      echo "✓ Added $PATH_HINT to $SHELL_RC"
+    fi
     
     echo "=== Installation Completed ==="
     echo "Installed to $INSTALL_DIR"
     echo "Run: $ZENE_PATH web --yolo --sandbox-off"
-    echo "Ensure $INSTALL_DIR is before ~/.cargo/bin in your PATH."
+    echo "If 'zene' still resolves to an old path, open a new terminal or run: hash -r"
     exit 0
   else
     echo "Could not download pre-built binaries. Falling back to source compilation..."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
修复预编译安装后仍加载旧 Web UI 的问题：当 `~/.cargo/bin/zene` 优先于 `~/.local/bin/zene` 时会启动旧的 `zene-gateway`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efd39aaf-e54f-43fd-b8bf-a03c90b6ac16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efd39aaf-e54f-43fd-b8bf-a03c90b6ac16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

