### PR TITLE
feat: 拆出异步 ApprovalBroker，策略判定不再阻塞 mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,8 +4158,10 @@ dependencies = [
 name = "zene-permission"
 version = "0.1.11"
 dependencies = [
+ "async-trait",
  "parking_lot",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/apps/cli/src/acp/server.rs
+++ b/apps/cli/src/acp/server.rs
@@ -4,13 +4,14 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, bail, Context, Result};
+use async_trait::async_trait;
 use serde_json::{json, Value};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 use zene_config::ZeneConfig;
 use zene_core::{
-    Agent, AskUserOption, PermissionGate, PermissionMode, PromptChoice, RuntimeEvent,
-    RuntimeEventKind, RuntimeHandle,
+    Agent, ApprovalBroker, ApprovalRequest, AskUserOption, PermissionGate, PermissionMode,
+    PromptChoice, RuntimeEvent, RuntimeEventKind, RuntimeHandle,
 };
 use zene_runtime::{RuntimeControl, RuntimeRecoveryInfo};
 use zene_sandbox::LocalSandbox;
@@ -640,36 +641,49 @@ fn configure_agent_brokers(
     pending_tool: Arc<Mutex<PendingToolCall>>,
 ) {
     if !yolo {
-        let writer_perm = writer.clone();
-        let session_id = sid.clone();
-        let mode_str = permission_mode.as_str().to_string();
-        let pending_for_perm = Arc::clone(&pending_tool);
-        let gate = PermissionGate::with_prompter(
-            permission_mode,
-            Box::new(move |tool_name, preview| {
-                let tool_call_id = pending_for_perm
-                    .lock()
-                    .unwrap()
-                    .id
-                    .clone()
-                    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-                acp_permission_prompt(
-                    &writer_perm,
-                    &session_id,
-                    &mode_str,
-                    tool_name,
-                    preview,
-                    &tool_call_id,
-                )
-            }),
-        );
-        agent.set_permission_gate(gate);
+        agent.set_permission_gate(PermissionGate::new(permission_mode));
+        agent.set_approval_broker(Arc::new(AcpApprovalBroker {
+            writer: writer.clone(),
+            session_id: sid.clone(),
+            permission_mode: permission_mode.as_str().to_string(),
+            pending_tool: Arc::clone(&pending_tool),
+        }));
     }
 
     let writer_ask = writer.clone();
     agent.set_ask_user_prompter(Arc::new(move |question, options| {
         acp_ask_user_prompt(&writer_ask, &sid, question, options)
     }));
+}
+
+struct AcpApprovalBroker {
+    writer: AcpWriter,
+    session_id: String,
+    permission_mode: String,
+    pending_tool: Arc<Mutex<PendingToolCall>>,
+}
+
+#[async_trait]
+impl ApprovalBroker for AcpApprovalBroker {
+    async fn request(&self, request: ApprovalRequest) -> io::Result<PromptChoice> {
+        let tool_call_id = request.tool_call_id.clone().unwrap_or_else(|| {
+            self.pending_tool
+                .lock()
+                .unwrap()
+                .id
+                .clone()
+                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
+        });
+        acp_permission_prompt(
+            &self.writer,
+            &self.session_id,
+            &self.permission_mode,
+            &request.tool_name,
+            &request.preview(),
+            &tool_call_id,
+        )
+        .await
+    }
 }
 
 async fn run_prompt_job(
@@ -1020,7 +1034,7 @@ fn acp_ask_user_prompt(
     Ok(option_id.to_string())
 }
 
-fn acp_permission_prompt(
+async fn acp_permission_prompt(
     writer: &AcpWriter,
     session_id: &str,
     permission_mode: &str,
@@ -1028,60 +1042,42 @@ fn acp_permission_prompt(
     preview: &str,
     tool_call_id: &str,
 ) -> io::Result<PromptChoice> {
-    let (tx, rx) = std::sync::mpsc::channel::<Result<Value, String>>();
-    let writer = writer.clone();
-    let session_id = session_id.to_string();
-    let permission_mode = permission_mode.to_string();
-    let tool = tool_name.to_string();
-    let preview = preview.to_string();
-    let tool_call_id = tool_call_id.to_string();
-    let handle = tokio::runtime::Handle::current();
-    handle.spawn(async move {
-        let raw_input = serde_json::from_str::<Value>(&preview)
-            .unwrap_or_else(|_| json!({ "preview": preview }));
-        let result = writer
-            .request(
-                "session/request_permission",
-                json!({
-                    "sessionId": session_id,
-                    "toolCall": {
-                        "toolCallId": tool_call_id,
-                        "title": tool_title(&tool, &preview),
-                        "kind": tool_kind(&tool),
-                        "status": "pending",
-                        "rawInput": raw_input,
+    let raw_input = serde_json::from_str::<Value>(preview)
+        .unwrap_or_else(|_| json!({ "preview": preview }));
+    let result = writer
+        .request(
+            "session/request_permission",
+            json!({
+                "sessionId": session_id,
+                "toolCall": {
+                    "toolCallId": tool_call_id,
+                    "title": tool_title(tool_name, preview),
+                    "kind": tool_kind(tool_name),
+                    "status": "pending",
+                    "rawInput": raw_input,
+                },
+                "options": [
+                    {
+                        "optionId": "allow-once",
+                        "name": "Allow once",
+                        "kind": "allow_once"
                     },
-                    "options": [
-                        {
-                            "optionId": "allow-once",
-                            "name": "Allow once",
-                            "kind": "allow_once"
-                        },
-                        {
-                            "optionId": "allow-always",
-                            "name": "Allow always",
-                            "kind": "allow_always"
-                        },
-                        {
-                            "optionId": "reject-once",
-                            "name": "Reject",
-                            "kind": "reject_once"
-                        }
-                    ],
-                    "permissionMode": permission_mode,
-                }),
-            )
-            .await
-            .map_err(|e| e.to_string());
-        let _ = tx.send(result);
-    });
-
-    // Avoid blocking a tokio worker while waiting for the client reply.
-    let result = std::thread::spawn(move || rx.recv())
-        .join()
-        .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "permission thread panicked"))?
-        .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))?
-        .map_err(|e| io::Error::new(io::ErrorKind::BrokenPipe, e))?;
+                    {
+                        "optionId": "allow-always",
+                        "name": "Allow always",
+                        "kind": "allow_always"
+                    },
+                    {
+                        "optionId": "reject-once",
+                        "name": "Reject",
+                        "kind": "reject_once"
+                    }
+                ],
+                "permissionMode": permission_mode,
+            }),
+        )
+        .await
+        .map_err(|err| io::Error::new(io::ErrorKind::BrokenPipe, err))?;
 
     let option_id = result
         .pointer("/outcome/optionId")

--- a/crates/core/src/agent_builder.rs
+++ b/crates/core/src/agent_builder.rs
@@ -64,6 +64,7 @@ pub struct AgentBuilder {
     record_writer: Option<AgentRecordWriter>,
     session_store: Option<Arc<dyn SessionStore>>,
     model_executor: Option<Arc<dyn zene_model_executor::ModelExecutor>>,
+    approval_broker: Option<zene_permission::SharedApprovalBroker>,
     external_session_id: Option<String>,
     include_workspace_context: Option<bool>,
 }
@@ -95,6 +96,7 @@ impl AgentBuilder {
             record_writer: None,
             session_store: None,
             model_executor: None,
+            approval_broker: None,
             external_session_id: None,
             include_workspace_context: None,
         }
@@ -154,6 +156,12 @@ impl AgentBuilder {
         executor: Arc<dyn zene_model_executor::ModelExecutor>,
     ) -> Self {
         self.model_executor = Some(executor);
+        self
+    }
+
+    /// Inject the async approval waiter used when policy returns `Ask`.
+    pub fn approval_broker(mut self, broker: zene_permission::SharedApprovalBroker) -> Self {
+        self.approval_broker = Some(broker);
         self
     }
 
@@ -347,6 +355,7 @@ impl AgentBuilder {
                 .unwrap_or_else(|| Arc::new(FileSessionStore)),
             mcp,
             background: self.background.unwrap_or_else(shared_background_tasks),
+            approval_broker: self.approval_broker,
         })
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -58,8 +58,10 @@ pub use tool_dedup::{append_reminder, ToolDedup};
 pub use tool_scheduler::{classify_tool_accesses, ToolScheduler};
 pub use zene_hooks::{HookBlock, HookRunner, HookSpec};
 pub use zene_permission::{
-    approve_tool_call, policy_denied, PermissionGate, PermissionMode, PermissionPrompter,
-    PermissionRule, PromptChoice, RuleAction, SharedToolPermission, ToolPermission,
+    approve_tool_call, policy_denied, resolve_permission, ApprovalBroker, ApprovalRequest,
+    AutoApprovalBroker, PermissionGate, PermissionMode, PermissionPrompter, PermissionRule,
+    PolicyDecision, PromptChoice, RuleAction, SharedApprovalBroker, SharedToolPermission,
+    TerminalApprovalBroker, ToolPermission,
 };
 pub use zene_runtime::{
     ApprovalDecision, ExecutionState, RuntimeCommand, RuntimeLifecycle, RuntimeResponse,
@@ -122,6 +124,7 @@ pub struct Agent {
     session_store: Arc<dyn zene_session::SessionStore>,
     mcp: Option<McpManager>,
     background: SharedBackgroundTasks,
+    approval_broker: Option<zene_permission::SharedApprovalBroker>,
 }
 
 pub struct PromptOptions {
@@ -626,6 +629,11 @@ impl Agent {
         self.permission = Arc::new(Mutex::new(gate));
     }
 
+    /// Inject the async approval waiter used when policy returns `Ask`.
+    pub fn set_approval_broker(&mut self, broker: zene_permission::SharedApprovalBroker) {
+        self.approval_broker = Some(broker);
+    }
+
     /// Replace the AskUserQuestion prompter (e.g. TUI modal).
     pub fn set_ask_user_prompter(&mut self, prompter: SharedAskUserPrompter) {
         self.ask_user = prompter;
@@ -1106,12 +1114,15 @@ impl Agent {
             )?;
         }
 
-        let subagent_runner = Arc::new(CoreSubagentRunner::new(self.config.clone()));
+        let subagent_runner = Arc::new(
+            CoreSubagentRunner::new(self.config.clone()).with_broker(self.approval_broker.clone()),
+        );
         let result = {
             let executor = DefaultToolExecutor::new(ToolExecutorDeps {
                 tools: Arc::clone(&self.tools),
                 sandbox: Arc::clone(&self.sandbox),
                 permission: Arc::clone(&self.permission),
+                approval_broker: self.approval_broker.clone(),
                 plan_mode: Arc::clone(&self.plan_mode),
                 plan_approval: &self.plan_approval,
                 todos: Arc::clone(&self.todos),

--- a/crates/core/src/subagent.rs
+++ b/crates/core/src/subagent.rs
@@ -38,11 +38,20 @@ impl ChatBackend for ChatClient {
 
 pub struct CoreSubagentRunner {
     config: ZeneConfig,
+    broker: Option<zene_permission::SharedApprovalBroker>,
 }
 
 impl CoreSubagentRunner {
     pub fn new(config: ZeneConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            broker: None,
+        }
+    }
+
+    pub fn with_broker(mut self, broker: Option<zene_permission::SharedApprovalBroker>) -> Self {
+        self.broker = broker;
+        self
     }
 }
 
@@ -63,7 +72,7 @@ impl SubagentRunner for CoreSubagentRunner {
             .map(|env| env.depth)
             .unwrap_or(0);
 
-        run_subagent(
+        run_subagent_with_runner(
             prompt,
             profile,
             sandbox,
@@ -72,6 +81,8 @@ impl SubagentRunner for CoreSubagentRunner {
             parent_ctx.cancel.as_ref(),
             parent_depth,
             parent_ctx.permission.clone(),
+            None,
+            self.broker.clone(),
         )
         .await
     }
@@ -97,6 +108,7 @@ pub async fn run_subagent(
         parent_depth,
         permission,
         None,
+        None,
     )
     .await
 }
@@ -111,6 +123,7 @@ pub(crate) async fn run_subagent_with_runner(
     parent_depth: u32,
     permission: Option<SharedToolPermission>,
     runner: Option<Arc<dyn SubagentRunner>>,
+    broker: Option<zene_permission::SharedApprovalBroker>,
 ) -> Result<String> {
     let subagent_depth = parent_depth + 1;
     if subagent_depth > DEFAULT_SUBAGENT_MAX_DEPTH {
@@ -119,7 +132,9 @@ pub(crate) async fn run_subagent_with_runner(
         );
     }
 
-    let runner = runner.unwrap_or_else(|| Arc::new(CoreSubagentRunner::new(config.clone())));
+    let runner = runner.unwrap_or_else(|| {
+        Arc::new(CoreSubagentRunner::new(config.clone()).with_broker(broker.clone()))
+    });
     let subagent_env = SubagentEnv {
         depth: subagent_depth,
         max_depth: DEFAULT_SUBAGENT_MAX_DEPTH,
@@ -132,6 +147,7 @@ pub(crate) async fn run_subagent_with_runner(
         backend,
         subagent_env,
         permission,
+        broker,
     );
 
     TurnEngine::new(&mut runtime)
@@ -150,6 +166,7 @@ struct SubagentTurnRuntime<'a> {
     backend: &'a dyn ChatBackend,
     subagent_env: SubagentEnv,
     permission: Option<SharedToolPermission>,
+    broker: Option<zene_permission::SharedApprovalBroker>,
     tools: ToolRegistry,
     messages: Vec<Message>,
     compaction_config: zene_context::CompactionConfig,
@@ -164,6 +181,7 @@ impl<'a> SubagentTurnRuntime<'a> {
         backend: &'a dyn ChatBackend,
         subagent_env: SubagentEnv,
         permission: Option<SharedToolPermission>,
+        broker: Option<zene_permission::SharedApprovalBroker>,
     ) -> Self {
         let system_prompt = subagent_system_prompt(profile, sandbox.workdir());
         Self {
@@ -172,6 +190,7 @@ impl<'a> SubagentTurnRuntime<'a> {
             backend,
             subagent_env,
             permission,
+            broker,
             tools: tools_for_profile(profile),
             messages: vec![Message::system(&system_prompt)],
             compaction_config: subagent_compaction_config(
@@ -332,6 +351,7 @@ impl ToolExecutorPort<()> for SubagentTurnRuntime<'_> {
             cancel,
             &self.subagent_env,
             self.permission.clone(),
+            self.broker.clone(),
             &mut self.messages,
         )
         .await?;
@@ -407,6 +427,7 @@ impl TurnRuntime for SubagentTurnRuntime<'_> {
             cancel,
             &self.subagent_env,
             self.permission.clone(),
+            self.broker.clone(),
             &mut self.messages,
         )
         .await?;
@@ -449,6 +470,7 @@ async fn run_subagent_tools(
     cancel: Option<&CancellationToken>,
     subagent_env: &SubagentEnv,
     permission: Option<SharedToolPermission>,
+    broker: Option<zene_permission::SharedApprovalBroker>,
     messages: &mut Vec<Message>,
 ) -> Result<()> {
     let ctx = ToolContext {
@@ -468,7 +490,17 @@ async fn run_subagent_tools(
         }
 
         let allowed = if let Some(ref gate) = permission {
-            gate.lock().approve_tool_call(&call.name, &call.arguments)?
+            zene_permission::resolve_permission(
+                gate,
+                broker.as_ref(),
+                zene_permission::ApprovalRequest {
+                    request_id: call.id.clone(),
+                    tool_name: call.name.clone(),
+                    arguments: call.arguments.clone(),
+                    tool_call_id: Some(call.id.clone()),
+                },
+            )
+            .await?
         } else {
             true
         };
@@ -681,7 +713,7 @@ mod tests {
                 .as_ref()
                 .map(|env| env.depth)
                 .unwrap_or(0);
-            run_subagent(
+            run_subagent_with_runner(
                 prompt,
                 profile,
                 sandbox,
@@ -690,6 +722,8 @@ mod tests {
                 parent_ctx.cancel.as_ref(),
                 parent_depth,
                 parent_ctx.permission.clone(),
+                None,
+                None,
             )
             .await
         }

--- a/crates/core/src/tool_executor.rs
+++ b/crates/core/src/tool_executor.rs
@@ -26,6 +26,7 @@ pub(crate) struct ToolExecutorDeps<'a> {
     pub tools: Arc<ToolRegistry>,
     pub sandbox: Arc<dyn Sandbox>,
     pub permission: zene_tools::SharedToolPermission,
+    pub approval_broker: Option<zene_permission::SharedApprovalBroker>,
     pub plan_mode: SharedPlanMode,
     pub plan_approval: &'a PlanApprovalPrompter,
     pub todos: SharedTodoStore,
@@ -183,11 +184,17 @@ impl<'a> DefaultToolExecutor<'a> {
                     None,
                 ))
             } else {
-                let allowed = match self
-                    .deps
-                    .permission
-                    .lock()
-                    .approve_tool_call(&call.name, &call.arguments)
+                let allowed = match zene_permission::resolve_permission(
+                    &self.deps.permission,
+                    self.deps.approval_broker.as_ref(),
+                    zene_permission::ApprovalRequest {
+                        request_id: call.id.clone(),
+                        tool_name: call.name.clone(),
+                        arguments: call.arguments.clone(),
+                        tool_call_id: Some(call.id.clone()),
+                    },
+                )
+                .await
                 {
                     Ok(v) => v,
                     Err(err) => {

--- a/crates/permission/Cargo.toml
+++ b/crates/permission/Cargo.toml
@@ -10,7 +10,9 @@ keywords = ["agent", "permission", "security"]
 categories = ["development-tools"]
 
 [dependencies]
+async-trait.workspace = true
 parking_lot.workspace = true
 serde_json.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]

--- a/crates/permission/README.md
+++ b/crates/permission/README.md
@@ -2,6 +2,10 @@
 
 Tool permission modes, rules, and `PermissionGate` for [Zene](https://github.com/ParaTensor/zene) agents.
 
+Policy (`PermissionGate::evaluate`) is a pure allow/deny/ask decision. User
+interaction goes through [`ApprovalBroker`](src/broker.rs) so ACP, Cloud, and
+tests can inject waiters without holding a sync mutex.
+
 ## License
 
 MIT

--- a/crates/permission/src/broker.rs
+++ b/crates/permission/src/broker.rs
@@ -1,0 +1,97 @@
+//! Async approval port. Policy (`evaluate`) stays in [`PermissionGate`];
+//! user interaction lives here so ACP / Cloud / tests can inject their own
+//! waiter without blocking a sync mutex.
+
+use std::io;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::{default_prompter, PromptChoice};
+
+/// One request for a human (or test double) to approve a gated tool.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApprovalRequest {
+    pub request_id: String,
+    pub tool_name: String,
+    pub arguments: String,
+    pub tool_call_id: Option<String>,
+}
+
+impl ApprovalRequest {
+    pub fn preview(&self) -> String {
+        crate::truncate(&self.arguments, 120)
+    }
+}
+
+/// Transport-neutral async approval. Core must not know ACP or Cloud HTTP.
+#[async_trait]
+pub trait ApprovalBroker: Send + Sync {
+    async fn request(&self, request: ApprovalRequest) -> io::Result<PromptChoice>;
+}
+
+pub type SharedApprovalBroker = Arc<dyn ApprovalBroker>;
+
+/// Always returns a configured choice. Used by tests and yolo-adjacent fakes.
+#[derive(Debug, Clone, Copy)]
+pub struct AutoApprovalBroker {
+    pub choice: PromptChoice,
+}
+
+impl AutoApprovalBroker {
+    pub fn allow_once() -> Self {
+        Self {
+            choice: PromptChoice::AllowOnce,
+        }
+    }
+
+    pub fn deny() -> Self {
+        Self {
+            choice: PromptChoice::Deny,
+        }
+    }
+}
+
+#[async_trait]
+impl ApprovalBroker for AutoApprovalBroker {
+    async fn request(&self, _request: ApprovalRequest) -> io::Result<PromptChoice> {
+        Ok(self.choice)
+    }
+}
+
+/// Local stdin prompt, moved off the async worker via `spawn_blocking`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TerminalApprovalBroker;
+
+#[async_trait]
+impl ApprovalBroker for TerminalApprovalBroker {
+    async fn request(&self, request: ApprovalRequest) -> io::Result<PromptChoice> {
+        let preview = request.preview();
+        let tool_name = request.tool_name;
+        tokio::task::spawn_blocking(move || default_prompter(&tool_name, &preview))
+            .await
+            .map_err(io::Error::other)?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn auto_broker_returns_configured_choice() {
+        let allow = AutoApprovalBroker::allow_once();
+        let deny = AutoApprovalBroker::deny();
+        let request = ApprovalRequest {
+            request_id: "req-1".into(),
+            tool_name: "Write".into(),
+            arguments: r#"{"path":"a.txt"}"#.into(),
+            tool_call_id: Some("call-1".into()),
+        };
+        assert_eq!(
+            allow.request(request.clone()).await.unwrap(),
+            PromptChoice::AllowOnce
+        );
+        assert_eq!(deny.request(request).await.unwrap(), PromptChoice::Deny);
+    }
+}

--- a/crates/permission/src/lib.rs
+++ b/crates/permission/src/lib.rs
@@ -1,14 +1,23 @@
 //! Tool permission gate: modes, rules, and interactive approval for gated tools.
 
+mod broker;
+
 use std::collections::HashSet;
 use std::io::{self, Write};
 use std::sync::Arc;
 
 use serde_json::Value;
 
+pub use broker::{
+    ApprovalBroker, ApprovalRequest, AutoApprovalBroker, SharedApprovalBroker,
+    TerminalApprovalBroker,
+};
+
 /// Shared permission gate used by main agent and subagents.
 pub trait ToolPermission: Send + Sync {
     fn approve_tool_call(&mut self, tool_name: &str, arguments: &str) -> io::Result<bool>;
+    fn evaluate(&self, tool_name: &str, arguments: &str) -> PolicyDecision;
+    fn apply_choice(&mut self, tool_name: &str, arguments: &str, choice: PromptChoice) -> bool;
     fn denied_message(tool_name: &str) -> String
     where
         Self: Sized;
@@ -77,6 +86,14 @@ pub enum PromptChoice {
     AllowOnce,
     AllowSession,
     Deny,
+}
+
+/// Pure policy outcome. `Ask` is the only case that may call [`ApprovalBroker`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyDecision {
+    Allow,
+    Deny,
+    Ask,
 }
 
 /// A single allow/deny/ask rule matched against tool name (glob-ish prefix/suffix `*`).
@@ -189,10 +206,10 @@ impl PermissionGate {
         self.rules.iter().find(|r| r.matches(tool_name))
     }
 
-    /// Returns `Ok(true)` if the tool may run, `Ok(false)` if denied.
-    pub fn check(&mut self, tool_name: &str, arguments: &str) -> io::Result<bool> {
+    /// Classify a tool call without talking to a user.
+    pub fn evaluate(&self, tool_name: &str, arguments: &str) -> PolicyDecision {
         if policy_denied(tool_name, arguments).is_some() {
-            return Ok(false);
+            return PolicyDecision::Deny;
         }
 
         let forced_ask = matches!(
@@ -202,52 +219,74 @@ impl PermissionGate {
 
         if let Some(rule) = self.matching_rule(tool_name) {
             match rule.action {
-                RuleAction::Allow => return Ok(true),
-                RuleAction::Deny => return Ok(false),
-                RuleAction::Ask => { /* force prompt below */ }
+                RuleAction::Allow => return PolicyDecision::Allow,
+                RuleAction::Deny => return PolicyDecision::Deny,
+                RuleAction::Ask => {}
             }
         }
 
         if !forced_ask {
             if self.mode.auto_approves_all() {
-                return Ok(true);
+                return PolicyDecision::Allow;
             }
 
             if !Self::requires_confirmation(tool_name) {
-                return Ok(true);
+                return PolicyDecision::Allow;
             }
 
             if self.mode.auto_approves_edits() && matches!(tool_name, "Write" | "Edit") {
-                return Ok(true);
+                return PolicyDecision::Allow;
             }
 
             if self.auto_allow_bash && tool_name == "Bash" {
-                return Ok(true);
+                return PolicyDecision::Allow;
             }
 
             if self.mode.denies_without_prompt() {
-                return Ok(false);
+                return PolicyDecision::Deny;
             }
         } else if self.mode.denies_without_prompt() {
-            return Ok(false);
+            return PolicyDecision::Deny;
         }
 
         if let Some(key) = session_approval_key(tool_name, arguments) {
             if self.approved_session.contains(&key) {
-                return Ok(true);
+                return PolicyDecision::Allow;
             }
         }
 
-        let preview = truncate(arguments, 120);
-        match (self.prompter)(tool_name, &preview)? {
-            PromptChoice::AllowOnce => Ok(true),
+        PolicyDecision::Ask
+    }
+
+    /// Record a prompt decision. `AllowSession` is remembered for this gate.
+    pub fn apply_choice(
+        &mut self,
+        tool_name: &str,
+        arguments: &str,
+        choice: PromptChoice,
+    ) -> bool {
+        match choice {
+            PromptChoice::AllowOnce => true,
             PromptChoice::AllowSession => {
                 if let Some(key) = session_approval_key(tool_name, arguments) {
                     self.approved_session.insert(key);
                 }
-                Ok(true)
+                true
             }
-            PromptChoice::Deny => Ok(false),
+            PromptChoice::Deny => false,
+        }
+    }
+
+    /// Returns `Ok(true)` if the tool may run, `Ok(false)` if denied.
+    pub fn check(&mut self, tool_name: &str, arguments: &str) -> io::Result<bool> {
+        match self.evaluate(tool_name, arguments) {
+            PolicyDecision::Allow => Ok(true),
+            PolicyDecision::Deny => Ok(false),
+            PolicyDecision::Ask => {
+                let preview = truncate(arguments, 120);
+                let choice = (self.prompter)(tool_name, &preview)?;
+                Ok(self.apply_choice(tool_name, arguments, choice))
+            }
         }
     }
 
@@ -289,8 +328,47 @@ impl ToolPermission for PermissionGate {
         self.check(tool_name, arguments)
     }
 
+    fn evaluate(&self, tool_name: &str, arguments: &str) -> PolicyDecision {
+        PermissionGate::evaluate(self, tool_name, arguments)
+    }
+
+    fn apply_choice(&mut self, tool_name: &str, arguments: &str, choice: PromptChoice) -> bool {
+        PermissionGate::apply_choice(self, tool_name, arguments, choice)
+    }
+
     fn denied_message(tool_name: &str) -> String {
         PermissionGate::denied_message(tool_name)
+    }
+}
+
+/// Resolve a tool call against policy, then the optional async broker.
+///
+/// The permission mutex is not held while awaiting the broker.
+pub async fn resolve_permission(
+    permission: &SharedToolPermission,
+    broker: Option<&SharedApprovalBroker>,
+    request: ApprovalRequest,
+) -> io::Result<bool> {
+    let decision = permission
+        .lock()
+        .evaluate(&request.tool_name, &request.arguments);
+    match decision {
+        PolicyDecision::Allow => Ok(true),
+        PolicyDecision::Deny => Ok(false),
+        PolicyDecision::Ask => {
+            let choice = if let Some(broker) = broker {
+                broker.request(request.clone()).await?
+            } else {
+                return permission
+                    .lock()
+                    .approve_tool_call(&request.tool_name, &request.arguments);
+            };
+            Ok(permission.lock().apply_choice(
+                &request.tool_name,
+                &request.arguments,
+                choice,
+            ))
+        }
     }
 }
 
@@ -312,7 +390,7 @@ fn path_has_segment(path: &str, segment: &str) -> bool {
     path.split('/').any(|part| part == segment)
 }
 
-fn default_prompter(tool_name: &str, args_preview: &str) -> io::Result<PromptChoice> {
+pub(crate) fn default_prompter(tool_name: &str, args_preview: &str) -> io::Result<PromptChoice> {
     eprint!(
         "\nAllow {tool_name}({args_preview})? [y]es / [n]o / [a]pprove for session: "
     );
@@ -343,7 +421,7 @@ pub fn session_approval_key(tool_name: &str, arguments: &str) -> Option<String> 
     }
 }
 
-fn truncate(input: &str, max: usize) -> String {
+pub(crate) fn truncate(input: &str, max: usize) -> String {
     if input.chars().count() <= max {
         input.to_string()
     } else {
@@ -521,5 +599,77 @@ mod tests {
         assert_eq!(PermissionMode::parse("accept_edits"), PermissionMode::AcceptEdits);
         assert_eq!(PermissionMode::parse("dont_ask"), PermissionMode::DontAsk);
         assert_eq!(PermissionMode::parse("manual"), PermissionMode::Default);
+    }
+
+    #[test]
+    fn evaluate_is_pure_and_does_not_prompt() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_clone = Arc::clone(&calls);
+        let gate = PermissionGate::with_prompter(PermissionMode::Default, {
+            Box::new(move |_tool, _args| {
+                calls_clone.fetch_add(1, Ordering::SeqCst);
+                Ok(PromptChoice::Deny)
+            })
+        });
+        assert_eq!(
+            gate.evaluate("Read", r#"{"path":"a.txt"}"#),
+            PolicyDecision::Allow
+        );
+        assert_eq!(
+            gate.evaluate("Write", r#"{"path":"a.txt","content":"x"}"#),
+            PolicyDecision::Ask
+        );
+        assert_eq!(
+            gate.evaluate("Write", r#"{"path":"node_modules/x","content":"x"}"#),
+            PolicyDecision::Deny
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn resolve_permission_uses_broker_for_ask() {
+        let permission: SharedToolPermission = Arc::new(parking_lot::Mutex::new(
+            PermissionGate::with_prompter(PermissionMode::Default, {
+                Box::new(|_tool, _args| panic!("sync prompter should not run"))
+            }),
+        ));
+        let broker: SharedApprovalBroker = Arc::new(AutoApprovalBroker::deny());
+        let allowed = resolve_permission(
+            &permission,
+            Some(&broker),
+            ApprovalRequest {
+                request_id: "req".into(),
+                tool_name: "Bash".into(),
+                arguments: r#"{"command":"ls"}"#.into(),
+                tool_call_id: None,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(!allowed);
+    }
+
+    #[tokio::test]
+    async fn resolve_permission_records_session_approval() {
+        let permission: SharedToolPermission =
+            Arc::new(parking_lot::Mutex::new(PermissionGate::new(PermissionMode::Default)));
+        let broker: SharedApprovalBroker = Arc::new(AutoApprovalBroker {
+            choice: PromptChoice::AllowSession,
+        });
+        let request = ApprovalRequest {
+            request_id: "req".into(),
+            tool_name: "Write".into(),
+            arguments: r#"{"path":"src/foo.rs","content":"x"}"#.into(),
+            tool_call_id: None,
+        };
+        assert!(resolve_permission(&permission, Some(&broker), request.clone())
+            .await
+            .unwrap());
+        assert_eq!(
+            permission
+                .lock()
+                .evaluate("Write", r#"{"path":"src/foo.rs","content":"x"}"#),
+            PolicyDecision::Allow
+        );
     }
 }

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `6efd592`。**
+> **进度快照：2026-08-13，基线 `39257dc`（PR #60 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> 「已建立边界」不等于「可插拔 runtime 已完成」。下一阶段不再优先拆 crate，而是让 `TurnEngine` 的默认路径消费真实 ports，让 `Agent` 退回 composition root。
+> Wave 13 已让默认 Turn 路径消费 `PreparedContext`。当前工作是 Wave 15：把策略判定和异步 `ApprovalBroker` 拆开。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -32,7 +32,7 @@
 3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。本地 `zene-runtime::RuntimeCommand` 与 Cloud `RuntimeCommand` 是两套类型；Cloud `RuntimeNotification.payload` 仍携带原始 ACP JSON。
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者，但 Agent-specific actor 仍在 `zene-core`，ACP 仍保留 transport 层 session bookkeeping。
-6. 权限仍是同步 `ToolPermission` + stdio prompt，没有独立的异步 `ApprovalBroker`，因此 ACP / Cloud 审批只能绕开 Core 各自实现。
+6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`；ACP 通过 broker 等待客户端，不再用同步 prompter 卡线程。Runtime-owned approval waiter（`RuntimeCommand::Approval` 唤醒）仍待下一刀。
 7. `ToolRegistry` 仍同时承担目录与执行；`RuntimeScope` 尚未成为 Subagent 的正式差异注入面。
 
 本文目标不是立刻重写 runtime，而是建立一个可以渐进落地的目标架构：
@@ -100,7 +100,7 @@ RuntimeHandle → Agent → TurnEngine
 | Tool 并发 | `crates/core/src/tool_scheduler.rs` | 同一模型 step 内进行冲突感知并发 |
 | Session | `crates/session` | `SessionRecord` + `SessionStore`；events 优先，messages 为 materialized cache |
 | Context | `crates/context` | observe/commit/project；`SessionView` 驱动 event-backed projection |
-| Permission | `crates/permission` | 策略判断仍与同步 prompter 绑在一起，尚无 `ApprovalBroker` |
+| Permission | `crates/permission` | `evaluate` 纯判定；`Ask` 走 `ApprovalBroker`。ACP 注入 `AcpApprovalBroker` |
 | Subagent | `crates/core/src/subagent.rs` | 直接实现 `TurnEnginePorts`；仍用独立 `ChatBackend` 和内存消息，尚未 `RuntimeScope` |
 | Runtime | `crates/runtime` + `crates/core/src/agent_runtime.rs` | 公共 command/event 在 `zene-runtime`；Agent actor 仍在 core |
 | ACP | `apps/cli/src/acp/server.rs` | transport adapter；创建/加载 session，并把请求接入 `RuntimeHandle` |
@@ -939,6 +939,7 @@ crates/
 - PR #56：Runtime control plane
 - PR #57：Execution recovery checkpoints and ACP recovery metadata
 - PR #58：Subagent TurnEngine unification and SessionStore injection
+- PR #60：TurnEngine default path consumes PreparedContext
 
 ### 15.2 当前判断（2026-08-13）
 
@@ -946,12 +947,12 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 
 真正的缺口不在 crate 数量，而在默认执行路径和产品面仍耦合在具体对象上：
 
-1. **Turn ports 必须成为真入口（Wave 13，本轮）**：`AgentTurnPorts.prepare_context` 产出 `PreparedContext`，`run_model` 只消费它；Subagent 直接实现 `TurnEnginePorts`。`LegacyTurnPorts` 只服务旧 `TurnRuntime` 适配，不再是默认 Agent/Subagent 路径。
+1. **Turn ports 已是真入口（Wave 13，PR #60）**：`AgentTurnPorts.prepare_context` 产出 `PreparedContext`，`run_model` 只消费它；Subagent 直接实现 `TurnEnginePorts`。
 2. **`Agent` 仍是 God Object**：它同时持有 model、tools、sandbox、permission、hooks、MCP、todos、plan mode。下一步是把它变成 wiring，而不是继续实现 step。
 3. **模型抽象仍偏 provider**：`ModelExecutor` 吃 `ChatRequest`；Subagent 另有 `ChatBackend`。目标是 Turn 只看见 `PreparedContext` → `ModelRequest`。
-4. **审批不是 port**：同步 `ToolPermission` 无法表达 ACP/Cloud 异步等待。需要 `PermissionService`（纯判定）+ `ApprovalBroker`（外部交互）。
+4. **审批 port 已建立（Wave 15，本轮）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。ACP 不再把 reverse RPC 塞进同步 prompter。仍缺 runtime-owned waiter：`RuntimeCommand::Approval` 尚未唤醒正在执行的 tool。
 5. **Cloud 仍消费 transport 形状**：`zene-cloud-runtime-client` 藏起了 ACP method，但 `payload` 仍是原始 JSON；本地与 Cloud 的 `RuntimeCommand` 不是同一类型。JobRunner 应对齐 Core 的 command/event，而不是再包一层 ACP。
-6. **不要再为干净拆 crate**：在 ports 成为默认路径、审批和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
+6. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
 Conversation event 与 materialized `messages` cache 的双轨可以保留，直到 legacy session 可证明无损迁移。不要为了架构干净上完整 Event Sourcing。
 
@@ -1060,9 +1061,9 @@ Wave 16  统一 transport command/event
 | Wave 10 | 已完成（当前设计范围） | strict projection、compaction event-backed planning、ProjectionExplain、cache drift/fallback provenance 已落地 |
 | Wave 11 | 已完成第一阶段 | ModelExecutor、ContextModel、usage boundary、runtime protocol 和 lifecycle publisher 已落地；Agent-specific actor 尚在 core |
 | Wave 12 | 已完成第一阶段 | safe resume、Cloud RuntimeClient、neutral runtime notifications、fenced command lease/ack、atomic state/event writes、outbox replay 和真实 replacement 测试已落地 |
-| Wave 13 | 进行中 | 默认 Agent/Subagent 路径消费 `PreparedContext`；不再在 `run_model` 内重新组装上下文 |
+| Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
-| Wave 15 | 未开始 | 异步 ApprovalBroker |
+| Wave 15 | 进行中 | `evaluate` + `ApprovalBroker` 已落地；runtime-owned waiter 仍待完成 |
 | Wave 16 | 未开始 | 统一本地/Cloud command/event 语义 |
 
 ### 当前收口状态与剩余边界
@@ -1098,7 +1099,7 @@ Wave 16  统一 transport command/event
    - pending tool / approval 的任意副作用自动 replay：继续采用 inspection/manual intervention，避免重复写操作。
    - `Agent` 从 step orchestrator 完全退回 composition root。
    - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor` / ModelExecutor，而不是并行 `ChatBackend`。
-   - 异步 `ApprovalBroker`；ACP/Cloud 审批不再绕开 Core。
+   - Runtime-owned approval waiter：`RuntimeCommand::Approval` 唤醒正在执行的 tool；Cloud 审批走同一 broker，而不是 ACP JSON。
    - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`；Cloud payload 不再以 ACP JSON 为产品语义。
    - Agent-specific actor 从 `zene-core` 移入独立 runtime implementation crate（应在 ports/审批稳定之后）。
    - 跨 VM outbox 的共享持久化实现；当前部署文档要求共享 POSIX volume 或后续 DB/object spool。
@@ -1148,14 +1149,20 @@ Wave 16  统一 transport command/event
    - 已覆盖 outbox retryable HTTP failure（503 → retry → 200）和 non-retryable HTTP failure（400 保留事件）路径，并在 Cloud deploy 文档中明确本地 outbox 的跨 VM 限制、共享持久卷要求和清理策略。
    - 同一 durable filesystem 的真实跨 worker reconnect/replay、crash recovery 和 DB/API/SSE 集成测试已完成；跨 VM outbox 仍需共享 POSIX volume 或 DB/object-backed spool 的部署决策。
 
-5. **Wave 13：默认路径真正走 ports（进行中）**
+5. **Wave 13：默认路径真正走 ports（PR #60，已完成）**
    - `PreparedContext` 携带 messages、tools、metadata、estimate_tokens；TurnEngine 把 assembler 输出传给 `run_model`。
    - `AgentTurnPorts.prepare_context` 调用 ContextEngine 并记录 step checkpoint；`run_model` 只调用 `invoke_model`，不再忽略上下文。
    - Subagent 直接实现 `TurnEnginePorts`，`ChatBackend` 收到的 messages/tools 来自 `PreparedContext`。
    - `AgentBuilder.model_executor` 允许注入 fake executor，便于不经过真实 provider 测试 runtime。
    - `LegacyTurnPorts` / `run_turn_loop` 保留给旧 `TurnRuntime` 实现。
 
-6. **持续质量门槛**
+6. **Wave 15：ApprovalBroker（进行中）**
+   - `PermissionGate::evaluate` 纯 allow/deny/ask；`Ask` 才进入 broker。
+   - `resolve_permission` 在 await 期间不持有 permission mutex。
+   - `AutoApprovalBroker` / `TerminalApprovalBroker` 可注入；ACP 使用 `AcpApprovalBroker`，不再 `std::thread` 阻塞等待。
+   - 未做：runtime-owned waiter 与 `RuntimeCommand::Approval` 打通。
+
+7. **持续质量门槛**
    - 每个 wave 保持 `cargo test --workspace --locked`；
    - 不破坏旧 ACP `AgentEvent` / RuntimeEvent 协议；
    - 不把 Cloud HTTP、Git、ACP JSON 格式引入 `zene-turn`；
@@ -1178,11 +1185,11 @@ Wave 16  统一 transport command/event
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 13** | ports 存在但默认路径不走，开放/解耦都是假的 |
-| 产品面灵活度 | Wave 15 | 没有 ApprovalBroker，ACP/Cloud 无法只换 port |
-| 跨进程一致 | Wave 16 | 两套 RuntimeCommand 会让 CLI/Cloud 行为分叉 |
+| 当前最大杠杆 | **Wave 15 waiter** | broker 已在，但 Approval command 还不能唤醒 tool |
+| 产品面灵活度 | Wave 16 | 两套 RuntimeCommand 会让 CLI/Cloud 行为分叉 |
+| 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**先完成 Wave 13**（本轮），再 **Wave 15 ApprovalBroker** 与 **Wave 16 统一事件**，最后才用 Wave 14 把 `Agent` 收成 wiring。不要先搬 runtime crate。
+推荐组合：**Wave 15 收口 runtime-owned waiter**，再 **Wave 16 统一事件**，最后才用 Wave 14 把 `Agent` 收成 wiring。不要先搬 runtime crate。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1229,4 +1236,10 @@ Wave 16  统一 transport command/event
 - 下一阶段优先级改为 Wave 13 → 15 → 16；暂缓再拆 crate。
 - 本轮落地：`PreparedContext` 携带 messages/tools/metadata；Agent/Subagent 默认路径消费它；`AgentBuilder` 可注入 `ModelExecutor`。
 - 明确非目标：完整 Event Sourcing、pending tool 自动 replay、把 God Object 一次性拆完。
+
+### 2026-08-13 — ApprovalBroker
+
+- 策略 `evaluate` 与异步 `ApprovalBroker` 拆开；`resolve_permission` 在 await 期间不持有 permission mutex。
+- ACP 注入 `AcpApprovalBroker`，去掉 `spawn` + `std::thread` 同步等待。
+- 未做：`RuntimeCommand::Approval` 唤醒 tool、`RuntimeEventKind::ApprovalRequested`、Cloud 共用同一 broker。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wave 13（PR #60）之后，审批仍把策略和用户交互绑在同步 `PermissionGate::check` 里。ACP 用 `spawn` + `std::thread` 等待 `session/request_permission`，并在持有 parking_lot mutex 期间阻塞。

本 PR 是 Wave 15 第一刀：把纯策略和异步审批拆开。

## 改动

- `PermissionGate::evaluate` 只返回 allow / deny / ask，不访问用户。
- `Ask` 走 `ApprovalBroker`；`resolve_permission` 在 await 期间不持有 permission mutex。
- 可注入 `AutoApprovalBroker` / `TerminalApprovalBroker`；ACP 使用 `AcpApprovalBroker`，直接 await reverse RPC。
- 无 broker 时仍回落到原来的同步 prompter，CLI 行为不变。

## 非目标

- 不把 `RuntimeCommand::Approval` 接到正在执行的 tool（runtime-owned waiter 是下一刀）
- 不改 Cloud 审批 DB / ACP JSON payload 形状
- 不把 Agent 收成纯 wiring

`cargo test -p zene-permission -p zene-core -p zene-cli` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

