### PR TITLE
refactor: context IO decoupling — segments event + MemoryStore (Phase 4)

### DIFF
--- a/crates/context/src/compaction.rs
+++ b/crates/context/src/compaction.rs
@@ -1,13 +1,10 @@
-use std::fs;
-use std::path::PathBuf;
-
 use anyhow::{bail, Context, Result};
 use tracing::info;
 use crate::config::CompactionConfig;
 use zene_llm::{ChatClient, ChatRequest, ChatResponse, Message, MessageKind, Role, ToolDefinition};
-use zene_session::session_record_dir;
 
 use crate::hooks::ContextHooks;
+use crate::segment_store::CompactionSegmentWrite;
 use crate::input_ladder::{prepare_summary_input, InputLadderStage};
 use crate::session::ContextSession;
 use crate::prefire::PrefireCache;
@@ -400,23 +397,21 @@ pub async fn summarize_prefix(
 }
 
 /// Persist compacted prefix for recovery (grok CompactionMode::Segments lite).
-pub fn persist_compaction_segment(
+pub fn plan_compaction_segment(
     session_id: &str,
     prefix: &[Message],
     summary: &str,
-) -> Result<PathBuf> {
-    let dir = session_record_dir(session_id).join("compaction_segments");
-    fs::create_dir_all(&dir).context("create compaction_segments dir")?;
-    let ts = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
-    let path = dir.join(format!("{ts}.md"));
+) -> CompactionSegmentWrite {
     let mut body = String::new();
     body.push_str("# Compaction segment\n\n");
     body.push_str("## Final summary\n\n");
     body.push_str(summary);
     body.push_str("\n\n## Compacted prefix\n\n");
     body.push_str(&format_messages_for_summary(prefix));
-    fs::write(&path, body).context("write compaction segment")?;
-    Ok(path)
+    CompactionSegmentWrite {
+        session_id: session_id.to_string(),
+        body,
+    }
 }
 
 pub struct CompactionPlan {
@@ -435,6 +430,8 @@ pub struct CompactionResult {
     pub reason: String,
     pub compacted_count: usize,
     pub stats: CompactionStats,
+    /// Segment payload for runtime persistence (`ContextEvent::CompactionSegment`).
+    pub segment: Option<CompactionSegmentWrite>,
 }
 
 pub fn plan_compaction(
@@ -619,6 +616,7 @@ fn try_truncate_only_compaction<S: ContextSession + ?Sized>(
             tokens_before,
             tokens_after,
         },
+        segment: None,
     };
     record_compaction_result(session, &result, None);
     Some(result)
@@ -660,6 +658,7 @@ fn try_slice_keep_compaction<S: ContextSession + ?Sized>(
             tokens_before,
             tokens_after,
         },
+        segment: None,
     };
     record_compaction_result(session, &result, None);
     Some(result)
@@ -834,6 +833,7 @@ where
             tokens_before,
             tokens_after,
         },
+        segment: None,
     }))
 }
 
@@ -867,6 +867,7 @@ fn try_truncate_only_on_messages(
             tokens_before,
             tokens_after,
         },
+        segment: None,
     })
 }
 
@@ -894,6 +895,7 @@ fn try_slice_keep_on_messages(
             tokens_before,
             tokens_after,
         },
+        segment: None,
     })
 }
 
@@ -983,9 +985,11 @@ pub async fn compact_session<S: ContextSession + ?Sized>(
     )
     .await?;
 
-    if let Ok(path) = persist_compaction_segment(session.session_id(), &prefix, &summary) {
-        info!(path = %path.display(), "wrote compaction segment");
-    }
+    let segment = Some(plan_compaction_segment(
+        session.session_id(),
+        &prefix,
+        &summary,
+    ));
 
     info!(
         reason = reason,
@@ -1017,6 +1021,7 @@ pub async fn compact_session<S: ContextSession + ?Sized>(
             tokens_before,
             tokens_after,
         },
+        segment,
     }))
 }
 
@@ -1085,9 +1090,11 @@ pub async fn compact_session_forced<S: ContextSession + ?Sized>(
     )
     .await?;
 
-    if let Ok(path) = persist_compaction_segment(session.session_id(), &prefix, &summary) {
-        info!(path = %path.display(), "wrote compaction segment");
-    }
+    let segment = Some(plan_compaction_segment(
+        session.session_id(),
+        &prefix,
+        &summary,
+    ));
 
     apply_full_replace_to_session(
         session,
@@ -1110,6 +1117,7 @@ pub async fn compact_session_forced<S: ContextSession + ?Sized>(
             tokens_before,
             tokens_after,
         },
+        segment,
     }))
 }
 

--- a/crates/context/src/engine.rs
+++ b/crates/context/src/engine.rs
@@ -62,6 +62,20 @@ pub enum ContextEvent {
     Checkpoint {
         reason: &'static str,
     },
+    /// Runtime should persist a compaction segment for recovery.
+    CompactionSegment {
+        session_id: String,
+        body: String,
+    },
+}
+
+fn push_compaction_segment_events(events: &mut Vec<ContextEvent>, result: &CompactionResult) {
+    if let Some(segment) = &result.segment {
+        events.push(ContextEvent::CompactionSegment {
+            session_id: segment.session_id.clone(),
+            body: segment.body.clone(),
+        });
+    }
 }
 
 /// Result of [`ContextEngine::prepare_step`].
@@ -310,6 +324,7 @@ impl ContextEngine {
             .await
             {
                 Ok(Some(result)) => {
+                    push_compaction_segment_events(&mut events, &result);
                     self.prefire.clear();
                     self.water.clear_auto_compact_suppression();
                     self.bump_epoch_and_publish("compaction", deps.session)
@@ -406,6 +421,9 @@ impl ContextEngine {
             Ok(compaction) => {
                 self.water.clear_auto_compact_suppression();
                 if compaction.is_some() {
+                    if let Some(ref result) = compaction {
+                        push_compaction_segment_events(&mut events, result);
+                    }
                     self.bump_epoch_and_publish("manual_compaction", deps.session)
                         .await;
                     self.sync_water_from_estimate(
@@ -476,6 +494,7 @@ impl ContextEngine {
             .await
             {
                 Ok(Some(result)) => {
+                    push_compaction_segment_events(&mut events, &result);
                     self.prefire.clear();
                     self.water.clear_auto_compact_suppression();
                     self.bump_epoch_and_publish("overflow_compaction", deps.session)

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -5,9 +5,13 @@ mod context_water;
 mod engine;
 mod hooks;
 mod input_ladder;
+mod segment_store;
 mod session;
 mod tokens;
 mod two_pass;
+
+#[cfg(feature = "memory")]
+mod memory_store;
 
 #[cfg(feature = "gateway")]
 mod gateway;
@@ -30,7 +34,7 @@ pub use compaction::{
     build_sliced_messages, compact_message_list_with_chat, compact_session,
     compact_session_forced, is_context_overflow_error, is_degenerate_summary,
     keep_recent_token_budget, last_user_query_index, plan_compaction,
-    persist_compaction_segment, should_compact, subagent_compaction_config,
+    plan_compaction_segment, should_compact, subagent_compaction_config,
     tail_start_index, truncate_old_message_bodies, truncate_old_tool_results,
     CompactionPlan, CompactionResult, CompactionStats, MIN_SUMMARY_SEED_CHARS,
 };
@@ -51,6 +55,8 @@ pub use gateway_stub::{close_session, external_session_id_from_env, gateway_conf
 pub use hooks::{ContextHooks, NoContextHooks};
 pub use input_ladder::{fit_messages_to_budget, prepare_summary_input, InputLadderStage};
 #[cfg(feature = "memory")]
+pub use memory_store::{FsMemoryStore, MemoryStore};
+#[cfg(feature = "memory")]
 pub use memory::{
     append_daily_log, conversation_has_memory_context, daily_log_path, ensure_memory_in_system,
     format_memory_context_block, is_duplicate_flush, load_recent_memory, memory_enabled,
@@ -68,6 +74,9 @@ pub use memory_stub::{
 pub use prefire::{prefire_lead_percent, PrefireCache, PrefireState};
 #[cfg(not(feature = "prefire"))]
 pub use prefire_stub::{prefire_lead_percent, PrefireCache, PrefireState};
+pub use segment_store::{
+    CompactionSegmentStore, CompactionSegmentWrite, FsCompactionSegmentStore,
+};
 pub use session::ContextSession;
 pub use tokens::{
     estimate_chars_as_tokens, estimate_context, estimate_message_tokens, estimate_messages_tokens,

--- a/crates/context/src/memory.rs
+++ b/crates/context/src/memory.rs
@@ -6,12 +6,13 @@
 //! block so work survives history loss without reshuffling the system prefix
 //! every turn.
 
-use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use tracing::{info, warn};
 use zene_llm::{ChatClient, ChatRequest, Message, ToolDefinition};
+
+use crate::memory_store::{FsMemoryStore, MemoryStore};
 
 pub const MEMORY_CONTEXT_OPEN: &str = "<memory-context>";
 pub const MEMORY_CONTEXT_CLOSE: &str = "</memory-context>";
@@ -31,7 +32,6 @@ Do NOT include ephemeral progress or routine Q&A.
 Respond with NO_REPLY if nothing genuinely useful was learned.";
 
 const MAX_FLUSH_CHARS: usize = 4_000;
-const MAX_INJECT_CHARS: usize = 3_000;
 const FLUSH_INPUT_MSG_CAP: usize = 40;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -94,99 +94,18 @@ pub fn process_flush_response(response: &str) -> Result<Option<String>, FlushRes
     Ok(Some(content))
 }
 
-fn content_fingerprint(content: &str) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut h = std::collections::hash_map::DefaultHasher::new();
-    content.trim().hash(&mut h);
-    h.finish()
-}
-
-fn last_flush_hash_path(workdir: &Path) -> PathBuf {
-    memory_root(workdir).join(".last_flush_hash")
-}
-
 /// Returns true when `content` matches the previous accepted flush (exact text).
 pub fn is_duplicate_flush(workdir: &Path, content: &str) -> bool {
-    let path = last_flush_hash_path(workdir);
-    let Ok(prev) = fs::read_to_string(path) else {
-        return false;
-    };
-    prev.trim() == content_fingerprint(content).to_string()
+    FsMemoryStore::new(workdir).is_duplicate_flush(content)
 }
 
 pub fn append_daily_log(workdir: &Path, content: &str) -> Result<PathBuf> {
-    let path = daily_log_path(workdir);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).context("create memory daily dir")?;
-    }
-    let mut block = String::new();
-    if path.exists() {
-        block.push_str("\n\n---\n\n");
-    }
-    block.push_str(&format!(
-        "## Flush {}\n\n{content}\n",
-        chrono::Utc::now().format("%H:%M:%SZ")
-    ));
-    use std::io::Write;
-    let mut file = fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-        .context("open daily memory log")?;
-    file.write_all(block.as_bytes())
-        .context("write daily memory log")?;
-    let _ = fs::write(
-        last_flush_hash_path(workdir),
-        content_fingerprint(content).to_string(),
-    );
-    Ok(path)
+    FsMemoryStore::new(workdir).append_daily_log(content)
 }
 
 /// Load recent memory text for injection (MEMORY.md + recent daily logs).
 pub fn load_recent_memory(workdir: &Path) -> Option<String> {
-    let root = memory_root(workdir);
-    let mut chunks = Vec::new();
-
-    let memory_md = root.join("MEMORY.md");
-    if let Ok(text) = fs::read_to_string(&memory_md) {
-        if !text.trim().is_empty() {
-            chunks.push(text);
-        }
-    }
-
-    let daily_dir = root.join("daily");
-    if let Ok(entries) = fs::read_dir(&daily_dir) {
-        let mut files: Vec<PathBuf> = entries
-            .filter_map(|e| e.ok().map(|e| e.path()))
-            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("md"))
-            .collect();
-        files.sort();
-        for path in files.iter().rev().take(3) {
-            if let Ok(text) = fs::read_to_string(path) {
-                if !text.trim().is_empty() {
-                    chunks.push(text);
-                }
-            }
-        }
-    }
-
-    if chunks.is_empty() {
-        return None;
-    }
-    let mut combined = chunks.join("\n\n");
-    if combined.chars().count() > MAX_INJECT_CHARS {
-        // Keep the newest tail.
-        let owned: String = combined
-            .chars()
-            .rev()
-            .take(MAX_INJECT_CHARS)
-            .collect::<String>()
-            .chars()
-            .rev()
-            .collect();
-        combined = format!("…\n{owned}");
-    }
-    Some(combined)
+    FsMemoryStore::new(workdir).load_recent()
 }
 
 pub fn format_memory_context_block(body: &str) -> String {
@@ -251,6 +170,7 @@ pub async fn run_memory_flush(
     if !memory_enabled() {
         return Ok(FlushResult::NothingToStore);
     }
+    let store = FsMemoryStore::new(workdir);
     let conversation = format_flush_input(messages);
     if conversation.trim().is_empty() {
         return Ok(FlushResult::NothingToStore);
@@ -277,11 +197,11 @@ pub async fn run_memory_flush(
 
     match process_flush_response(&text) {
         Ok(Some(content)) => {
-            if is_duplicate_flush(workdir, &content) {
+            if store.is_duplicate_flush(&content) {
                 info!("memory flush: duplicate of last flush; skipped");
                 return Ok(FlushResult::NothingToStore);
             }
-            let path = append_daily_log(workdir, &content)?;
+            let path = store.append_daily_log(&content)?;
             info!(path = %path.display(), chars = content.len(), "memory flush wrote daily log");
             Ok(FlushResult::Accepted)
         }

--- a/crates/context/src/memory_store.rs
+++ b/crates/context/src/memory_store.rs
@@ -1,0 +1,153 @@
+//! Filesystem adapter for session memory persistence.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// Runtime adapter for durable memory files under `.zene/memory/`.
+pub trait MemoryStore: Send + Sync {
+    fn load_recent(&self) -> Option<String>;
+    fn is_duplicate_flush(&self, content: &str) -> bool;
+    fn append_daily_log(&self, content: &str) -> Result<PathBuf>;
+}
+
+const MAX_INJECT_CHARS: usize = 3_000;
+
+fn memory_root(workdir: &Path) -> PathBuf {
+    workdir.join(".zene").join("memory")
+}
+
+fn daily_log_path(workdir: &Path) -> PathBuf {
+    let day = chrono::Utc::now().format("%Y-%m-%d");
+    memory_root(workdir)
+        .join("daily")
+        .join(format!("{day}.md"))
+}
+
+fn last_flush_hash_path(workdir: &Path) -> PathBuf {
+    memory_root(workdir).join(".last_flush_hash")
+}
+
+fn content_fingerprint(content: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    content.trim().hash(&mut h);
+    h.finish()
+}
+
+/// Default store: `{workdir}/.zene/memory/`.
+pub struct FsMemoryStore {
+    workdir: PathBuf,
+}
+
+impl FsMemoryStore {
+    pub fn new(workdir: impl Into<PathBuf>) -> Self {
+        Self {
+            workdir: workdir.into(),
+        }
+    }
+
+    pub fn workdir(&self) -> &Path {
+        &self.workdir
+    }
+}
+
+impl MemoryStore for FsMemoryStore {
+    fn load_recent(&self) -> Option<String> {
+        let root = memory_root(&self.workdir);
+        let mut chunks = Vec::new();
+
+        let memory_md = root.join("MEMORY.md");
+        if let Ok(text) = std::fs::read_to_string(&memory_md) {
+            if !text.trim().is_empty() {
+                chunks.push(text);
+            }
+        }
+
+        let daily_dir = root.join("daily");
+        if let Ok(entries) = std::fs::read_dir(&daily_dir) {
+            let mut files: Vec<PathBuf> = entries
+                .filter_map(|e| e.ok().map(|e| e.path()))
+                .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("md"))
+                .collect();
+            files.sort();
+            for path in files.iter().rev().take(3) {
+                if let Ok(text) = std::fs::read_to_string(path) {
+                    if !text.trim().is_empty() {
+                        chunks.push(text);
+                    }
+                }
+            }
+        }
+
+        if chunks.is_empty() {
+            return None;
+        }
+        let mut combined = chunks.join("\n\n");
+        if combined.chars().count() > MAX_INJECT_CHARS {
+            let owned: String = combined
+                .chars()
+                .rev()
+                .take(MAX_INJECT_CHARS)
+                .collect::<String>()
+                .chars()
+                .rev()
+                .collect();
+            combined = format!("…\n{owned}");
+        }
+        Some(combined)
+    }
+
+    fn is_duplicate_flush(&self, content: &str) -> bool {
+        let path = last_flush_hash_path(&self.workdir);
+        let Ok(prev) = std::fs::read_to_string(path) else {
+            return false;
+        };
+        prev.trim() == content_fingerprint(content).to_string()
+    }
+
+    fn append_daily_log(&self, content: &str) -> Result<PathBuf> {
+        let path = daily_log_path(&self.workdir);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).context("create memory daily dir")?;
+        }
+        let mut block = String::new();
+        if path.exists() {
+            block.push_str("\n\n---\n\n");
+        }
+        block.push_str(&format!(
+            "## Flush {}\n\n{content}\n",
+            chrono::Utc::now().format("%H:%M:%SZ")
+        ));
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .context("open daily memory log")?;
+        file.write_all(block.as_bytes())
+            .context("write daily memory log")?;
+        let _ = std::fs::write(
+            last_flush_hash_path(&self.workdir),
+            content_fingerprint(content).to_string(),
+        );
+        Ok(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn append_and_load_daily() {
+        let dir = tempdir().unwrap();
+        let store = FsMemoryStore::new(dir.path());
+        store
+            .append_daily_log("## Decisions\n\nShip it.\n")
+            .unwrap();
+        let loaded = store.load_recent().unwrap();
+        assert!(loaded.contains("Ship it"));
+    }
+}

--- a/crates/context/src/segment_store.rs
+++ b/crates/context/src/segment_store.rs
@@ -1,0 +1,66 @@
+//! Filesystem adapter for compaction segment persistence.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use zene_session::session_record_dir;
+
+/// Payload for a compaction segment write (no IO).
+#[derive(Debug, Clone)]
+pub struct CompactionSegmentWrite {
+    pub session_id: String,
+    pub body: String,
+}
+
+/// Runtime adapter for persisting compaction segments.
+pub trait CompactionSegmentStore: Send + Sync {
+    fn write_segment(&self, write: &CompactionSegmentWrite) -> Result<PathBuf>;
+}
+
+/// Default store: `~/.zene/sessions/<id>/compaction_segments/`.
+pub struct FsCompactionSegmentStore;
+
+impl FsCompactionSegmentStore {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for FsCompactionSegmentStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CompactionSegmentStore for FsCompactionSegmentStore {
+    fn write_segment(&self, write: &CompactionSegmentWrite) -> Result<PathBuf> {
+        let dir = session_record_dir(&write.session_id).join("compaction_segments");
+        std::fs::create_dir_all(&dir).context("create compaction_segments dir")?;
+        let ts = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
+        let path = dir.join(format!("{ts}.md"));
+        std::fs::write(&path, &write.body).context("write compaction segment")?;
+        Ok(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn fs_store_writes_under_session_dir() {
+        let dir = tempdir().unwrap();
+        std::env::set_var("ZENE_HOME", dir.path());
+        let write = CompactionSegmentWrite {
+            session_id: "sess-1".into(),
+            body: "# segment\n".into(),
+        };
+        let path = FsCompactionSegmentStore::new()
+            .write_segment(&write)
+            .unwrap();
+        std::env::remove_var("ZENE_HOME");
+        assert!(path.to_string_lossy().contains("compaction_segments"));
+        assert!(std::fs::read_to_string(path).unwrap().contains("# segment"));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,7 +8,10 @@ use parking_lot::Mutex;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use zene_config::ZeneConfig;
-use zene_context::{ContextDeps, ContextEngine, ContextEvent, PrefireClientFactory, StepContext};
+use zene_context::{
+    CompactionSegmentStore, CompactionSegmentWrite, ContextDeps, ContextEngine, ContextEvent,
+    FsCompactionSegmentStore, PrefireClientFactory, StepContext,
+};
 use zene_llm::{ChatClient, ChatRequest, Message, StreamEvent, TokenUsage, ToolCall};
 use zene_sandbox::{LocalSandbox, Sandbox};
 use zene_session::{
@@ -320,9 +323,28 @@ impl Agent {
     }
 
     fn dispatch_context_events(&self, events: &[ContextEvent]) -> Result<()> {
+        let segment_store = FsCompactionSegmentStore::new();
         for event in events {
-            if let ContextEvent::Checkpoint { reason } = event {
-                let _ = save_checkpoint(&self.session, reason)?;
+            match event {
+                ContextEvent::Checkpoint { reason } => {
+                    let _ = save_checkpoint(&self.session, reason)?;
+                }
+                ContextEvent::CompactionSegment { session_id, body } => {
+                    let write = CompactionSegmentWrite {
+                        session_id: session_id.clone(),
+                        body: body.clone(),
+                    };
+                    match segment_store.write_segment(&write) {
+                        Ok(path) => {
+                            info!(path = %path.display(), "wrote compaction segment");
+                        }
+                        Err(err) => {
+                            warn!(error = %err, "failed to write compaction segment");
+                        }
+                    }
+                }
+                ContextEvent::EpochBumped { .. }
+                | ContextEvent::PublishPrefix { .. } => {}
             }
         }
         Ok(())

--- a/docs/agent-components.md
+++ b/docs/agent-components.md
@@ -139,6 +139,11 @@ loop {
 
 拆分方向：`AgentBuilder` + trait object hooks（**已实现 builder**）；`ToolContext` 已改为 `Arc<dyn Sandbox>`；`TodoItem` / Permission 双层仍待拆。
 
+### 2026-08-11 — Phase 4 Context IO
+
+- compaction segment：`plan_compaction_segment` + `ContextEvent::CompactionSegment`；core 用 `FsCompactionSegmentStore` 落盘
+- memory：`MemoryStore` / `FsMemoryStore`；`memory.rs` 逻辑不再直接 `fs::`
+
 ### 2026-08-11 — Phase 3 WorkspaceProvider
 
 - 新增 `zene-workspace`：`WorkspaceProvider`、`FsWorkspaceProvider`、`build_system_prompt`

--- a/docs/decoupling-plan.md
+++ b/docs/decoupling-plan.md
@@ -13,14 +13,15 @@ Phased refactor toward composable agent crates (see `docs/agent-components.md`).
 - **`zene-hooks`**: `HookEngine` plans `HookRunRequest`; `HookExecutor` trait + `BashHookExecutor` for subprocess IO.
 - `HookRunner` orchestrates plan + execute; core re-exports for CLI/ACP.
 
-## Phase 3 — Workspace / Skills (current)
+## Phase 3 — Workspace / Skills (done)
 
 - **`zene-workspace`**: `WorkspaceProvider` trait + `FsWorkspaceProvider`; pure `build_system_prompt`.
 - Agent instructions, directory listing, git branch, skills discovery IO in FS adapter.
 
-## Phase 4 — Context IO 收尾 (planned)
+## Phase 4 — Context IO 收尾 (current)
 
-- `compaction_segments` / `memory` → `ContextEvent` or `MemoryStore` trait.
+- **`CompactionSegmentWrite`** + `ContextEvent::CompactionSegment`; runtime persists via `FsCompactionSegmentStore`.
+- **`MemoryStore`** trait + `FsMemoryStore`; memory flush/load IO moved out of `memory.rs` logic.
 
 ## Phase 5 — Turn loop → `zene-turn` (planned)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 4 of the decoupling plan (`docs/decoupling-plan.md`).

### Compaction segments (event-driven IO)
- `plan_compaction_segment` builds payload without filesystem access
- `CompactionResult.segment` carries optional `CompactionSegmentWrite`
- `ContextEvent::CompactionSegment` emitted by `ContextEngine` on LLM summarize
- `FsCompactionSegmentStore` + `CompactionSegmentStore` trait; core `dispatch_context_events` persists segments (same pattern as `Checkpoint`)

### Memory (`MemoryStore` trait)
- `FsMemoryStore` handles load / duplicate check / daily log append
- `memory.rs` keeps flush/injection logic; delegates IO to the store

## Test plan
- [x] `cargo test --workspace --locked`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b71ce392-bcdf-4e4a-a83c-0f9e213722ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b71ce392-bcdf-4e4a-a83c-0f9e213722ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

