### PR TITLE
chore(sandbox): bump eero-keel-core to 0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- Bump Keel sandbox stack to `eero-keel-core` 0.0.15 (baseline credential denies, audit hash chain, Windows Job/AppContainer). On Linux, Zene strips Keel FS deny rules before `Space::create` to avoid Keel 0.0.15’s outer-`bwrap` + Landlock `pre_exec` userns failure; host `path_policy` still blocks credential reads.
+
 ## v0.1.7 (2026-07-20)
 
 Headless **Web Agent** becomes the default UI: local `zene-gateway` serves the browser UI over HTTP (long-polling + optional SSE), with `zene` / `zene web` as the launch entry. Releases and `www/install.sh` now ship both `zene` and `zene-gateway` binaries.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,9 +763,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "eero-keel-core"
-version = "0.0.11"
+version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ae4109897131b19fe438dc70422d1b370fe8630c4dd6f19a3bb15bf192a054"
+checksum = "a71304b54e89e23a7ab7acc70e7d0f1893c242f589237688e6b81ec208db7d0e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "eero-keel-enforce"
-version = "0.0.11"
+version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2c6ed43980780b59595fa2d2f96ff59d725331f5185d8abd8b28adb8741665"
+checksum = "61bf5c9c461192006345bd8b7299b161abe788a69bdc294c72f1aa6501705cee"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -800,17 +800,19 @@ dependencies = [
  "libc",
  "nono",
  "serde",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "eero-keel-policy"
-version = "0.0.11"
+version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59957bfca7570e35f78bb5a75b31c0a17f235535d21c2e2e6a920e0880354ba2"
+checksum = "7a452e5aa19596a390d18a28fc51307234eca15fd8a33d82ce0f4ac6367e41f7"
 dependencies = [
  "chrono",
  "serde",
@@ -823,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "eero-keel-record"
-version = "0.0.11"
+version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf19aecd0cc2c55884bcc384ccd7f2f4dfdfccc66427566a13cfbd788136be9"
+checksum = "8ca0fdff81fc3591c52ff9069d074eccb09957fb0a9835c30f97ac5716e50ed2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -833,6 +835,7 @@ dependencies = [
  "eero-keel-policy",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-eero-keel-core = "0.0.11"
+eero-keel-core = "0.0.15"
 globset = "0.4"
 regex.workspace = true
 serde.workspace = true

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -16,7 +16,7 @@ use globset::GlobBuilder;
 #[cfg(not(any(target_os = "linux", target_os = "macos")))]
 use keel_core::backend_process_guard;
 #[cfg(any(target_os = "linux", target_os = "macos"))]
-use keel_core::{backend_local_process, LocalProcessOptions};
+use keel_core::backend_local_process;
 use keel_core::{
     check_egress, ManagedProcess, NetworkPolicy, Space, SpaceHandle, SpawnRequest, StdioMode,
     TerminationReason,
@@ -178,11 +178,12 @@ impl LocalSandbox {
             });
         }
 
-        let policy = options::resolve_policy(&workdir, &opts)?;
+        let mut policy = options::resolve_policy(&workdir, &opts)?;
+        options::adapt_policy_for_keel_spawn(&mut policy);
         let network = policy.network.clone();
 
         #[cfg(any(target_os = "linux", target_os = "macos"))]
-        let backend = backend_local_process(LocalProcessOptions::default());
+        let backend = backend_local_process(options::local_process_options());
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         let backend = backend_process_guard();
 

--- a/crates/sandbox/src/options.rs
+++ b/crates/sandbox/src/options.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+use keel_core::LocalProcessOptions;
 use keel_core::{
     profile_read_only, profile_strict, profile_workspace, FsAccess, FsRule, NetworkPolicy,
     NetworkRule, Policy, SandboxConfig,
@@ -102,17 +104,39 @@ fn builtin_policy(profile: &str, workdir: &Path) -> Result<Policy> {
     }
 }
 
-fn inject_default_secret_denies(policy: &mut Policy) {
-    // Linux Landlock read-deny for explicit deny paths requires bubblewrap. When it is
-    // missing, keep host-side `path_policy` protection and skip kernel deny injection so
-    // Space::create still succeeds.
-    if cfg!(target_os = "linux") && !bubblewrap_available() {
-        tracing::warn!(
-            "bubblewrap (bwrap) not found; credential denies are host path_policy only"
-        );
-        return;
-    }
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub(crate) fn local_process_options() -> LocalProcessOptions {
+    LocalProcessOptions::default()
+}
 
+/// Keel 0.0.12–0.0.15 always outer-wraps with `bwrap` when FS deny rules exist
+/// (even if `auto_bwrap` is false), then applies Landlock in `pre_exec` on that
+/// bwrap process — which fails with `setting up uid map: Permission denied`.
+///
+/// On Linux, drop FS denies from the Keel policy so children use Landlock-only
+/// isolation. Credential gating stays on host [`crate::path_policy`]. Re-enable
+/// Keel denies once Keel applies isolation *inside* the bwrap jail.
+#[cfg(target_os = "linux")]
+pub(crate) fn adapt_policy_for_keel_spawn(policy: &mut Policy) {
+    let before = policy.fs.len();
+    policy.fs.retain(|rule| rule.access != FsAccess::Deny);
+    if policy.fs.len() != before {
+        tracing::warn!(
+            removed = before - policy.fs.len(),
+            "stripped Keel FS deny rules on Linux (bwrap+Landlock pre_exec userns bug in eero-keel 0.0.15); host path_policy still denies credentials"
+        );
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn adapt_policy_for_keel_spawn(policy: &mut Policy) {
+    let _ = policy;
+}
+
+fn inject_default_secret_denies(policy: &mut Policy) {
+    // Keel ≥0.0.12 baseline already covers ~/.ssh, ~/.aws, **/.env*, **/*.pem, etc.
+    // Keep Zene-specific + overlapping denies for macOS Seatbelt / soft SpaceFs.
+    // Linux strips denies in [`adapt_policy_for_keel_spawn`] before Space::create.
     let home = std::env::var_os("HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/tmp"));
@@ -145,16 +169,6 @@ fn inject_default_secret_denies(policy: &mut Policy) {
             policy.fs.push(FsRule::deny_glob(path));
         }
     }
-}
-
-fn bubblewrap_available() -> bool {
-    std::process::Command::new("bwrap")
-        .arg("--version")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
 }
 
 fn apply_network_overrides(policy: &mut Policy, opts: &SandboxOptions) -> Result<()> {

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -121,7 +121,7 @@ Production entry points build `LocalSandbox::with_options` from config / CLI:
 | `strict` | workspace + system paths only | deny-all | Untrusted repos |
 | custom | from `~/.zene/sandbox.toml` | per profile | Keel `SandboxConfig` loader |
 
-Overrides: CLI `--sandbox` > `ZENE_SANDBOX` > `[sandbox] profile` in config. `allow_hosts` (config / `ZENE_SANDBOX_ALLOW_HOSTS`) turns network into an allowlist and is enforced for Bash children (Keel egress proxy) plus host tools (`FetchUrl`, `WebSearch`, HTTP MCP) via `LocalSandbox::authorize_egress`. Default credential denies (`~/.ssh`, `~/.gnupg`, `~/.aws`, `**/.env*`, `**/*.pem`, …) are injected into every non-`off` policy; host Read also uses `check_read_allowed`. File I/O prefers Keel `SpaceFs` when a space is active. `[sandbox] auto_allow_bash = true` skips Bash permission prompts while enforcement is on.
+Overrides: CLI `--sandbox` > `ZENE_SANDBOX` > `[sandbox] profile` in config. `allow_hosts` (config / `ZENE_SANDBOX_ALLOW_HOSTS`) turns network into an allowlist and is enforced for Bash children (Keel egress proxy) plus host tools (`FetchUrl`, `WebSearch`, HTTP MCP) via `LocalSandbox::authorize_egress`. Keel ≥0.0.12 baseline credential denies apply on macOS/Windows; on Linux Zene strips those FS denies before creating the space (Keel 0.0.15 outer-`bwrap` + Landlock `pre_exec` breaks userns) and relies on host `path_policy` / `check_read_allowed` for credential gating, with Landlock still isolating child writes. File I/O prefers Keel `SpaceFs` when a space is active. `[sandbox] auto_allow_bash = true` skips Bash permission prompts while enforcement is on.
 
 ## Permission modes (grok-aligned)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bump the Keel sandbox stack from `eero-keel-core` 0.0.11 → 0.0.15 (baseline credential denies, audit hash chain, Windows Job/AppContainer).

## Linux workaround
Keel 0.0.15 always outer-wraps with `bwrap` when FS deny rules exist, then applies Landlock in `pre_exec` on that bwrap process, which fails with `setting up uid map: Permission denied`. Zene strips Keel FS deny rules on Linux before `Space::create` and keeps host `path_policy` for credential gating; Landlock still isolates child writes. Revisit once Keel applies isolation inside the bwrap jail.

## Test plan
- [x] `cargo test -p zene-sandbox --locked`
- [x] `cargo test --workspace --locked`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be5a105e-c074-4b08-b4ac-5f9363ec2240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be5a105e-c074-4b08-b4ac-5f9363ec2240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

