### PR TITLE
feat: RuntimeCommand::Approval 唤醒 in-flight tool

### DIFF
--- a/apps/cli/src/acp/server.rs
+++ b/apps/cli/src/acp/server.rs
@@ -4,13 +4,12 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, bail, Context, Result};
-use async_trait::async_trait;
 use serde_json::{json, Value};
 use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, warn};
 use zene_config::ZeneConfig;
 use zene_core::{
-    Agent, ApprovalBroker, ApprovalRequest, AskUserOption, PermissionGate, PermissionMode,
+    Agent, ApprovalDecision, ApprovalRequest, AskUserOption, PermissionGate, PermissionMode,
     PromptChoice, RuntimeEvent, RuntimeEventKind, RuntimeHandle,
 };
 use zene_runtime::{RuntimeControl, RuntimeRecoveryInfo};
@@ -61,6 +60,7 @@ struct AcpSession {
     /// Last tool call id observed via runtime events (used by permission prompts).
     pending_tool: Arc<Mutex<PendingToolCall>>,
     prompt_queue: VecDeque<QueuedPrompt>,
+    permission_mode: String,
 }
 
 pub struct AcpServer {
@@ -532,7 +532,6 @@ impl AcpServer {
             session_id.to_string(),
             self.yolo,
             permission_mode,
-            Arc::clone(&pending_tool),
         );
         let (runtime, _task) = if automatic_recovery {
             RuntimeHandle::spawn_with_automatic_recovery(agent)
@@ -544,6 +543,7 @@ impl AcpServer {
             busy: false,
             pending_tool,
             prompt_queue: VecDeque::new(),
+            permission_mode: permission_mode.as_str().to_string(),
         })
     }
 
@@ -616,6 +616,7 @@ impl AcpServer {
         sess.busy = true;
         let runtime = sess.runtime.clone();
         let pending_tool = Arc::clone(&sess.pending_tool);
+        let permission_mode = sess.permission_mode.clone();
 
         let (tx, rx) = oneshot::channel();
         *active = Some(ActivePrompt {
@@ -625,7 +626,8 @@ impl AcpServer {
         });
 
         tokio::spawn(async move {
-            let result = run_prompt_job(runtime, writer, sid, text, pending_tool).await;
+            let result =
+                run_prompt_job(runtime, writer, sid, text, pending_tool, permission_mode).await;
             let _ = tx.send(result);
         });
         Ok(())
@@ -638,16 +640,10 @@ fn configure_agent_brokers(
     sid: String,
     yolo: bool,
     permission_mode: PermissionMode,
-    pending_tool: Arc<Mutex<PendingToolCall>>,
 ) {
     if !yolo {
         agent.set_permission_gate(PermissionGate::new(permission_mode));
-        agent.set_approval_broker(Arc::new(AcpApprovalBroker {
-            writer: writer.clone(),
-            session_id: sid.clone(),
-            permission_mode: permission_mode.as_str().to_string(),
-            pending_tool: Arc::clone(&pending_tool),
-        }));
+        agent.enable_runtime_approval_waiters();
     }
 
     let writer_ask = writer.clone();
@@ -656,42 +652,13 @@ fn configure_agent_brokers(
     }));
 }
 
-struct AcpApprovalBroker {
-    writer: AcpWriter,
-    session_id: String,
-    permission_mode: String,
-    pending_tool: Arc<Mutex<PendingToolCall>>,
-}
-
-#[async_trait]
-impl ApprovalBroker for AcpApprovalBroker {
-    async fn request(&self, request: ApprovalRequest) -> io::Result<PromptChoice> {
-        let tool_call_id = request.tool_call_id.clone().unwrap_or_else(|| {
-            self.pending_tool
-                .lock()
-                .unwrap()
-                .id
-                .clone()
-                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
-        });
-        acp_permission_prompt(
-            &self.writer,
-            &self.session_id,
-            &self.permission_mode,
-            &request.tool_name,
-            &request.preview(),
-            &tool_call_id,
-        )
-        .await
-    }
-}
-
 async fn run_prompt_job(
     runtime: Arc<dyn RuntimeControl>,
     writer: AcpWriter,
     sid: String,
     text: String,
     pending_tool: Arc<Mutex<PendingToolCall>>,
+    permission_mode: String,
 ) -> Result<Value> {
     let mut events = runtime.subscribe();
     let prompt_id = uuid::Uuid::new_v4().to_string();
@@ -714,13 +681,34 @@ async fn run_prompt_job(
             }
             event = events.recv() => {
                 match event {
-                    Ok(event) => project_runtime_event(
-                        &writer,
-                        &event,
-                        &sid,
-                        &prompt_id,
-                        &pending_tool,
-                    ),
+                    Ok(event) => {
+                        if let RuntimeEventKind::ApprovalRequested {
+                            request_id,
+                            tool_name,
+                            arguments,
+                            tool_call_id,
+                        } = &event.kind
+                        {
+                            tokio::spawn(handle_runtime_approval(
+                                Arc::clone(&runtime),
+                                writer.clone(),
+                                sid.clone(),
+                                permission_mode.clone(),
+                                Arc::clone(&pending_tool),
+                                request_id.clone(),
+                                tool_name.clone(),
+                                arguments.clone(),
+                                tool_call_id.clone(),
+                            ));
+                        }
+                        project_runtime_event(
+                            &writer,
+                            &event,
+                            &sid,
+                            &prompt_id,
+                            &pending_tool,
+                        );
+                    }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                         return Err(anyhow!("runtime event stream closed"));
@@ -728,6 +716,61 @@ async fn run_prompt_job(
                 }
             }
         }
+    }
+}
+
+async fn handle_runtime_approval(
+    runtime: Arc<dyn RuntimeControl>,
+    writer: AcpWriter,
+    session_id: String,
+    permission_mode: String,
+    pending_tool: Arc<Mutex<PendingToolCall>>,
+    request_id: String,
+    tool_name: String,
+    arguments: String,
+    tool_call_id: Option<String>,
+) {
+    let tool_call_id = tool_call_id.unwrap_or_else(|| {
+        pending_tool
+            .lock()
+            .unwrap()
+            .id
+            .clone()
+            .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
+    });
+    let preview = ApprovalRequest {
+        request_id: request_id.clone(),
+        tool_name: tool_name.clone(),
+        arguments,
+        tool_call_id: Some(tool_call_id.clone()),
+    }
+    .preview();
+    let decision = match acp_permission_prompt(
+        &writer,
+        &session_id,
+        &permission_mode,
+        &tool_name,
+        &preview,
+        &tool_call_id,
+    )
+    .await
+    {
+        Ok(choice) => approval_decision(choice),
+        Err(err) => {
+            warn!(error = %err, request_id = %request_id, "ACP permission prompt failed");
+            ApprovalDecision::Deny
+        }
+    };
+    if let Err(err) = runtime.approve(request_id, decision).await {
+        warn!(error = %err, "runtime approval resolve failed");
+    }
+}
+
+fn approval_decision(choice: PromptChoice) -> ApprovalDecision {
+    match choice {
+        PromptChoice::AllowOnce => ApprovalDecision::AllowOnce,
+        PromptChoice::AllowSession => ApprovalDecision::AllowSession,
+        PromptChoice::Deny => ApprovalDecision::Deny,
     }
 }
 
@@ -868,7 +911,9 @@ fn project_runtime_event(
         RuntimeEventKind::TurnStarted
         | RuntimeEventKind::StepStarted { .. }
         | RuntimeEventKind::TurnEnded { .. }
-        | RuntimeEventKind::SteerInput { .. } => None,
+        | RuntimeEventKind::SteerInput { .. }
+        | RuntimeEventKind::ApprovalRequested { .. }
+        | RuntimeEventKind::ApprovalResolved { .. } => None,
     };
     if let Some(mut update) = update {
         attach_meta(&mut update, meta);
@@ -1042,8 +1087,8 @@ async fn acp_permission_prompt(
     preview: &str,
     tool_call_id: &str,
 ) -> io::Result<PromptChoice> {
-    let raw_input = serde_json::from_str::<Value>(preview)
-        .unwrap_or_else(|_| json!({ "preview": preview }));
+    let raw_input =
+        serde_json::from_str::<Value>(preview).unwrap_or_else(|_| json!({ "preview": preview }));
     let result = writer
         .request(
             "session/request_permission",
@@ -1114,18 +1159,19 @@ mod recovery_tests {
     }
 
     #[test]
-    fn recovery_metadata_advertises_only_a_prompt_backed_safe_resume() {
-        let metadata = recovery_info_metadata(&RuntimeRecoveryInfo {
-            disposition: "safe_to_resume".into(),
-            has_incomplete_execution: true,
-            active_turn_count: 1,
-            active_tool_count: 0,
-            safe_resume_allowed: true,
-            automatic_resume: true,
-            reason: "only a model-boundary turn is open".into(),
-        });
-        assert_eq!(metadata["safeResumeAllowed"], true);
-        assert_eq!(metadata["automaticResume"], true);
+    fn approval_decision_maps_permission_choice() {
+        assert_eq!(
+            approval_decision(PromptChoice::AllowOnce),
+            ApprovalDecision::AllowOnce
+        );
+        assert_eq!(
+            approval_decision(PromptChoice::AllowSession),
+            ApprovalDecision::AllowSession
+        );
+        assert_eq!(
+            approval_decision(PromptChoice::Deny),
+            ApprovalDecision::Deny
+        );
     }
 }
 

--- a/crates/core/src/agent_builder.rs
+++ b/crates/core/src/agent_builder.rs
@@ -356,6 +356,7 @@ impl AgentBuilder {
             mcp,
             background: self.background.unwrap_or_else(shared_background_tasks),
             approval_broker: self.approval_broker,
+            runtime_approval_waiters: false,
         })
     }
 }

--- a/crates/core/src/agent_runtime.rs
+++ b/crates/core/src/agent_runtime.rs
@@ -4,10 +4,7 @@
 //! module owns the Agent-specific actor state and command handling.
 
 use std::collections::VecDeque;
-#[cfg(test)]
 use std::sync::Arc;
-#[cfg(test)]
-use zene_turn::TurnId;
 
 use anyhow::{anyhow, Result};
 use tokio::sync::{broadcast, oneshot, watch};
@@ -15,28 +12,15 @@ use tokio::task::{JoinError, JoinHandle};
 use tokio_util::sync::CancellationToken;
 
 use crate::{RecoveryDisposition, RecoverySnapshot};
-#[cfg(test)]
-use zene_permission::PromptChoice;
-#[cfg(test)]
-use zene_runtime::ApprovalDecision;
 use zene_runtime::{
-    ExecutionState, RuntimeCommand, RuntimeCommandMessage, RuntimeCommandReceiver,
-    RuntimeCommandRouter, RuntimeControl, RuntimeEventPublisher, RuntimeLifecycle,
-    RuntimeRecoveryInfo, RuntimeResponse,
+    ApprovalDecision, ApprovalWaiters, ExecutionState, RuntimeCommand, RuntimeCommandMessage,
+    RuntimeCommandReceiver, RuntimeCommandRouter, RuntimeControl, RuntimeEventPublisher,
+    RuntimeLifecycle, RuntimeRecoveryInfo, RuntimeResponse,
 };
 use zene_session::{AgentRecordWriter, ExecutionCheckpointState, RecoveryPlan};
 use zene_turn::{RuntimeEvent, SessionId, SteerBuffer};
 
 use crate::{Agent, PromptOptions};
-
-#[cfg(test)]
-fn prompt_choice(decision: ApprovalDecision) -> PromptChoice {
-    match decision {
-        ApprovalDecision::AllowOnce => PromptChoice::AllowOnce,
-        ApprovalDecision::AllowSession => PromptChoice::AllowSession,
-        ApprovalDecision::Deny => PromptChoice::Deny,
-    }
-}
 
 type RuntimeMessage = RuntimeCommandMessage;
 
@@ -151,6 +135,19 @@ impl RuntimeHandle {
         self.command(RuntimeCommand::Shutdown).await.map(|_| ())
     }
 
+    pub async fn approve(
+        &self,
+        request_id: impl Into<String>,
+        decision: ApprovalDecision,
+    ) -> Result<()> {
+        self.command(RuntimeCommand::Approval {
+            request_id: request_id.into(),
+            decision,
+        })
+        .await
+        .map(|_| ())
+    }
+
     /// Subscribe to the ordered runtime event stream.
     pub fn subscribe(&self) -> broadcast::Receiver<RuntimeEvent> {
         self.router.subscribe()
@@ -177,10 +174,7 @@ impl RuntimeHandle {
     }
 }
 
-fn terminal_lifecycle(
-    cancelled: bool,
-    result: &Result<String>,
-) -> RuntimeLifecycle {
+fn terminal_lifecycle(cancelled: bool, result: &Result<String>) -> RuntimeLifecycle {
     match result {
         Ok(_) if !cancelled => RuntimeLifecycle::Completed,
         Ok(_) | Err(_) if cancelled => RuntimeLifecycle::Cancelled,
@@ -234,6 +228,10 @@ impl RuntimeControl for RuntimeHandle {
         RuntimeHandle::shutdown(self).await
     }
 
+    async fn approve(&self, request_id: String, decision: ApprovalDecision) -> Result<()> {
+        RuntimeHandle::approve(self, request_id, decision).await
+    }
+
     fn subscribe(&self) -> broadcast::Receiver<RuntimeEvent> {
         RuntimeHandle::subscribe(self)
     }
@@ -262,6 +260,7 @@ struct ActivePrompt {
     cancel: CancellationToken,
     reply: oneshot::Sender<std::result::Result<RuntimeResponse, String>>,
     task: JoinHandle<(Agent, Result<String>)>,
+    waiters: Arc<ApprovalWaiters>,
 }
 
 enum ActivePoll {
@@ -403,15 +402,13 @@ async fn run_actor(
                 }
             }
             ActivePoll::Command(Some(message)) => {
+                let current = active.as_ref().expect("active prompt exists");
                 handle_active_command(
                     message,
                     &mut queued,
                     &steer_buffer,
-                    active
-                        .as_ref()
-                        .expect("active prompt exists")
-                        .cancel
-                        .clone(),
+                    current.cancel.clone(),
+                    &current.waiters,
                     &mut shutdown_requested,
                 );
             }
@@ -426,12 +423,19 @@ async fn run_actor(
 }
 
 fn start_prompt(
-    agent: Agent,
+    mut agent: Agent,
     prompt: PendingPrompt,
     publisher: &RuntimeEventPublisher,
 ) -> ActivePrompt {
     publisher.set_state(ExecutionState::Starting);
     let event_handler = publisher.handler();
+    let waiters = Arc::new(ApprovalWaiters::new());
+    if agent.runtime_approval_waiters() {
+        agent.set_approval_broker(Arc::new(crate::approval::RuntimeOwnedBroker::new(
+            Arc::clone(&waiters),
+            publisher.clone(),
+        )));
+    }
     let cancel = CancellationToken::new();
     let task_cancel = cancel.clone();
     let task = tokio::spawn(async move {
@@ -454,6 +458,7 @@ fn start_prompt(
         cancel,
         reply: prompt.reply,
         task,
+        waiters,
     }
 }
 
@@ -564,11 +569,9 @@ fn handle_idle_command(
             }
         },
         RuntimeCommand::Approval { request_id, .. } => {
-            publisher.set_state(ExecutionState::AwaitingApproval { request_id });
             let _ = message
                 .reply
-                .send(Err("no approval request is pending".into()));
-            publisher.set_state(ExecutionState::Idle);
+                .send(Err(format!("no approval request {request_id} is pending")));
             None
         }
         RuntimeCommand::GetMode => {
@@ -593,6 +596,7 @@ fn handle_active_command(
     queued: &mut VecDeque<PendingPrompt>,
     steer_buffer: &std::sync::Arc<parking_lot::Mutex<SteerBuffer>>,
     cancel: CancellationToken,
+    waiters: &ApprovalWaiters,
     shutdown_requested: &mut bool,
 ) {
     match message.command {
@@ -623,6 +627,7 @@ fn handle_active_command(
             }
         }
         RuntimeCommand::Cancel => {
+            waiters.cancel_all();
             cancel.cancel();
             let _ = message.reply.send(Ok(RuntimeResponse::Accepted));
         }
@@ -631,13 +636,20 @@ fn handle_active_command(
                 "cannot change or read mode while a turn is active".into()
             ));
         }
-        RuntimeCommand::Approval { request_id, .. } => {
-            let _ = message.reply.send(Err(format!(
-                "approval request {request_id} cannot be handled by this runtime"
-            )));
-        }
+        RuntimeCommand::Approval {
+            request_id,
+            decision,
+        } => match waiters.resolve(&request_id, decision) {
+            Ok(()) => {
+                let _ = message.reply.send(Ok(RuntimeResponse::Accepted));
+            }
+            Err(err) => {
+                let _ = message.reply.send(Err(err.to_string()));
+            }
+        },
         RuntimeCommand::Shutdown => {
             *shutdown_requested = true;
+            waiters.cancel_all();
             cancel.cancel();
             let _ = message.reply.send(Ok(RuntimeResponse::Accepted));
         }
@@ -651,6 +663,8 @@ fn publish_state_event(publisher: &RuntimeEventPublisher, state: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zene_permission::PromptChoice;
+    use zene_turn::TurnId;
 
     #[test]
     fn recovery_disposition_names_are_protocol_stable() {
@@ -681,14 +695,17 @@ mod tests {
     #[test]
     fn approval_decisions_map_to_permission_choices() {
         assert_eq!(
-            prompt_choice(ApprovalDecision::AllowOnce),
+            crate::approval::prompt_choice(ApprovalDecision::AllowOnce),
             PromptChoice::AllowOnce
         );
         assert_eq!(
-            prompt_choice(ApprovalDecision::AllowSession),
+            crate::approval::prompt_choice(ApprovalDecision::AllowSession),
             PromptChoice::AllowSession
         );
-        assert_eq!(prompt_choice(ApprovalDecision::Deny), PromptChoice::Deny);
+        assert_eq!(
+            crate::approval::prompt_choice(ApprovalDecision::Deny),
+            PromptChoice::Deny
+        );
     }
 
     #[test]
@@ -784,7 +801,9 @@ mod tests {
         use tempfile::tempdir;
         use zene_config::ZeneConfig;
         use zene_sandbox::LocalSandbox;
-        use zene_session::{AgentRecordWriter, ExecutionCheckpointState, RecordEntry, SessionRecord};
+        use zene_session::{
+            AgentRecordWriter, ExecutionCheckpointState, RecordEntry, SessionRecord,
+        };
 
         let workdir = tempdir().expect("workdir");
         let record_dir = tempdir().expect("record dir");
@@ -841,6 +860,8 @@ mod tests {
         let cancel_for_assertion = cancel.clone();
         let mut queued = VecDeque::new();
         let steer = Arc::new(parking_lot::Mutex::new(SteerBuffer::default()));
+        let waiters = ApprovalWaiters::new();
+        let pending = waiters.register("req-1".into());
 
         handle_active_command(
             RuntimeMessage {
@@ -850,6 +871,7 @@ mod tests {
             &mut queued,
             &steer,
             cancel,
+            &waiters,
             &mut false,
         );
 
@@ -859,6 +881,8 @@ mod tests {
             Ok(RuntimeResponse::Accepted)
         ));
         assert!(queued.is_empty());
+        assert!(pending.await.is_err());
+        assert!(waiters.is_empty());
     }
 
     #[tokio::test]
@@ -879,6 +903,7 @@ mod tests {
                 &mut queued,
                 &steer,
                 cancel,
+                &ApprovalWaiters::new(),
                 &mut false,
             );
 
@@ -904,6 +929,7 @@ mod tests {
             &mut queued,
             &steer,
             cancel.clone(),
+            &ApprovalWaiters::new(),
             &mut false,
         );
         assert!(matches!(
@@ -921,6 +947,7 @@ mod tests {
             &mut queued,
             &steer,
             cancel,
+            &ApprovalWaiters::new(),
             &mut false,
         );
         assert!(response.await.unwrap().unwrap_err().contains("empty"));
@@ -941,6 +968,7 @@ mod tests {
             &mut queued,
             &steer,
             cancel.clone(),
+            &ApprovalWaiters::new(),
             &mut false,
         );
         assert!(response.await.unwrap().unwrap_err().contains("empty"));
@@ -957,10 +985,62 @@ mod tests {
             &mut queued,
             &steer,
             cancel,
+            &ApprovalWaiters::new(),
             &mut false,
         );
         assert_eq!(queued.len(), 1);
         assert_eq!(queued.front().unwrap().text, "next");
     }
 
+    #[tokio::test]
+    async fn active_approval_resolves_registered_waiter() {
+        let waiters = ApprovalWaiters::new();
+        let rx = waiters.register("req-1".into());
+        let (reply, response) = oneshot::channel();
+        handle_active_command(
+            RuntimeMessage {
+                command: RuntimeCommand::Approval {
+                    request_id: "req-1".into(),
+                    decision: ApprovalDecision::AllowOnce,
+                },
+                reply,
+            },
+            &mut VecDeque::new(),
+            &Arc::new(parking_lot::Mutex::new(SteerBuffer::default())),
+            CancellationToken::new(),
+            &waiters,
+            &mut false,
+        );
+        assert!(matches!(
+            response.await.unwrap(),
+            Ok(RuntimeResponse::Accepted)
+        ));
+        assert_eq!(rx.await.unwrap(), ApprovalDecision::AllowOnce);
+        assert!(waiters.is_empty());
+    }
+
+    #[tokio::test]
+    async fn active_approval_unknown_request_is_rejected() {
+        let waiters = ApprovalWaiters::new();
+        let (reply, response) = oneshot::channel();
+        handle_active_command(
+            RuntimeMessage {
+                command: RuntimeCommand::Approval {
+                    request_id: "missing".into(),
+                    decision: ApprovalDecision::Deny,
+                },
+                reply,
+            },
+            &mut VecDeque::new(),
+            &Arc::new(parking_lot::Mutex::new(SteerBuffer::default())),
+            CancellationToken::new(),
+            &waiters,
+            &mut false,
+        );
+        assert!(response
+            .await
+            .unwrap()
+            .unwrap_err()
+            .contains("no approval request missing is pending"));
+    }
 }

--- a/crates/core/src/approval.rs
+++ b/crates/core/src/approval.rs
@@ -1,0 +1,88 @@
+//! Runtime-owned approval broker. Transports send `RuntimeCommand::Approval`;
+//! this waiter does not know ACP or Cloud HTTP.
+
+use std::io;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use zene_permission::{ApprovalBroker, ApprovalRequest, PromptChoice};
+use zene_runtime::{ApprovalDecision, ApprovalWaiters, RuntimeEventPublisher};
+use zene_turn::RuntimeEventKind;
+
+pub fn prompt_choice(decision: ApprovalDecision) -> PromptChoice {
+    match decision {
+        ApprovalDecision::AllowOnce => PromptChoice::AllowOnce,
+        ApprovalDecision::AllowSession => PromptChoice::AllowSession,
+        ApprovalDecision::Deny => PromptChoice::Deny,
+    }
+}
+
+pub struct RuntimeOwnedBroker {
+    waiters: Arc<ApprovalWaiters>,
+    publisher: RuntimeEventPublisher,
+}
+
+impl RuntimeOwnedBroker {
+    pub fn new(waiters: Arc<ApprovalWaiters>, publisher: RuntimeEventPublisher) -> Self {
+        Self { waiters, publisher }
+    }
+}
+
+#[async_trait]
+impl ApprovalBroker for RuntimeOwnedBroker {
+    async fn request(&self, request: ApprovalRequest) -> io::Result<PromptChoice> {
+        let request_id = request.request_id.clone();
+        let rx = self.waiters.register(request_id.clone());
+        self.publisher
+            .publish_kind(RuntimeEventKind::ApprovalRequested {
+                request_id: request_id.clone(),
+                tool_name: request.tool_name,
+                arguments: request.arguments,
+                tool_call_id: request.tool_call_id,
+            });
+        match rx.await {
+            Ok(decision) => {
+                self.publisher
+                    .publish_kind(RuntimeEventKind::ApprovalResolved {
+                        request_id,
+                        allowed: decision.allowed(),
+                    });
+                Ok(prompt_choice(decision))
+            }
+            Err(_) => Err(io::Error::other("approval waiter dropped")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::{broadcast, watch};
+    use zene_runtime::ExecutionState;
+    use zene_turn::SessionId;
+
+    #[tokio::test]
+    async fn broker_waits_until_runtime_resolves_approval() {
+        let waiters = Arc::new(ApprovalWaiters::new());
+        let (events, _) = broadcast::channel(8);
+        let (state, _) = watch::channel(ExecutionState::Idle);
+        let publisher =
+            RuntimeEventPublisher::new(events, state, SessionId::from_string("session"));
+        let broker = RuntimeOwnedBroker::new(Arc::clone(&waiters), publisher);
+        let pending = tokio::spawn(async move {
+            broker
+                .request(ApprovalRequest {
+                    request_id: "req-1".into(),
+                    tool_name: "Bash".into(),
+                    arguments: r#"{"command":"ls"}"#.into(),
+                    tool_call_id: Some("call-1".into()),
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+        waiters
+            .resolve("req-1", ApprovalDecision::AllowSession)
+            .unwrap();
+        assert_eq!(pending.await.unwrap().unwrap(), PromptChoice::AllowSession);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -26,6 +26,7 @@ use zene_tools::{
 mod agent_builder;
 mod agent_runtime;
 mod agent_turn;
+mod approval;
 mod context_config;
 pub use zene_model_executor as model_executor;
 mod context_events;
@@ -125,6 +126,7 @@ pub struct Agent {
     mcp: Option<McpManager>,
     background: SharedBackgroundTasks,
     approval_broker: Option<zene_permission::SharedApprovalBroker>,
+    runtime_approval_waiters: bool,
 }
 
 pub struct PromptOptions {
@@ -632,6 +634,18 @@ impl Agent {
     /// Inject the async approval waiter used when policy returns `Ask`.
     pub fn set_approval_broker(&mut self, broker: zene_permission::SharedApprovalBroker) {
         self.approval_broker = Some(broker);
+    }
+
+    /// Ask the runtime actor to own approval waiters for this session.
+    ///
+    /// Transports then send [`zene_runtime::RuntimeCommand::Approval`] instead
+    /// of injecting an ACP/Cloud-specific broker.
+    pub fn enable_runtime_approval_waiters(&mut self) {
+        self.runtime_approval_waiters = true;
+    }
+
+    pub(crate) fn runtime_approval_waiters(&self) -> bool {
+        self.runtime_approval_waiters
     }
 
     /// Replace the AskUserQuestion prompter (e.g. TUI modal).

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
-    Arc,
+    Arc, Mutex,
 };
 
 use anyhow::{anyhow, Result};
@@ -36,6 +37,59 @@ pub enum ApprovalDecision {
     AllowOnce,
     AllowSession,
     Deny,
+}
+
+impl ApprovalDecision {
+    pub fn allowed(self) -> bool {
+        !matches!(self, Self::Deny)
+    }
+}
+
+/// Oneshot registry for in-flight tool approvals.
+///
+/// The turn task waits here; the actor resolves entries when a transport
+/// sends [`RuntimeCommand::Approval`].
+#[derive(Default)]
+pub struct ApprovalWaiters {
+    inner: Mutex<HashMap<String, oneshot::Sender<ApprovalDecision>>>,
+}
+
+impl ApprovalWaiters {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&self, request_id: String) -> oneshot::Receiver<ApprovalDecision> {
+        let (tx, rx) = oneshot::channel();
+        self.inner
+            .lock()
+            .expect("approval waiters")
+            .insert(request_id, tx);
+        rx
+    }
+
+    pub fn resolve(&self, request_id: &str, decision: ApprovalDecision) -> Result<()> {
+        match self
+            .inner
+            .lock()
+            .expect("approval waiters")
+            .remove(request_id)
+        {
+            Some(tx) => {
+                let _ = tx.send(decision);
+                Ok(())
+            }
+            None => Err(anyhow!("no approval request {request_id} is pending")),
+        }
+    }
+
+    pub fn cancel_all(&self) {
+        self.inner.lock().expect("approval waiters").clear();
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().expect("approval waiters").is_empty()
+    }
 }
 
 /// Runtime execution state, independent from Cloud Run state.
@@ -113,6 +167,7 @@ pub trait RuntimeControl: Send + Sync {
     async fn set_mode(&self, mode_id: String) -> Result<String>;
     async fn current_mode(&self) -> Result<String>;
     async fn shutdown(&self) -> Result<()>;
+    async fn approve(&self, request_id: String, decision: ApprovalDecision) -> Result<()>;
     fn subscribe(&self) -> tokio::sync::broadcast::Receiver<RuntimeEvent>;
     fn recovery_info(&self) -> Result<RuntimeRecoveryInfo>;
 }
@@ -266,10 +321,33 @@ impl RuntimeEventPublisher {
                         });
                     }
                 }
+                RuntimeEventKind::ApprovalRequested { request_id, .. } => {
+                    let _ = publisher.state.send(ExecutionState::AwaitingApproval {
+                        request_id: request_id.clone(),
+                    });
+                }
                 _ => {}
             }
             let _ = publisher.events.send(event);
         })
+    }
+
+    pub fn publish_kind(&self, kind: RuntimeEventKind) {
+        let event = RuntimeEvent {
+            sequence: zene_turn::EventSequence::new(
+                self.sequence.fetch_add(1, Ordering::Relaxed) + 1,
+            ),
+            session_id: self.session_id.clone(),
+            turn_id: None,
+            step_id: None,
+            kind,
+        };
+        if let RuntimeEventKind::ApprovalRequested { request_id, .. } = &event.kind {
+            self.set_state(ExecutionState::AwaitingApproval {
+                request_id: request_id.clone(),
+            });
+        }
+        let _ = self.events.send(event);
     }
 }
 
@@ -433,7 +511,12 @@ mod tests {
                 .unwrap();
         });
         let response = router.command(RuntimeCommand::GetMode).await.unwrap();
-        assert_eq!(response, RuntimeResponse::Mode { mode_id: "default".into() });
+        assert_eq!(
+            response,
+            RuntimeResponse::Mode {
+                mode_id: "default".into()
+            }
+        );
         task.await.unwrap();
     }
 
@@ -488,11 +571,8 @@ mod tests {
     async fn event_publisher_mirrors_terminal_state_before_event() {
         let (events, mut receiver) = broadcast::channel(4);
         let (state, state_receiver) = watch::channel(ExecutionState::Idle);
-        let publisher = RuntimeEventPublisher::new(
-            events,
-            state,
-            SessionId::from_string("runtime-session"),
-        );
+        let publisher =
+            RuntimeEventPublisher::new(events, state, SessionId::from_string("runtime-session"));
 
         let handler = publisher.handler();
         handler(RuntimeEvent {
@@ -529,11 +609,8 @@ mod tests {
         let (events, _receiver) = broadcast::channel(4);
         let (state, state_receiver) = watch::channel(ExecutionState::Idle);
         let turn_id = TurnId::new();
-        let publisher = RuntimeEventPublisher::new(
-            events,
-            state,
-            SessionId::from_string("runtime-session"),
-        );
+        let publisher =
+            RuntimeEventPublisher::new(events, state, SessionId::from_string("runtime-session"));
         let handler = publisher.handler();
         handler(RuntimeEvent {
             sequence: zene_turn::EventSequence::new(0),
@@ -577,5 +654,25 @@ mod tests {
         assert_eq!(*runtime.state().borrow(), DriverState::Idle);
         runtime.command(DriverCommand::Shutdown).await.unwrap();
         task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn approval_waiters_resolve_registered_request() {
+        let waiters = ApprovalWaiters::new();
+        let rx = waiters.register("req-1".into());
+        waiters
+            .resolve("req-1", ApprovalDecision::AllowOnce)
+            .unwrap();
+        assert_eq!(rx.await.unwrap(), ApprovalDecision::AllowOnce);
+        assert!(waiters.is_empty());
+    }
+
+    #[tokio::test]
+    async fn approval_waiters_cancel_drops_receivers() {
+        let waiters = ApprovalWaiters::new();
+        let rx = waiters.register("req-2".into());
+        waiters.cancel_all();
+        assert!(rx.await.is_err());
+        assert!(waiters.resolve("req-2", ApprovalDecision::Deny).is_err());
     }
 }

--- a/crates/turn/src/events.rs
+++ b/crates/turn/src/events.rs
@@ -110,6 +110,16 @@ pub enum RuntimeEventKind {
     StateChanged {
         state: String,
     },
+    ApprovalRequested {
+        request_id: String,
+        tool_name: String,
+        arguments: String,
+        tool_call_id: Option<String>,
+    },
+    ApprovalResolved {
+        request_id: String,
+        allowed: bool,
+    },
 }
 
 pub type RuntimeEventHandler = Arc<dyn Fn(RuntimeEvent) + Send + Sync>;

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `39257dc`（PR #60 已合并）。**
+> **进度快照：2026-08-13，基线 `b443970`（PR #61 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 13 已让默认 Turn 路径消费 `PreparedContext`。当前工作是 Wave 15：把策略判定和异步 `ApprovalBroker` 拆开。
+> Wave 13 已让默认 Turn 路径消费 `PreparedContext`。Wave 15 策略/broker 已拆开；本轮收口 runtime-owned approval waiter。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -32,7 +32,7 @@
 3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。本地 `zene-runtime::RuntimeCommand` 与 Cloud `RuntimeCommand` 是两套类型；Cloud `RuntimeNotification.payload` 仍携带原始 ACP JSON。
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者，但 Agent-specific actor 仍在 `zene-core`，ACP 仍保留 transport 层 session bookkeeping。
-6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`；ACP 通过 broker 等待客户端，不再用同步 prompter 卡线程。Runtime-owned approval waiter（`RuntimeCommand::Approval` 唤醒）仍待下一刀。
+6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `RuntimeEventKind::ApprovalRequested`，再发 `RuntimeCommand::Approval` 唤醒 in-flight tool；不再注入 ACP 专用 broker。Cloud 共用同一 command 仍待 Wave 16。
 7. `ToolRegistry` 仍同时承担目录与执行；`RuntimeScope` 尚未成为 Subagent 的正式差异注入面。
 
 本文目标不是立刻重写 runtime，而是建立一个可以渐进落地的目标架构：
@@ -100,7 +100,7 @@ RuntimeHandle → Agent → TurnEngine
 | Tool 并发 | `crates/core/src/tool_scheduler.rs` | 同一模型 step 内进行冲突感知并发 |
 | Session | `crates/session` | `SessionRecord` + `SessionStore`；events 优先，messages 为 materialized cache |
 | Context | `crates/context` | observe/commit/project；`SessionView` 驱动 event-backed projection |
-| Permission | `crates/permission` | `evaluate` 纯判定；`Ask` 走 `ApprovalBroker`。ACP 注入 `AcpApprovalBroker` |
+| Permission | `crates/permission` | `evaluate` 纯判定；`Ask` 走 `ApprovalBroker`。Runtime 挂 waiter，transport 发 `RuntimeCommand::Approval` |
 | Subagent | `crates/core/src/subagent.rs` | 直接实现 `TurnEnginePorts`；仍用独立 `ChatBackend` 和内存消息，尚未 `RuntimeScope` |
 | Runtime | `crates/runtime` + `crates/core/src/agent_runtime.rs` | 公共 command/event 在 `zene-runtime`；Agent actor 仍在 core |
 | ACP | `apps/cli/src/acp/server.rs` | transport adapter；创建/加载 session，并把请求接入 `RuntimeHandle` |
@@ -449,9 +449,10 @@ pub trait ApprovalBroker: Send + Sync {
 
 - `TerminalApprovalBroker`；
 - `TuiApprovalBroker`；
-- `AcpApprovalBroker`；
-- `CloudApprovalBroker`；
+- `RuntimeOwnedBroker`（actor 持有 waiter，transport 发 `RuntimeCommand::Approval`）；
 - 测试用 `AutoApprovalBroker`。
+
+ACP 不再注入专用 broker：它监听 `ApprovalRequested`，把 `session/request_permission` 的结果转成 `RuntimeCommand::Approval`。Cloud 应走同一条 command，而不是另写 `CloudApprovalBroker`。
 
 Core runtime 不应知道 Cloud approval database、Web UI 或 HTTP API。
 
@@ -950,7 +951,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 1. **Turn ports 已是真入口（Wave 13，PR #60）**：`AgentTurnPorts.prepare_context` 产出 `PreparedContext`，`run_model` 只消费它；Subagent 直接实现 `TurnEnginePorts`。
 2. **`Agent` 仍是 God Object**：它同时持有 model、tools、sandbox、permission、hooks、MCP、todos、plan mode。下一步是把它变成 wiring，而不是继续实现 step。
 3. **模型抽象仍偏 provider**：`ModelExecutor` 吃 `ChatRequest`；Subagent 另有 `ChatBackend`。目标是 Turn 只看见 `PreparedContext` → `ModelRequest`。
-4. **审批 port 已建立（Wave 15，本轮）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。ACP 不再把 reverse RPC 塞进同步 prompter。仍缺 runtime-owned waiter：`RuntimeCommand::Approval` 尚未唤醒正在执行的 tool。
+4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。Cloud 尚未共用这条 command。
 5. **Cloud 仍消费 transport 形状**：`zene-cloud-runtime-client` 藏起了 ACP method，但 `payload` 仍是原始 JSON；本地与 Cloud 的 `RuntimeCommand` 不是同一类型。JobRunner 应对齐 Core 的 command/event，而不是再包一层 ACP。
 6. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
@@ -1024,7 +1025,7 @@ Wave 11  ModelExecutor 与 Runtime crate 边界
 Wave 12  Execution resume 与 Cloud RuntimeClient
          safe resume、approval/tool inspection、JobRunner/RuntimeClient 解耦
 
-Wave 13  默认路径真正走 ports          ← 当前工作
+Wave 13  默认路径真正走 ports
          AgentTurnPorts.prepare_context 产出 PreparedContext
          run_model 只消费该上下文
          Subagent 直接实现 TurnEnginePorts
@@ -1037,9 +1038,9 @@ Wave 14  RuntimeScope 与能力注入
 
 Wave 15  ApprovalBroker
          PermissionService（纯判定）与异步 ApprovalBroker 拆开
-         ACP / Cloud / 测试 fake 各写一个 broker
+         Runtime-owned waiter：Approval command 唤醒 in-flight tool
 
-Wave 16  统一 transport command/event
+Wave 16  统一 transport command/event  ← 下一步
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
          Cloud payload 不再以 ACP JSON 为产品语义
 ```
@@ -1063,15 +1064,15 @@ Wave 16  统一 transport command/event
 | Wave 12 | 已完成第一阶段 | safe resume、Cloud RuntimeClient、neutral runtime notifications、fenced command lease/ack、atomic state/event writes、outbox replay 和真实 replacement 测试已落地 |
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
-| Wave 15 | 进行中 | `evaluate` + `ApprovalBroker` 已落地；runtime-owned waiter 仍待完成 |
+| Wave 15 | 已完成（本地/ACP） | `evaluate` + `ApprovalBroker` + runtime-owned waiter；Cloud 共用 `RuntimeCommand::Approval` 仍待 Wave 16 |
 | Wave 16 | 未开始 | 统一本地/Cloud command/event 语义 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮正在做的执行路径收口**：让默认 Agent/Subagent 真正走 `prepare_context → run_model(PreparedContext)`；禁止再用空 context + `Agent::run_step` 伪装 ports 完成。
-- **可继续做但需要协议的产品面解耦**：`ApprovalBroker`、本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
+- **本轮已完成的审批收口**：runtime-owned waiter 让 `RuntimeCommand::Approval` 唤醒 in-flight tool；ACP 只做事件适配。
+- **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
 本轮已落地的 durability 收口包括：
@@ -1156,11 +1157,12 @@ Wave 16  统一 transport command/event
    - `AgentBuilder.model_executor` 允许注入 fake executor，便于不经过真实 provider 测试 runtime。
    - `LegacyTurnPorts` / `run_turn_loop` 保留给旧 `TurnRuntime` 实现。
 
-6. **Wave 15：ApprovalBroker（进行中）**
+6. **Wave 15：ApprovalBroker（本地/ACP 已完成）**
    - `PermissionGate::evaluate` 纯 allow/deny/ask；`Ask` 才进入 broker。
    - `resolve_permission` 在 await 期间不持有 permission mutex。
-   - `AutoApprovalBroker` / `TerminalApprovalBroker` 可注入；ACP 使用 `AcpApprovalBroker`，不再 `std::thread` 阻塞等待。
-   - 未做：runtime-owned waiter 与 `RuntimeCommand::Approval` 打通。
+   - `AutoApprovalBroker` / `TerminalApprovalBroker` 可注入；runtime 默认挂 `RuntimeOwnedBroker`。
+   - ACP 监听 `ApprovalRequested`，`session/request_permission` 结束后发 `RuntimeCommand::Approval`。
+   - 未做：Cloud 走同一条 Approval command（Wave 16）。
 
 7. **持续质量门槛**
    - 每个 wave 保持 `cargo test --workspace --locked`；
@@ -1185,11 +1187,11 @@ Wave 16  统一 transport command/event
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 15 waiter** | broker 已在，但 Approval command 还不能唤醒 tool |
+| 当前最大杠杆 | **Wave 16** | 本地已用 `RuntimeCommand::Approval`；Cloud 仍是另一套 command/event |
 | 产品面灵活度 | Wave 16 | 两套 RuntimeCommand 会让 CLI/Cloud 行为分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**Wave 15 收口 runtime-owned waiter**，再 **Wave 16 统一事件**，最后才用 Wave 14 把 `Agent` 收成 wiring。不要先搬 runtime crate。
+推荐组合：**Wave 16 统一事件**，最后才用 Wave 14 把 `Agent` 收成 wiring。不要先搬 runtime crate。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1242,4 +1244,12 @@ Wave 16  统一 transport command/event
 - 策略 `evaluate` 与异步 `ApprovalBroker` 拆开；`resolve_permission` 在 await 期间不持有 permission mutex。
 - ACP 注入 `AcpApprovalBroker`，去掉 `spawn` + `std::thread` 同步等待。
 - 未做：`RuntimeCommand::Approval` 唤醒 tool、`RuntimeEventKind::ApprovalRequested`、Cloud 共用同一 broker。
+
+### 2026-08-13 — runtime-owned approval waiter
+
+- `ApprovalWaiters` 挂在 runtime actor 上；`RuntimeOwnedBroker` 发 `ApprovalRequested` 并等待 oneshot。
+- `RuntimeCommand::Approval` 在 active turn 中 `resolve` waiter；Cancel/Shutdown 会 `cancel_all`。
+- ACP 不再注入 `AcpApprovalBroker`：事件循环看到 `ApprovalRequested` 后发 `session/request_permission`，再 `runtime.approve`。
+- CLI 未开 waiter 时仍走旧同步 prompter。Cloud 共用同一 command 仍待 Wave 16。
+- 未做：pending tool 自动 replay、把 Agent actor 搬出 core、完整 Event Sourcing。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #61 把策略和 `ApprovalBroker` 拆开了，但 Ask 仍由 ACP 自己的 broker await reverse RPC，`RuntimeCommand::Approval` 还唤醒不了正在执行的 tool。

本 PR 是 Wave 15 第二刀：runtime 持有 waiter。

Turn 在 `Ask` 时通过 `RuntimeOwnedBroker` 注册 oneshot，并发 `RuntimeEventKind::ApprovalRequested`。Actor 收到 `RuntimeCommand::Approval` 后 resolve waiter。ACP 不再注入 `AcpApprovalBroker`：事件循环看到 `ApprovalRequested` 后发 `session/request_permission`，再 `runtime.approve`。未开 waiter 的 CLI 仍走旧同步 prompter。

不自动 replay pending tool。不统一 Cloud 的 `RuntimeCommand`（Wave 16）。不把 Agent actor 搬出 core。

`cargo test --workspace --locked` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

