### PR TITLE
Phase 6: Context runtime boundary (ContextEventHandler)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,6 +4023,7 @@ name = "zene-context"
 version = "0.1.11"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "parking_lot",
  "reqwest 0.12.28",

--- a/crates/context/Cargo.toml
+++ b/crates/context/Cargo.toml
@@ -17,6 +17,7 @@ prefire = []
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 chrono.workspace = true
 parking_lot.workspace = true
 serde.workspace = true

--- a/crates/context/README.md
+++ b/crates/context/README.md
@@ -8,6 +8,7 @@ Part of the composable [Zene](https://github.com/ParaTensor/zene) agent stack. U
 
 - `ContextEngine` — estimate → compact → assemble → epoch
 - `ContextSession` trait for any runtime's session store
+- `ContextEventHandler` trait for runtime IO (gateway, memory flush, segment store)
 - `ContextHooks` for todos / background task reminders
 - Optional cargo features: `memory`, `gateway`, `prefire` (all on by default)
 
@@ -15,12 +16,33 @@ Part of the composable [Zene](https://github.com/ParaTensor/zene) agent stack. U
 
 ```rust
 use zene_context::{
-    ContextDeps, ContextEngine, ContextEvent, ContextHooks, ContextSession,
-    NoContextHooks, CompactionConfig,
+    ContextDeps, ContextEngine, ContextEvent, ContextEventHandler, ContextHooks,
+    EventOutcome, NoContextHooks, NoopContextEventHandler, CompactionConfig,
 };
 use zene_llm::{ChatClient, ChatRequest};
 
-struct MySession { /* impl ContextSession */ }
+struct MySession { /* impl ContextSession + persist_checkpoint */ }
+
+struct MyHandler;
+
+#[async_trait::async_trait]
+impl ContextEventHandler for MyHandler {
+    async fn handle(&mut self, event: &ContextEvent) -> anyhow::Result<EventOutcome> {
+        match event {
+            ContextEvent::MemoryFlush { conversation } => {
+                // run sidecar LLM + persist to your store
+                let _ = conversation;
+                Ok(EventOutcome::MemoryFlush(zene_context::FlushResult::NothingToStore))
+            }
+            ContextEvent::PublishPrefix { session_id, epoch, messages } => {
+                // notify inference gateway
+                let _ = (session_id, epoch, messages);
+                Ok(EventOutcome::Void)
+            }
+            _ => Ok(EventOutcome::Void),
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -28,6 +50,7 @@ async fn main() -> anyhow::Result<()> {
     let client = ChatClient::from_config(&config).await?;
     let compaction = CompactionConfig::default();
     let hooks = NoContextHooks;
+    let mut handler = NoopContextEventHandler;
 
     loop {
         let mut session: MySession = /* ... */;
@@ -35,20 +58,16 @@ async fn main() -> anyhow::Result<()> {
             session: &mut session,
             compaction_config: &compaction,
             model: "gpt-4o",
-            workdir: std::path::Path::new("."),
             client: &client,
             hooks: Some(&hooks),
             system_prompt: "You are a helpful assistant.",
             estimator: &Default::default(),
+            handler: &mut handler,
             #[cfg(feature = "prefire")]
             prefire_client_factory: None,
         };
         let prepared = engine.prepare_step(&mut deps, &[]).await?;
-        for event in &prepared.events {
-            if let ContextEvent::Checkpoint { reason } = event {
-                eprintln!("checkpoint: {reason}");
-            }
-        }
+        // prepared.events mirrors side effects already handled by handler
         let resp = client.chat(ChatRequest {
             model: "gpt-4o".into(),
             messages: prepared.step.messages,

--- a/crates/context/src/engine.rs
+++ b/crates/context/src/engine.rs
@@ -1,7 +1,6 @@
 //! Context orchestration: estimate, compact, memory, prefire, epoch.
 
 use std::future::Future;
-use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -16,6 +15,8 @@ use crate::compaction::{
 };
 use crate::config::CompactionConfig;
 use crate::context_water::ContextWaterLevel;
+use crate::event_handler::{ContextEventHandler, EventOutcome};
+use crate::events::ContextEvent;
 use crate::hooks::ContextHooks;
 #[cfg(feature = "memory")]
 use crate::memory;
@@ -28,9 +29,9 @@ use crate::prefire_stub::{self, PrefireCache, PrefireState};
 use crate::session::ContextSession;
 use crate::tokens::{self, TokenEstimator};
 #[cfg(feature = "gateway")]
-use crate::gateway::{gateway_configured, publish_prefix};
+use crate::gateway::gateway_configured;
 #[cfg(not(feature = "gateway"))]
-use crate::gateway_stub::{gateway_configured, publish_prefix};
+use crate::gateway_stub::gateway_configured;
 use crate::two_pass;
 
 /// Builds a dedicated client for prefire pass1 (runtime-provided; avoids `ZeneConfig` in this crate).
@@ -44,38 +45,6 @@ pub struct StepContext {
     pub messages: Vec<Message>,
     pub metadata: ContextMetadata,
     pub estimate_tokens: u32,
-}
-
-/// Events emitted when context state changes (for runtime hooks / observability).
-#[derive(Debug, Clone)]
-pub enum ContextEvent {
-    EpochBumped {
-        old: u64,
-        new: u64,
-        reason: &'static str,
-    },
-    PublishPrefix {
-        epoch: u64,
-        message_count: usize,
-    },
-    /// Runtime should persist a rewind checkpoint (e.g. before/after compact).
-    Checkpoint {
-        reason: &'static str,
-    },
-    /// Runtime should persist a compaction segment for recovery.
-    CompactionSegment {
-        session_id: String,
-        body: String,
-    },
-}
-
-fn push_compaction_segment_events(events: &mut Vec<ContextEvent>, result: &CompactionResult) {
-    if let Some(segment) = &result.segment {
-        events.push(ContextEvent::CompactionSegment {
-            session_id: segment.session_id.clone(),
-            body: segment.body.clone(),
-        });
-    }
 }
 
 /// Result of [`ContextEngine::prepare_step`].
@@ -106,11 +75,11 @@ pub struct ContextDeps<'a> {
     pub session: &'a mut dyn ContextSession,
     pub compaction_config: &'a CompactionConfig,
     pub model: &'a str,
-    pub workdir: &'a Path,
     pub client: &'a ChatClient,
     pub hooks: Option<&'a dyn ContextHooks>,
     pub system_prompt: &'a str,
     pub estimator: &'a TokenEstimator,
+    pub handler: &'a mut dyn ContextEventHandler,
     #[cfg(feature = "prefire")]
     pub prefire_client_factory: Option<PrefireClientFactory>,
 }
@@ -180,10 +149,7 @@ impl ContextEngine {
     }
 
     pub fn metadata(&self, session: &dyn ContextSession) -> ContextMetadata {
-        let session_id = self
-            .external_session_id
-            .clone()
-            .unwrap_or_else(|| session.session_id().to_string());
+        let session_id = self.session_id_for(session);
         ContextMetadata::new(session_id, self.epoch)
     }
 
@@ -213,41 +179,6 @@ impl ContextEngine {
         }
     }
 
-    async fn flush_pending_publish(&mut self, session: &dyn ContextSession) {
-        if !self.pending_publish {
-            return;
-        }
-        self.pending_publish = false;
-        self.gateway_prefix_len = session.messages().len();
-        let session_id = self
-            .external_session_id
-            .clone()
-            .unwrap_or_else(|| session.session_id().to_string());
-        publish_prefix(&session_id, self.epoch, session.messages()).await;
-    }
-
-    /// Publish canonical prefix once at run start when inference gateway is configured.
-    async fn ensure_initial_publish(&mut self, session: &dyn ContextSession) {
-        if self.initial_publish_done || !gateway_configured() {
-            return;
-        }
-        self.initial_publish_done = true;
-        self.gateway_prefix_len = session.messages().len();
-        let session_id = self
-            .external_session_id
-            .clone()
-            .unwrap_or_else(|| session.session_id().to_string());
-        let pinned_boundary = stable_system_boundary(session.messages());
-        info!(
-            session_id = %session_id,
-            epoch = self.epoch,
-            messages = session.messages().len(),
-            pinned_boundary,
-            "initial gateway prefix publish"
-        );
-        publish_prefix(&session_id, self.epoch, session.messages()).await;
-    }
-
     /// Re-assemble outbound view after session mutation (e.g. overflow compact).
     pub fn assemble_step(
         &self,
@@ -271,9 +202,9 @@ impl ContextEngine {
         self.water.record_estimate(estimated_tokens);
         self.water.set_window(deps.compaction_config.context_window_tokens);
 
-        self.flush_pending_publish(deps.session).await;
-        self.ensure_initial_publish(deps.session).await;
-        self.maybe_start_prefire(&deps, tools);
+        self.flush_pending_publish(deps, &mut events).await?;
+        self.ensure_initial_publish(deps, &mut events).await?;
+        self.maybe_start_prefire(deps, tools);
 
         let mut compaction_result = None;
         let preflight = self.water.exceeds_window() && !self.water.auto_compact_suppressed;
@@ -299,11 +230,16 @@ impl ContextEngine {
 
             self.prefire.await_in_flight().await;
             let prefire_cache = self.prefire_cache_for_session(deps.session);
-            let _ = self.maybe_flush_memory(&deps).await;
-            let memory_block = memory::memory_reminder(deps.workdir);
-            events.push(ContextEvent::Checkpoint {
-                reason: "pre_auto_compact",
-            });
+            self.maybe_flush_memory(deps, &mut events).await?;
+            let memory_block = deps.handler.memory_reminder();
+            Self::emit(
+                deps,
+                &mut events,
+                ContextEvent::Checkpoint {
+                    reason: "pre_auto_compact",
+                },
+            )
+            .await?;
             let reason = if preflight {
                 "preflight_overflow"
             } else {
@@ -324,20 +260,25 @@ impl ContextEngine {
             .await
             {
                 Ok(Some(result)) => {
-                    push_compaction_segment_events(&mut events, &result);
+                    Self::emit_compaction_segments(deps, &mut events, &result).await?;
                     self.prefire.clear();
                     self.water.clear_auto_compact_suppression();
-                    self.bump_epoch_and_publish("compaction", deps.session)
-                        .await;
+                    self.bump_epoch_and_publish("compaction", deps, &mut events)
+                        .await?;
                     self.sync_water_from_estimate(
                         deps.session,
                         tools,
                         deps.estimator,
                         deps.compaction_config,
                     );
-                    events.push(ContextEvent::Checkpoint {
-                        reason: "post_auto_compact",
-                    });
+                    Self::emit(
+                        deps,
+                        &mut events,
+                        ContextEvent::Checkpoint {
+                            reason: "post_auto_compact",
+                        },
+                    )
+                    .await?;
                     compaction_result = Some(result);
                 }
                 Ok(None) => {}
@@ -396,11 +337,16 @@ impl ContextEngine {
         let mut events = Vec::new();
         self.prefire.await_in_flight().await;
         let prefire_cache = self.prefire_cache_for_session(deps.session);
-        let _ = self.maybe_flush_memory(&deps).await;
-        let memory_block = memory::memory_reminder(deps.workdir);
-        events.push(ContextEvent::Checkpoint {
-            reason: "pre_manual_compact",
-        });
+        self.maybe_flush_memory(deps, &mut events).await?;
+        let memory_block = deps.handler.memory_reminder();
+        Self::emit(
+            deps,
+            &mut events,
+            ContextEvent::Checkpoint {
+                reason: "pre_manual_compact",
+            },
+        )
+        .await?;
         let result = compact_session_forced(
             deps.session,
             deps.client,
@@ -422,19 +368,24 @@ impl ContextEngine {
                 self.water.clear_auto_compact_suppression();
                 if compaction.is_some() {
                     if let Some(ref result) = compaction {
-                        push_compaction_segment_events(&mut events, result);
+                        Self::emit_compaction_segments(deps, &mut events, result).await?;
                     }
-                    self.bump_epoch_and_publish("manual_compaction", deps.session)
-                        .await;
+                    self.bump_epoch_and_publish("manual_compaction", deps, &mut events)
+                        .await?;
                     self.sync_water_from_estimate(
                         deps.session,
                         tools,
                         deps.estimator,
                         deps.compaction_config,
                     );
-                    events.push(ContextEvent::Checkpoint {
-                        reason: "post_manual_compact",
-                    });
+                    Self::emit(
+                        deps,
+                        &mut events,
+                        ContextEvent::Checkpoint {
+                            reason: "post_manual_compact",
+                        },
+                    )
+                    .await?;
                 }
                 deps.session.ensure_system_message(deps.system_prompt);
                 Ok(ForcedCompactResult {
@@ -474,11 +425,16 @@ impl ContextEngine {
             *overflow_summarized = true;
             self.prefire.await_in_flight().await;
             let prefire_cache = self.prefire_cache_for_session(deps.session);
-            let _ = self.maybe_flush_memory(&deps).await;
-            let memory_block = memory::memory_reminder(deps.workdir);
-            events.push(ContextEvent::Checkpoint {
-                reason: "pre_overflow_compact",
-            });
+            self.maybe_flush_memory(deps, &mut events).await?;
+            let memory_block = deps.handler.memory_reminder();
+            Self::emit(
+                deps,
+                &mut events,
+                ContextEvent::Checkpoint {
+                    reason: "pre_overflow_compact",
+                },
+            )
+            .await?;
             match compact_session(
                 deps.session,
                 deps.client,
@@ -494,20 +450,25 @@ impl ContextEngine {
             .await
             {
                 Ok(Some(result)) => {
-                    push_compaction_segment_events(&mut events, &result);
+                    Self::emit_compaction_segments(deps, &mut events, &result).await?;
                     self.prefire.clear();
                     self.water.clear_auto_compact_suppression();
-                    self.bump_epoch_and_publish("overflow_compaction", deps.session)
-                        .await;
+                    self.bump_epoch_and_publish("overflow_compaction", deps, &mut events)
+                        .await?;
                     self.sync_water_from_estimate(
                         deps.session,
                         tools,
                         deps.estimator,
                         deps.compaction_config,
                     );
-                    events.push(ContextEvent::Checkpoint {
-                        reason: "post_overflow_compact",
-                    });
+                    Self::emit(
+                        deps,
+                        &mut events,
+                        ContextEvent::Checkpoint {
+                            reason: "post_overflow_compact",
+                        },
+                    )
+                    .await?;
                     deps.session.ensure_system_message(deps.system_prompt);
                     return Ok(OverflowHandleResult {
                         retry: true,
@@ -573,10 +534,111 @@ impl ContextEngine {
         session.update_context_usage(estimated, compaction_config.context_window_tokens);
     }
 
-    async fn bump_epoch_and_publish(&mut self, reason: &'static str, session: &dyn ContextSession) {
+    fn session_id_for(&self, session: &dyn ContextSession) -> String {
+        self.external_session_id
+            .clone()
+            .unwrap_or_else(|| session.session_id().to_string())
+    }
+
+    async fn emit(
+        deps: &mut ContextDeps<'_>,
+        events: &mut Vec<ContextEvent>,
+        event: ContextEvent,
+    ) -> Result<EventOutcome> {
+        if let ContextEvent::Checkpoint { reason } = &event {
+            deps.session.persist_checkpoint(reason)?;
+            events.push(event);
+            return Ok(EventOutcome::Void);
+        }
+        let outcome = deps.handler.handle(&event).await?;
+        events.push(event);
+        Ok(outcome)
+    }
+
+    async fn emit_compaction_segments(
+        deps: &mut ContextDeps<'_>,
+        events: &mut Vec<ContextEvent>,
+        result: &CompactionResult,
+    ) -> Result<()> {
+        if let Some(segment) = &result.segment {
+            Self::emit(
+                deps,
+                events,
+                ContextEvent::CompactionSegment {
+                    session_id: segment.session_id.clone(),
+                    body: segment.body.clone(),
+                },
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn flush_pending_publish(
+        &mut self,
+        deps: &mut ContextDeps<'_>,
+        events: &mut Vec<ContextEvent>,
+    ) -> Result<()> {
+        if !self.pending_publish {
+            return Ok(());
+        }
+        self.pending_publish = false;
+        self.gateway_prefix_len = deps.session.messages().len();
+        let session_id = self.session_id_for(deps.session);
+        Self::emit(
+            deps,
+            events,
+            ContextEvent::PublishPrefix {
+                session_id,
+                epoch: self.epoch,
+                messages: deps.session.messages().to_vec(),
+            },
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn ensure_initial_publish(
+        &mut self,
+        deps: &mut ContextDeps<'_>,
+        events: &mut Vec<ContextEvent>,
+    ) -> Result<()> {
+        if self.initial_publish_done || !gateway_configured() {
+            return Ok(());
+        }
+        self.initial_publish_done = true;
+        self.gateway_prefix_len = deps.session.messages().len();
+        let session_id = self.session_id_for(deps.session);
+        let pinned_boundary = stable_system_boundary(deps.session.messages());
+        info!(
+            session_id = %session_id,
+            epoch = self.epoch,
+            messages = deps.session.messages().len(),
+            pinned_boundary,
+            "initial gateway prefix publish"
+        );
+        Self::emit(
+            deps,
+            events,
+            ContextEvent::PublishPrefix {
+                session_id,
+                epoch: self.epoch,
+                messages: deps.session.messages().to_vec(),
+            },
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn bump_epoch_and_publish(
+        &mut self,
+        reason: &'static str,
+        deps: &mut ContextDeps<'_>,
+        events: &mut Vec<ContextEvent>,
+    ) -> Result<()> {
         let old = self.epoch;
         self.epoch = self.epoch.saturating_add(1);
-        self.gateway_prefix_len = session.messages().len();
+        self.gateway_prefix_len = deps.session.messages().len();
         info!(
             old,
             new = self.epoch,
@@ -584,11 +646,18 @@ impl ContextEngine {
             gateway_prefix_len = self.gateway_prefix_len,
             "context epoch bumped"
         );
-        let session_id = self
-            .external_session_id
-            .clone()
-            .unwrap_or_else(|| session.session_id().to_string());
-        publish_prefix(&session_id, self.epoch, session.messages()).await;
+        let session_id = self.session_id_for(deps.session);
+        Self::emit(
+            deps,
+            events,
+            ContextEvent::PublishPrefix {
+                session_id,
+                epoch: self.epoch,
+                messages: deps.session.messages().to_vec(),
+            },
+        )
+        .await?;
+        Ok(())
     }
 
     fn prefire_cache_for_session(&self, session: &dyn ContextSession) -> Option<PrefireCache> {
@@ -694,7 +763,11 @@ impl ContextEngine {
         }
     }
 
-    async fn maybe_flush_memory(&mut self, deps: &ContextDeps<'_>) -> Result<()> {
+    async fn maybe_flush_memory(
+        &mut self,
+        deps: &mut ContextDeps<'_>,
+        events: &mut Vec<ContextEvent>,
+    ) -> Result<()> {
         let cycle = deps.session.compaction_cycle();
         let marker = cycle.saturating_add(1);
         let threshold =
@@ -706,20 +779,18 @@ impl ContextEngine {
         ) {
             return Ok(());
         }
-        match memory::run_memory_flush(
-            deps.client,
-            deps.model,
-            deps.session.messages(),
-            deps.workdir,
+        let conversation = memory::format_flush_input(deps.session.messages());
+        if conversation.trim().is_empty() {
+            return Ok(());
+        }
+        let outcome = Self::emit(
+            deps,
+            events,
+            ContextEvent::MemoryFlush { conversation },
         )
-        .await?
-        {
-            memory::FlushResult::Accepted => {
-                self.last_memory_flush_compaction = marker;
-            }
-            other => {
-                tracing::debug!(?other, "memory flush finished without write");
-            }
+        .await?;
+        if let EventOutcome::MemoryFlush(memory::FlushResult::Accepted) = outcome {
+            self.last_memory_flush_compaction = marker;
         }
         Ok(())
     }

--- a/crates/context/src/event_handler.rs
+++ b/crates/context/src/event_handler.rs
@@ -1,0 +1,83 @@
+//! Runtime IO boundary for context events (checkpoint, segments, gateway, memory).
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::events::ContextEvent;
+use crate::memory::FlushResult;
+use crate::segment_store::CompactionSegmentWrite;
+
+/// Outcome of handling a single [`ContextEvent`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventOutcome {
+    Void,
+    MemoryFlush(FlushResult),
+}
+
+/// Handles context side effects (persistence, gateway publish, memory flush).
+///
+/// The engine invokes this inline when an operation must complete before continuing
+/// (e.g. memory flush before compaction). Implementations perform the actual IO.
+#[async_trait]
+pub trait ContextEventHandler: Send {
+    async fn handle(&mut self, event: &ContextEvent) -> Result<EventOutcome>;
+
+    /// Recent memory block for post-compaction reinjection.
+    fn memory_reminder(&self) -> Option<String> {
+        None
+    }
+}
+
+/// No-op handler for tests and minimal integrations.
+pub struct NoopContextEventHandler;
+
+#[async_trait]
+impl ContextEventHandler for NoopContextEventHandler {
+    async fn handle(&mut self, _event: &ContextEvent) -> Result<EventOutcome> {
+        Ok(EventOutcome::Void)
+    }
+}
+
+/// Records events without performing IO (useful in unit tests).
+pub struct RecordingContextEventHandler {
+    pub events: Vec<ContextEvent>,
+}
+
+impl RecordingContextEventHandler {
+    pub fn new() -> Self {
+        Self {
+            events: Vec::new(),
+        }
+    }
+}
+
+impl Default for RecordingContextEventHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ContextEventHandler for RecordingContextEventHandler {
+    async fn handle(&mut self, event: &ContextEvent) -> Result<EventOutcome> {
+        self.events.push(event.clone());
+        Ok(match event {
+            ContextEvent::MemoryFlush { .. } => EventOutcome::MemoryFlush(FlushResult::NothingToStore),
+            _ => EventOutcome::Void,
+        })
+    }
+}
+
+/// Convenience: persist a compaction segment write via handler.
+pub async fn write_compaction_segment_via(
+    handler: &mut dyn ContextEventHandler,
+    write: CompactionSegmentWrite,
+) -> Result<()> {
+    handler
+        .handle(&ContextEvent::CompactionSegment {
+            session_id: write.session_id,
+            body: write.body,
+        })
+        .await?;
+    Ok(())
+}

--- a/crates/context/src/events.rs
+++ b/crates/context/src/events.rs
@@ -1,0 +1,32 @@
+//! Context side-effect events emitted by [`ContextEngine`](crate::ContextEngine).
+
+use zene_llm::Message;
+
+/// Events emitted when context state changes (for runtime hooks / observability).
+#[derive(Debug, Clone)]
+pub enum ContextEvent {
+    EpochBumped {
+        old: u64,
+        new: u64,
+        reason: &'static str,
+    },
+    /// Runtime should publish canonical prefix to inference gateway.
+    PublishPrefix {
+        session_id: String,
+        epoch: u64,
+        messages: Vec<Message>,
+    },
+    /// Runtime should persist a rewind checkpoint (e.g. before/after compact).
+    Checkpoint {
+        reason: &'static str,
+    },
+    /// Runtime should persist a compaction segment for recovery.
+    CompactionSegment {
+        session_id: String,
+        body: String,
+    },
+    /// Runtime should run memory flush LLM + persist before compaction.
+    MemoryFlush {
+        conversation: String,
+    },
+}

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -3,15 +3,15 @@ mod compaction;
 mod config;
 mod context_water;
 mod engine;
+mod event_handler;
+mod events;
 mod hooks;
 mod input_ladder;
+mod memory_store;
 mod segment_store;
 mod session;
 mod tokens;
 mod two_pass;
-
-#[cfg(feature = "memory")]
-mod memory_store;
 
 #[cfg(feature = "gateway")]
 mod gateway;
@@ -45,30 +45,36 @@ pub use assemble::{
     DeliveryMode,
 };
 pub use engine::{
-    ContextDeps, ContextEngine, ContextEvent, ForcedCompactResult, OverflowHandleResult,
+    ContextDeps, ContextEngine, ForcedCompactResult, OverflowHandleResult,
     PrefireClientFactory, PrepareStepResult, StepContext,
 };
+pub use event_handler::{
+    write_compaction_segment_via, ContextEventHandler, EventOutcome,
+    NoopContextEventHandler, RecordingContextEventHandler,
+};
+pub use events::ContextEvent;
 #[cfg(feature = "gateway")]
 pub use gateway::{close_session, external_session_id_from_env, gateway_configured, publish_prefix};
 #[cfg(not(feature = "gateway"))]
 pub use gateway_stub::{close_session, external_session_id_from_env, gateway_configured, publish_prefix};
 pub use hooks::{ContextHooks, NoContextHooks};
 pub use input_ladder::{fit_messages_to_budget, prepare_summary_input, InputLadderStage};
-#[cfg(feature = "memory")]
 pub use memory_store::{FsMemoryStore, MemoryStore};
 #[cfg(feature = "memory")]
 pub use memory::{
     append_daily_log, conversation_has_memory_context, daily_log_path, ensure_memory_in_system,
-    format_memory_context_block, is_duplicate_flush, load_recent_memory, memory_enabled,
-    memory_reminder, memory_root, process_flush_response, run_memory_flush, should_flush,
-    FlushResult, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN,
+    format_flush_input, format_memory_context_block, is_duplicate_flush, load_recent_memory,
+    load_recent_memory_from_store, memory_enabled, memory_reminder, memory_reminder_from_store,
+    memory_root, process_flush_response, run_memory_flush, should_flush, FlushResult,
+    MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN,
 };
 #[cfg(not(feature = "memory"))]
 pub use memory_stub::{
     append_daily_log, conversation_has_memory_context, daily_log_path, ensure_memory_in_system,
-    format_memory_context_block, is_duplicate_flush, load_recent_memory, memory_enabled,
-    memory_reminder, memory_root, process_flush_response, run_memory_flush, should_flush,
-    FlushResult, MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN,
+    format_flush_input, format_memory_context_block, is_duplicate_flush, load_recent_memory,
+    load_recent_memory_from_store, memory_enabled, memory_reminder, memory_reminder_from_store,
+    memory_root, process_flush_response, run_memory_flush, should_flush, FlushResult,
+    MEMORY_CONTEXT_CLOSE, MEMORY_CONTEXT_OPEN,
 };
 #[cfg(feature = "prefire")]
 pub use prefire::{prefire_lead_percent, PrefireCache, PrefireState};

--- a/crates/context/src/memory.rs
+++ b/crates/context/src/memory.rs
@@ -1,10 +1,9 @@
 //! Session memory flush + post-compact injection (grok-aligned subset).
 //!
 //! Before compaction, optionally ask the model to extract durable lessons into
-//! `{workdir}/.zene/memory/daily/YYYY-MM-DD.md`. After compaction (and at
-//! session start), recent memory is re-injected as a stable `<memory-context>`
-//! block so work survives history loss without reshuffling the system prefix
-//! every turn.
+//! daily memory logs. After compaction (and at session start), recent memory is
+//! re-injected as a stable `<memory-context>` block so work survives history loss
+//! without reshuffling the system prefix every turn.
 
 use std::path::{Path, PathBuf};
 
@@ -108,6 +107,10 @@ pub fn load_recent_memory(workdir: &Path) -> Option<String> {
     FsMemoryStore::new(workdir).load_recent()
 }
 
+pub fn load_recent_memory_from_store(store: &dyn MemoryStore) -> Option<String> {
+    store.load_recent()
+}
+
 pub fn format_memory_context_block(body: &str) -> String {
     format!(
         "{MEMORY_CONTEXT_OPEN}\n## Relevant Memory from Past Sessions\n\n{body}\n{MEMORY_CONTEXT_CLOSE}"
@@ -115,11 +118,11 @@ pub fn format_memory_context_block(body: &str) -> String {
 }
 
 /// Append memory context to the system message once (KV-stable for the session).
-pub fn ensure_memory_in_system(messages: &mut [Message], workdir: &Path) {
+pub fn ensure_memory_in_system(messages: &mut [Message], store: &dyn MemoryStore) {
     if !memory_enabled() || conversation_has_memory_context(messages) {
         return;
     }
-    let Some(body) = load_recent_memory(workdir) else {
+    let Some(body) = store.load_recent() else {
         return;
     };
     let block = format_memory_context_block(&body);
@@ -132,15 +135,21 @@ pub fn ensure_memory_in_system(messages: &mut [Message], workdir: &Path) {
 }
 
 /// Reminder fragment for post-compaction reinjection.
-pub fn memory_reminder(workdir: &Path) -> Option<String> {
+pub fn memory_reminder_from_store(store: &dyn MemoryStore) -> Option<String> {
     if !memory_enabled() {
         return None;
     }
-    let body = load_recent_memory(workdir)?;
+    let body = store.load_recent()?;
     Some(format_memory_context_block(&body))
 }
 
-fn format_flush_input(messages: &[Message]) -> String {
+/// Reminder fragment using filesystem store (convenience for callers with a workdir).
+pub fn memory_reminder(workdir: &Path) -> Option<String> {
+    memory_reminder_from_store(&FsMemoryStore::new(workdir))
+}
+
+/// Format recent messages for memory flush LLM input.
+pub fn format_flush_input(messages: &[Message]) -> String {
     let start = messages.len().saturating_sub(FLUSH_INPUT_MSG_CAP);
     let mut out = String::new();
     for message in &messages[start..] {
@@ -164,14 +173,12 @@ fn format_flush_input(messages: &[Message]) -> String {
 pub async fn run_memory_flush(
     client: &ChatClient,
     model: &str,
-    messages: &[Message],
-    workdir: &Path,
+    conversation: &str,
+    store: &dyn MemoryStore,
 ) -> Result<FlushResult> {
     if !memory_enabled() {
         return Ok(FlushResult::NothingToStore);
     }
-    let store = FsMemoryStore::new(workdir);
-    let conversation = format_flush_input(messages);
     if conversation.trim().is_empty() {
         return Ok(FlushResult::NothingToStore);
     }
@@ -190,10 +197,7 @@ pub async fn run_memory_flush(
     };
 
     let response = client.chat(request).await.context("memory flush chat")?;
-    let text = response
-        .message
-        .content
-        .unwrap_or_default();
+    let text = response.message.content.unwrap_or_default();
 
     match process_flush_response(&text) {
         Ok(Some(content)) => {

--- a/crates/context/src/memory_stub.rs
+++ b/crates/context/src/memory_stub.rs
@@ -10,13 +10,12 @@ pub const MEMORY_CONTEXT_CLOSE: &str = "</memory-context>";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FlushResult {
-    Skipped,
+    NothingToStore,
     Accepted,
-    Duplicate,
     Rejected,
 }
 
-pub fn memory_enabled(_workdir: &Path) -> bool {
+pub fn memory_enabled() -> bool {
     false
 }
 
@@ -24,7 +23,7 @@ pub fn memory_root(_workdir: &Path) -> std::path::PathBuf {
     std::path::PathBuf::new()
 }
 
-pub fn ensure_memory_in_system(_messages: &mut Vec<Message>, _workdir: &Path) {}
+pub fn ensure_memory_in_system(_messages: &mut [Message], _store: &dyn crate::memory_store::MemoryStore) {}
 
 pub fn conversation_has_memory_context(_messages: &[Message]) -> bool {
     false
@@ -34,6 +33,14 @@ pub fn memory_reminder(_workdir: &Path) -> Option<String> {
     None
 }
 
+pub fn memory_reminder_from_store(_store: &dyn crate::memory_store::MemoryStore) -> Option<String> {
+    None
+}
+
+pub fn format_flush_input(_messages: &[Message]) -> String {
+    String::new()
+}
+
 pub fn should_flush(_usage_percent: u8, _threshold: u8, _already_flushed: bool) -> bool {
     false
 }
@@ -41,33 +48,36 @@ pub fn should_flush(_usage_percent: u8, _threshold: u8, _already_flushed: bool) 
 pub async fn run_memory_flush(
     _client: &zene_llm::ChatClient,
     _model: &str,
-    _messages: &[Message],
-    _workdir: &Path,
+    _conversation: &str,
+    _store: &dyn crate::memory_store::MemoryStore,
 ) -> Result<FlushResult> {
-    Ok(FlushResult::Skipped)
+    Ok(FlushResult::NothingToStore)
 }
 
-pub fn append_daily_log(_workdir: &Path, _content: &str) -> Result<()> {
-    Ok(())
+pub fn append_daily_log(_workdir: &Path, _content: &str) -> Result<std::path::PathBuf> {
+    Ok(std::path::PathBuf::new())
 }
 
 pub fn daily_log_path(_workdir: &Path) -> std::path::PathBuf {
     std::path::PathBuf::new()
 }
 
-pub fn format_memory_context_block(_workdir: &Path) -> Option<String> {
+pub fn format_memory_context_block(_body: &str) -> String {
+    String::new()
+}
+
+pub fn load_recent_memory(_workdir: &Path) -> Option<String> {
     None
 }
 
-pub fn load_recent_memory(_workdir: &Path) -> Result<String> {
-    Ok(String::new())
+pub fn load_recent_memory_from_store(_store: &dyn crate::memory_store::MemoryStore) -> Option<String> {
+    None
 }
 
 pub fn is_duplicate_flush(_workdir: &Path, _content: &str) -> bool {
     false
 }
 
-pub fn process_flush_response(_content: &str) -> FlushResult {
-    let _ = _content;
-    FlushResult::Rejected
+pub fn process_flush_response(_content: &str) -> Result<Option<String>, FlushResult> {
+    Err(FlushResult::NothingToStore)
 }

--- a/crates/context/src/session.rs
+++ b/crates/context/src/session.rs
@@ -1,7 +1,8 @@
 //! Runtime-agnostic session view for context operations.
 
+use anyhow::Result;
 use zene_llm::Message;
-use zene_session::SessionRecord;
+use zene_session::{save_checkpoint, SessionRecord};
 
 /// Mutable conversation state consumed by [`ContextEngine`](crate::ContextEngine).
 pub trait ContextSession: Send + Sync {
@@ -11,6 +12,10 @@ pub trait ContextSession: Send + Sync {
     fn compaction_cycle(&self) -> u64;
     fn update_context_usage(&mut self, tokens_used: u32, context_window: u32);
     fn ensure_system_message(&mut self, content: &str);
+    fn persist_checkpoint(&self, reason: &str) -> Result<()> {
+        let _ = reason;
+        Ok(())
+    }
     fn record_compaction_event(
         &mut self,
         reason: &str,
@@ -45,6 +50,10 @@ impl ContextSession for SessionRecord {
 
     fn ensure_system_message(&mut self, content: &str) {
         SessionRecord::ensure_system_message(self, content);
+    }
+
+    fn persist_checkpoint(&self, reason: &str) -> Result<()> {
+        save_checkpoint(self, reason).map(|_| ())
     }
 
     fn record_compaction_event(

--- a/crates/core/src/agent_builder.rs
+++ b/crates/core/src/agent_builder.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use parking_lot::Mutex;
 use tracing::{info, warn};
 use zene_config::ZeneConfig;
-use zene_context::{ensure_memory_in_system, ContextEngine};
+use zene_context::{ensure_memory_in_system, ContextEngine, FsMemoryStore};
 use zene_llm::ChatClient;
 use zene_sandbox::{LocalSandbox, Sandbox};
 use zene_session::{AgentRecordWriter, SessionRecord};
@@ -195,7 +195,10 @@ impl AgentBuilder {
             include_workspace,
         );
         self.session.ensure_system_message(&system_prompt);
-        ensure_memory_in_system(&mut self.session.messages, &workdir);
+        ensure_memory_in_system(
+            &mut self.session.messages,
+            &FsMemoryStore::new(&workdir),
+        );
 
         let client = match self.client {
             Some(client) => client,

--- a/crates/core/src/context_events.rs
+++ b/crates/core/src/context_events.rs
@@ -1,0 +1,75 @@
+//! Default [`ContextEventHandler`] for [`Agent`](crate::Agent).
+
+use std::path::Path;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tracing::{info, warn};
+use zene_context::{
+    publish_prefix, CompactionSegmentStore, CompactionSegmentWrite, ContextEvent,
+    ContextEventHandler, EventOutcome, FsCompactionSegmentStore, FsMemoryStore, MemoryStore,
+    run_memory_flush,
+};
+use zene_llm::ChatClient;
+
+pub struct AgentContextHandler<'a> {
+    client: &'a ChatClient,
+    model: &'a str,
+    segment_store: FsCompactionSegmentStore,
+    memory_store: FsMemoryStore,
+}
+
+impl<'a> AgentContextHandler<'a> {
+    pub fn new(client: &'a ChatClient, model: &'a str, workdir: &'a Path) -> Self {
+        Self {
+            client,
+            model,
+            segment_store: FsCompactionSegmentStore::new(),
+            memory_store: FsMemoryStore::new(workdir),
+        }
+    }
+}
+
+#[async_trait]
+impl ContextEventHandler for AgentContextHandler<'_> {
+    async fn handle(&mut self, event: &ContextEvent) -> Result<EventOutcome> {
+        match event {
+            ContextEvent::Checkpoint { .. } | ContextEvent::EpochBumped { .. } => {
+                Ok(EventOutcome::Void)
+            }
+            ContextEvent::CompactionSegment { session_id, body } => {
+                let write = CompactionSegmentWrite {
+                    session_id: session_id.clone(),
+                    body: body.clone(),
+                };
+                match self.segment_store.write_segment(&write) {
+                    Ok(path) => {
+                        info!(path = %path.display(), "wrote compaction segment");
+                    }
+                    Err(err) => {
+                        warn!(error = %err, "failed to write compaction segment");
+                    }
+                }
+                Ok(EventOutcome::Void)
+            }
+            ContextEvent::PublishPrefix {
+                session_id,
+                epoch,
+                messages,
+            } => {
+                publish_prefix(session_id, *epoch, messages).await;
+                Ok(EventOutcome::Void)
+            }
+            ContextEvent::MemoryFlush { conversation } => {
+                let result =
+                    run_memory_flush(self.client, self.model, conversation, &self.memory_store)
+                        .await?;
+                Ok(EventOutcome::MemoryFlush(result))
+            }
+        }
+    }
+
+    fn memory_reminder(&self) -> Option<String> {
+        zene_context::memory_reminder_from_store(&self.memory_store)
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -9,8 +9,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use zene_config::ZeneConfig;
 use zene_context::{
-    CompactionSegmentStore, CompactionSegmentWrite, ContextDeps, ContextEngine, ContextEvent,
-    FsCompactionSegmentStore, PrefireClientFactory, StepContext,
+    ContextDeps, ContextEngine, FsMemoryStore, PrefireClientFactory, StepContext,
 };
 use zene_llm::{ChatClient, ChatRequest, Message, StreamEvent, TokenUsage, ToolCall};
 use zene_sandbox::{LocalSandbox, Sandbox};
@@ -33,6 +32,7 @@ use zene_mcp::McpManager;
 mod agent_builder;
 mod agent_turn;
 mod context_config;
+mod context_events;
 mod context_hooks;
 mod events;
 mod plan_mode;
@@ -296,16 +296,21 @@ impl Agent {
         let background_tasks = self.background.lock().list();
         let hooks = context_hooks::ZeneContextHooks::new(&self.session, &background_tasks);
         let compaction_config = context_config::context_compaction_config(&self.config.compaction);
+        let mut handler = context_events::AgentContextHandler::new(
+            &self.client,
+            &self.config.model,
+            self.sandbox.workdir(),
+        );
         let prefire_factory = self.prefire_client_factory();
         let mut deps = ContextDeps {
             session: &mut self.session,
             compaction_config: &compaction_config,
             model: &self.config.model,
-            workdir: self.sandbox.workdir(),
             client: &self.client,
             hooks: Some(&hooks),
             system_prompt: &self.system_prompt,
             estimator: &estimator,
+            handler: &mut handler,
             prefire_client_factory: prefire_factory,
         };
         let result = self
@@ -314,7 +319,6 @@ impl Agent {
             .await;
         match &result {
             Ok(forced) => {
-                self.dispatch_context_events(&forced.events)?;
                 if let Some(compact_result) = &forced.compaction {
                     self.record_compaction(compact_result)?;
                 }
@@ -323,34 +327,6 @@ impl Agent {
             }
             Err(_) => result.map(|forced| forced.compaction),
         }
-    }
-
-    fn dispatch_context_events(&self, events: &[ContextEvent]) -> Result<()> {
-        let segment_store = FsCompactionSegmentStore::new();
-        for event in events {
-            match event {
-                ContextEvent::Checkpoint { reason } => {
-                    let _ = save_checkpoint(&self.session, reason)?;
-                }
-                ContextEvent::CompactionSegment { session_id, body } => {
-                    let write = CompactionSegmentWrite {
-                        session_id: session_id.clone(),
-                        body: body.clone(),
-                    };
-                    match segment_store.write_segment(&write) {
-                        Ok(path) => {
-                            info!(path = %path.display(), "wrote compaction segment");
-                        }
-                        Err(err) => {
-                            warn!(error = %err, "failed to write compaction segment");
-                        }
-                    }
-                }
-                ContextEvent::EpochBumped { .. }
-                | ContextEvent::PublishPrefix { .. } => {}
-            }
-        }
-        Ok(())
     }
 
     /// Human-readable context report for `/context` (grok-aligned).
@@ -651,20 +627,24 @@ impl Agent {
         let background_tasks = self.background.lock().list();
         let hooks = context_hooks::ZeneContextHooks::new(&self.session, &background_tasks);
         let compaction_config = context_config::context_compaction_config(&self.config.compaction);
+        let mut handler = context_events::AgentContextHandler::new(
+            &self.client,
+            &self.config.model,
+            self.sandbox.workdir(),
+        );
         let prefire_factory = self.prefire_client_factory();
         let mut deps = ContextDeps {
             session: &mut self.session,
             compaction_config: &compaction_config,
             model: &self.config.model,
-            workdir: self.sandbox.workdir(),
             client: &self.client,
             hooks: Some(&hooks),
             system_prompt: &self.system_prompt,
             estimator: &estimator,
+            handler: &mut handler,
             prefire_client_factory: prefire_factory,
         };
         let prepared = self.context.prepare_step(&mut deps, &tools).await?;
-        self.dispatch_context_events(&prepared.events)?;
         if let Some(result) = &prepared.compaction {
             self.record_compaction(result)?;
         }
@@ -742,17 +722,22 @@ impl Agent {
                     let hooks = context_hooks::ZeneContextHooks::new(&self.session, &background_tasks);
                     let compaction_config =
                         context_config::context_compaction_config(&self.config.compaction);
+                    let mut handler = context_events::AgentContextHandler::new(
+                        &self.client,
+                        &self.config.model,
+                        self.sandbox.workdir(),
+                    );
                     let prefire_factory = self.prefire_client_factory();
                     let overflow = {
                         let mut deps = ContextDeps {
                             session: &mut self.session,
                             compaction_config: &compaction_config,
                             model: &self.config.model,
-                            workdir: self.sandbox.workdir(),
                             client: &self.client,
                             hooks: Some(&hooks),
                             system_prompt: &self.system_prompt,
                             estimator: &estimator,
+                            handler: &mut handler,
                             prefire_client_factory: prefire_factory,
                         };
                         self.context
@@ -764,7 +749,6 @@ impl Agent {
                             )
                             .await?
                     };
-                    self.dispatch_context_events(&overflow.events)?;
                     if let Some(result) = &overflow.compaction {
                         self.record_compaction(result)?;
                     }

--- a/docs/agent-components.md
+++ b/docs/agent-components.md
@@ -48,7 +48,7 @@ assemble/epoch        内置 + MCP 工具         checkpoint/fork
 
 ## 组合原则
 
-1. **引擎不做 IO**：compaction、checkpoint、record、gateway publish 通过 `ContextEvent` 交给 runtime。
+1. **引擎不做 IO**：compaction segment、gateway publish、memory flush 通过 [`ContextEventHandler`](../../crates/context/src/event_handler.rs) 交给 runtime；checkpoint 通过 [`ContextSession::persist_checkpoint`](../../crates/context/src/session.rs)。
 2. **trait 边界**：Session、Hooks、Sandbox、Tool 用 trait；Zene 类型提供 adapter，不强制 adopt。
 3. **feature 可选**：`memory`、`gateway`、`prefire` 为 `zene-context` 的 cargo feature，轻量集成可关闭。
 4. **core 是 composition root，不是唯一入口**：CLI / Cloud / 第三方只依赖需要的 crate。
@@ -138,6 +138,14 @@ loop {
 - Permission 双层：`ToolPermission` vs `PermissionGate`
 
 拆分方向：`AgentBuilder` + trait object hooks（**已实现 builder**）；`ToolContext` 已改为 `Arc<dyn Sandbox>`；`TodoItem` / Permission 双层仍待拆。
+
+### 2026-08-11 — Phase 6 Context runtime boundary
+
+- **`ContextEventHandler`** trait + `EventOutcome`；引擎 inline 调用 handler 完成需 await 的 IO
+- **`ContextEvent::MemoryFlush`**、扩展 **`PublishPrefix`**；gateway HTTP 与 memory flush LLM 移出 engine
+- **`ContextSession::persist_checkpoint`**：checkpoint 经 session trait 落盘
+- **`ContextDeps`** 移除 `workdir`；memory reminder 经 handler + `MemoryStore`
+- core：`AgentContextHandler`（`context_events.rs`）替代 `dispatch_context_events`
 
 ### 2026-08-11 — Phase 5 Turn loop
 

--- a/docs/context-engine.md
+++ b/docs/context-engine.md
@@ -52,21 +52,22 @@ pub struct ContextMetadata {
 
 pub enum ContextEvent {
     EpochBumped { old: u64, new: u64, reason: &'static str },
-    PublishPrefix { epoch: u64, message_count: usize },
+    PublishPrefix { session_id: String, epoch: u64, messages: Vec<Message> },
     Checkpoint { reason: &'static str },
-    CompactionCompleted(CompactionResult),
+    CompactionSegment { session_id: String, body: String },
+    MemoryFlush { conversation: String },
 }
 
 pub struct ContextDeps<'a> {
-    pub session: &'a mut SessionRecord,
+    pub session: &'a mut dyn ContextSession,
     pub compaction_config: &'a CompactionConfig,
     pub model: &'a str,
-    pub workdir: &'a Path,
     pub client: &'a ChatClient,
-    pub background_tasks: &'a [BackgroundTask],
+    pub hooks: Option<&'a dyn ContextHooks>,
     pub system_prompt: &'a str,
     pub estimator: &'a TokenEstimator,
-    pub full_config: &'a ZeneConfig,  // prefire 旁路 LLM 建 client
+    pub handler: &'a mut dyn ContextEventHandler,
+    pub prefire_client_factory: Option<PrefireClientFactory>,
 }
 ```
 

--- a/docs/decoupling-plan.md
+++ b/docs/decoupling-plan.md
@@ -23,7 +23,15 @@ Phased refactor toward composable agent crates (see `docs/agent-components.md`).
 - **`CompactionSegmentWrite`** + `ContextEvent::CompactionSegment`; runtime persists via `FsCompactionSegmentStore`.
 - **`MemoryStore`** trait + `FsMemoryStore`; memory flush/load IO moved out of `memory.rs` logic.
 
-## Phase 5 — Turn loop → `zene-turn` (current)
+## Phase 5 — Turn loop → `zene-turn` (done)
 
 - **`zene-turn`**: `TurnId` / `SteerBuffer` / turn guards; `TurnRuntime` trait + `run_turn_loop`.
 - `Agent` implements `TurnRuntime`; core keeps step/tools/LLM wiring, loop orchestration in `zene-turn`.
+
+## Phase 6 — Context runtime boundary (current)
+
+- **`ContextEventHandler`** trait: gateway publish, memory flush LLM+store, compaction segment IO.
+- **`ContextEvent::MemoryFlush`** + extended **`PublishPrefix`** (session_id + messages); engine no longer calls HTTP/LLM/store directly.
+- **`ContextSession::persist_checkpoint`**: checkpoint IO via session trait (not handler).
+- **`ContextDeps`**: removed `workdir`; memory reminder via handler + `MemoryStore`.
+- **`AgentContextHandler`** in `zene-core` composes FS stores + gateway + memory flush.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues context decoupling (Phase 6) by moving all runtime IO out of `ContextEngine`:

- **`ContextEventHandler` trait** — gateway `PublishPrefix`, `MemoryFlush` (LLM + store), compaction segment writes
- **`ContextEvent` extensions** — `MemoryFlush { conversation }`, `PublishPrefix { session_id, epoch, messages }`
- **`ContextSession::persist_checkpoint`** — checkpoint IO via session trait (engine no longer depends on `save_checkpoint`)
- **`ContextDeps` slimming** — removed `workdir`; memory reminder loaded via handler + `MemoryStore`
- **Core composition** — `AgentContextHandler` replaces `dispatch_context_events`

Compaction summarize LLM (`compact_session`) and prefire pass1 remain in-engine (semantic algorithm); all filesystem/HTTP/memory-flush side effects now go through handler or session trait.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b71ce392-bcdf-4e4a-a83c-0f9e213722ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b71ce392-bcdf-4e4a-a83c-0f9e213722ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

