### PR TITLE
feat: Cloud 时间线 payload 使用产品字段

### DIFF
--- a/cloud/apps/web/lib/runtimeEvent.ts
+++ b/cloud/apps/web/lib/runtimeEvent.ts
@@ -17,15 +17,44 @@ export function eventKind(event: Pick<RunEvent, "eventType" | "event_type">): st
 /**
  * Resolve the ACP-shaped update used to render a timeline item.
  *
- * Classified kinds (`text_delta`, …) dispatch from `eventType` even if the
- * stored payload still says `sessionUpdate: "agent_message_chunk"`. Legacy
- * `acp` / `runtime` events keep reading `payload.params.update.sessionUpdate`.
+ * New timeline kinds store a denormalized product payload (`text`,
+ * `toolCallId`, …). Records that still have `params.update` (legacy `acp` /
+ * `runtime`, and classified events from before payload denormalization) keep
+ * that path. Classified kinds overwrite `sessionUpdate`.
  */
 export function timelineUpdateFromEvent(event: RunEvent): AcpSessionUpdate | undefined {
-  const update = event.payload?.params?.update;
-  if (!update) return undefined;
   const kind = eventKind(event);
   const mapped = TIMELINE_KIND_TO_SESSION_UPDATE[kind as TimelineEventKind];
-  if (!mapped) return update;
-  return { ...update, sessionUpdate: mapped };
+  const legacy = event.payload?.params?.update;
+  if (legacy) {
+    if (!mapped) return legacy;
+    return { ...legacy, sessionUpdate: mapped };
+  }
+  if (!mapped || !event.payload) return undefined;
+  return productToSessionUpdate(mapped, event.payload);
+}
+
+function productToSessionUpdate(
+  sessionUpdate: (typeof TIMELINE_KIND_TO_SESSION_UPDATE)[TimelineEventKind],
+  payload: NonNullable<RunEvent["payload"]>,
+): AcpSessionUpdate {
+  const text = typeof payload.text === "string" ? payload.text : undefined;
+  const update: AcpSessionUpdate = {
+    sessionUpdate,
+    toolCallId: payload.toolCallId,
+    title: payload.title,
+    toolName: payload.toolName,
+    kind: payload.kind,
+    status: payload.status,
+    rawInput: payload.rawInput,
+    rawOutput: payload.rawOutput,
+  };
+  if (payload.rawOutput == null && (text != null || payload.isError != null)) {
+    update.rawOutput = { text, isError: payload.isError };
+  }
+  if (text != null) {
+    update.content =
+      sessionUpdate === "tool_call_update" ? [{ content: { text }, text }] : { text };
+  }
+  return update;
 }

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -91,6 +91,12 @@ export interface RunEvent {
     role?: string;
     text?: string;
     title?: string;
+    toolCallId?: string;
+    toolName?: string;
+    kind?: string;
+    rawInput?: unknown;
+    rawOutput?: { text?: string; isError?: boolean };
+    isError?: boolean;
     params?: {
       update?: AcpSessionUpdate;
     };

--- a/cloud/crates/runtime-client/src/lib.rs
+++ b/cloud/crates/runtime-client/src/lib.rs
@@ -121,8 +121,10 @@ pub enum RuntimeCommand {
 
 /// A runtime notification with the stable fields persisted by the worker.
 ///
-/// `event_type` is the product kind. `payload` remains the original ACP JSON so
-/// existing event records and the Console can replay without a migration.
+/// `event_type` is the product kind. Timeline kinds (`text_delta`,
+/// `thought_delta`, `tool_call`, `tool_result`) store a denormalized product
+/// payload. Other frames keep the original ACP JSON. Records written before
+/// this change still have ACP JSON; Console falls back to `params.update`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeNotification {
     pub source_event_id: String,
@@ -185,8 +187,95 @@ fn runtime_notification(event: AcpEvent) -> RuntimeNotification {
         source_event_id: event.source_event_id,
         cursor: event.cursor,
         event_type: kind.as_event_type().into(),
-        payload: event.payload,
+        payload: product_payload(kind, &event.payload),
     }
+}
+
+fn product_payload(kind: RuntimeEventKind, raw: &Value) -> Value {
+    let Some(update) = raw.pointer("/params/update") else {
+        return raw.clone();
+    };
+    match kind {
+        RuntimeEventKind::TextDelta | RuntimeEventKind::ThoughtDelta => {
+            serde_json::json!({ "text": text_from_update(update) })
+        }
+        RuntimeEventKind::ToolCall => {
+            Value::Object(take_fields(
+                update,
+                &["toolCallId", "title", "toolName", "kind", "status", "rawInput"],
+            ))
+        }
+        RuntimeEventKind::ToolResult => {
+            let mut map = take_fields(
+                update,
+                &[
+                    "toolCallId",
+                    "title",
+                    "toolName",
+                    "kind",
+                    "status",
+                    "rawOutput",
+                ],
+            );
+            let text = tool_result_text(update);
+            if !text.is_empty() {
+                map.insert("text".into(), Value::String(text));
+            }
+            if let Some(is_error) = update.pointer("/rawOutput/isError") {
+                map.insert("isError".into(), is_error.clone());
+            }
+            Value::Object(map)
+        }
+        _ => raw.clone(),
+    }
+}
+
+fn take_fields(update: &Value, keys: &[&str]) -> serde_json::Map<String, Value> {
+    let mut map = serde_json::Map::new();
+    for key in keys {
+        if let Some(value) = update.get(*key) {
+            if !value.is_null() {
+                map.insert((*key).to_string(), value.clone());
+            }
+        }
+    }
+    map
+}
+
+fn text_from_update(update: &Value) -> String {
+    if let Some(text) = update.get("text").and_then(Value::as_str) {
+        return text.to_string();
+    }
+    match update.get("content") {
+        Some(content) if content.is_object() => content
+            .get("text")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        Some(content) if content.is_array() => content_array_text(content),
+        _ => String::new(),
+    }
+}
+
+fn tool_result_text(update: &Value) -> String {
+    if let Some(text) = update.pointer("/rawOutput/text").and_then(Value::as_str) {
+        return text.to_string();
+    }
+    text_from_update(update)
+}
+
+fn content_array_text(content: &Value) -> String {
+    content
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|item| {
+            item.pointer("/content/text")
+                .and_then(Value::as_str)
+                .or_else(|| item.get("text").and_then(Value::as_str))
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn runtime_request(id: &Value, method: &str, params: &Value) -> RuntimeRequest {
@@ -380,28 +469,101 @@ mod tests {
     }
 
     #[test]
-    fn notification_contract_preserves_stored_event_shape() {
+    fn text_delta_stores_product_text_not_acp_envelope() {
         let raw = serde_json::json!({
             "jsonrpc": "2.0",
             "method": "session/update",
             "params": {
                 "sessionId": "session-1",
-                "update": { "sessionUpdate": "agent_message_chunk", "text": "hello" }
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": { "type": "text", "text": "hello" }
+                }
             }
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
         assert_eq!(event.event_type, "text_delta");
         assert!(event.source_event_id.starts_with("acp-"));
         assert_eq!(event.cursor, None);
-        assert_eq!(event.payload, raw);
+        assert_eq!(event.payload, serde_json::json!({ "text": "hello" }));
     }
 
     #[test]
-    fn session_update_kinds_are_classified_without_changing_payload() {
+    fn thought_delta_reads_content_text() {
+        let raw = serde_json::json!({
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "agent_thought_chunk",
+                    "content": { "type": "text", "text": "hmm" }
+                }
+            }
+        });
+        let event = runtime_notification(AcpEvent::from_notification(&raw));
+        assert_eq!(event.event_type, "thought_delta");
+        assert_eq!(event.payload, serde_json::json!({ "text": "hmm" }));
+    }
+
+    #[test]
+    fn tool_call_stores_product_fields() {
+        let raw = serde_json::json!({
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "tool_call",
+                    "toolCallId": "call-1",
+                    "title": "Read lib.rs",
+                    "kind": "read",
+                    "status": "pending",
+                    "rawInput": { "path": "lib.rs" }
+                }
+            }
+        });
+        let event = runtime_notification(AcpEvent::from_notification(&raw));
+        assert_eq!(event.event_type, "tool_call");
+        assert_eq!(
+            event.payload,
+            serde_json::json!({
+                "toolCallId": "call-1",
+                "title": "Read lib.rs",
+                "kind": "read",
+                "status": "pending",
+                "rawInput": { "path": "lib.rs" }
+            })
+        );
+    }
+
+    #[test]
+    fn tool_result_stores_product_fields() {
+        let raw = serde_json::json!({
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "call-1",
+                    "status": "completed",
+                    "content": [{
+                        "type": "content",
+                        "content": { "type": "text", "text": "ok" }
+                    }],
+                    "rawOutput": { "text": "ok", "isError": false }
+                }
+            }
+        });
+        let event = runtime_notification(AcpEvent::from_notification(&raw));
+        assert_eq!(event.event_type, "tool_result");
+        assert_eq!(event.payload["toolCallId"], "call-1");
+        assert_eq!(event.payload["status"], "completed");
+        assert_eq!(event.payload["text"], "ok");
+        assert_eq!(event.payload["isError"], false);
+        assert_eq!(event.payload["rawOutput"]["text"], "ok");
+        assert!(event.payload.get("sessionUpdate").is_none());
+        assert!(event.payload.get("method").is_none());
+    }
+
+    #[test]
+    fn non_timeline_kinds_keep_original_payload() {
         let cases = [
-            ("agent_thought_chunk", "thought_delta"),
-            ("tool_call", "tool_call"),
-            ("tool_call_update", "tool_result"),
             ("current_mode_update", "state_changed"),
             ("usage_update", "usage_update"),
             ("projection_update", "projection_ready"),

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `7996720`（PR #64 已合并）。**
+> **进度快照：2026-08-13，基线 `b1bb24b`（PR #65 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 审批 command 与 `event_type` 已中性。当前工作是 Console 按 `event_type` 分发时间线。
+> Wave 16 审批 command、`event_type`、Console 分发已中性。当前工作是时间线 payload 去 ACP JSON。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -29,10 +29,10 @@
 
 1. `TurnEngine` 已统一主 Agent 和 Subagent 的循环，ports 也已抽出；Wave 13 起默认路径必须真正把 `prepare_context` 的 `PreparedContext` 交给 `run_model`，而不是在 model 步骤里重新组装上下文。
 2. `Provider`、`ChatClient`、`ChatBackend` 仍存在相近但不统一的模型抽象；`zene-model-executor` 已可注入，但请求类型仍是 `zene-llm::ChatRequest`，Turn 还看不到中性 `ModelRequest`。
-3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。本地 `zene-runtime::RuntimeCommand` 与 Cloud `RuntimeCommand` 是两套类型。Cloud `event_type` 已是中性 kind，Console 按 kind 分发时间线；`payload` 仍为 ACP JSON。
+3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。本地 `zene-runtime::RuntimeCommand` 与 Cloud `RuntimeCommand` 是两套类型。Cloud 时间线 `event_type` 与 payload 已是产品字段；未分类帧仍为 ACP JSON。
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者，但 Agent-specific actor 仍在 `zene-core`，ACP 仍保留 transport 层 session bookkeeping。
-6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 用同一套 `ApprovalDecision` 回复审批；ACP `optionId` JSON 只留在 RuntimeClient adapter。Cloud `event_type` 已分类，Console 按 kind 分发；payload 仍是 ACP JSON。
+6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 用同一套 `ApprovalDecision` 回复审批；ACP `optionId` JSON 只留在 RuntimeClient adapter。Cloud 时间线 payload 已是产品字段；非时间线帧仍为 ACP JSON。
 7. `ToolRegistry` 仍同时承担目录与执行；`RuntimeScope` 尚未成为 Subagent 的正式差异注入面。
 
 本文目标不是立刻重写 runtime，而是建立一个可以渐进落地的目标架构：
@@ -77,7 +77,7 @@ Cloud API
 zene-cloud-worker  (JobRunner)
    │  claim / workspace / heartbeat / approval / cancel
    ▼
-zene-cloud-runtime-client  (event_type 中性；payload 仍是 ACP JSON)
+zene-cloud-runtime-client  (时间线 event_type + 产品 payload；其余帧仍是 ACP JSON)
    │
    ▼
 zene acp
@@ -104,7 +104,7 @@ RuntimeHandle → Agent → TurnEngine
 | Subagent | `crates/core/src/subagent.rs` | 直接实现 `TurnEnginePorts`；仍用独立 `ChatBackend` 和内存消息，尚未 `RuntimeScope` |
 | Runtime | `crates/runtime` + `crates/core/src/agent_runtime.rs` | 公共 command/event 在 `zene-runtime`；Agent actor 仍在 core |
 | ACP | `apps/cli/src/acp/server.rs` | transport adapter；创建/加载 session，并把请求接入 `RuntimeHandle` |
-| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 生命周期与 RuntimeClient 已分层；`event_type` 中性，payload 仍是 ACP JSON |
+| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 生命周期与 RuntimeClient 已分层；时间线 `event_type` 与 payload 已是产品字段，未分类帧仍为 ACP JSON |
 
 ## 3. 核心概念边界
 
@@ -952,7 +952,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 2. **`Agent` 仍是 God Object**：它同时持有 model、tools、sandbox、permission、hooks、MCP、todos、plan mode。下一步是把它变成 wiring，而不是继续实现 step。
 3. **模型抽象仍偏 provider**：`ModelExecutor` 吃 `ChatRequest`；Subagent 另有 `ChatBackend`。目标是 Turn 只看见 `PreparedContext` → `ModelRequest`。
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
-5. **Cloud 审批 command 已中性化（Wave 16 第一刀）**：JobRunner 用 `ApprovalDecision` 回复审批，不再构造 ACP `outcome.optionId`。`event_type` 已是中性 kind，Console 按 kind 分发时间线；`payload` 仍是 ACP JSON。Cloud `RuntimeCommand` 仍不是 `zene-runtime::RuntimeCommand`。
+5. **Cloud 审批 command 已中性化（Wave 16 第一刀）**：JobRunner 用 `ApprovalDecision` 回复审批，不再构造 ACP `outcome.optionId`。时间线 `event_type` 与 payload 已是产品字段；未分类帧仍为 ACP JSON。Cloud `RuntimeCommand` 仍不是 `zene-runtime::RuntimeCommand`。
 6. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
 Conversation event 与 materialized `messages` cache 的双轨可以保留，直到 legacy session 可证明无损迁移。不要为了架构干净上完整 Event Sourcing。
@@ -1043,7 +1043,8 @@ Wave 15  ApprovalBroker
 Wave 16  统一 transport command/event  ← 当前工作
          Cloud 审批 command 使用 ApprovalDecision
          Cloud event_type 使用中性 kind
-         Console 按 event_type 分发时间线（本轮）
+         Console 按 event_type 分发时间线
+         Cloud 时间线 payload 使用产品字段（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1068,13 +1069,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | 审批 command、`event_type`、Console 分发已中性；payload 与整型 RuntimeCommand 仍待统一 |
+| Wave 16 | 进行中 | 审批 command、`event_type`、Console 分发、时间线 payload 已中性；其余帧与整型 RuntimeCommand 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `ApprovalDecision`；Cloud `event_type` 已是中性 kind，Console 按 kind 分发时间线；payload 仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `ApprovalDecision`；Cloud 时间线 `event_type` 与 payload 已是产品字段；未分类帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1103,7 +1104,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - pending tool / approval 的任意副作用自动 replay：继续采用 inspection/manual intervention，避免重复写操作。
    - `Agent` 从 step orchestrator 完全退回 composition root。
    - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor` / ModelExecutor，而不是并行 `ChatBackend`。
-   - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`；Cloud payload 不再以 ACP JSON 为产品语义（`event_type` 与 Console 分发已中性）。
+   - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`；非时间线 Cloud payload 不再以 ACP JSON 为产品语义（时间线 kind 与 payload 已中性）。
    - Agent-specific actor 从 `zene-core` 移入独立 runtime implementation crate（应在 ports/审批稳定之后）。
    - 跨 VM outbox 的共享持久化实现；当前部署文档要求共享 POSIX volume 或后续 DB/object spool。
 
@@ -1168,9 +1169,9 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 7. **Wave 16：统一 command/event（进行中）**
    - JobRunner 不再构造 ACP `outcome.optionId`；`RuntimeCommand::RespondApproval` 携带 `ApprovalDecision`。
-   - RuntimeClient 把 ACP `sessionUpdate` 分类为中性 `event_type`；payload 仍存原始 JSON。
-   - Console 按 `event_type` 分发时间线；legacy `acp` / `runtime` 仍读 `payload.params.update.sessionUpdate`。
-   - 未做：payload 去 ACP JSON；Cloud `RuntimeCommand` 与 `zene-runtime::RuntimeCommand` 合成一套类型。
+   - RuntimeClient 把 ACP `sessionUpdate` 分类为中性 `event_type`；时间线 payload 存产品字段（`text`、`toolCallId` 等）。
+   - Console 按 `event_type` 分发；新产品 payload 直接渲染，legacy `params.update` 仍可回放。
+   - 未做：非时间线帧去 ACP JSON；Cloud `RuntimeCommand` 与 `zene-runtime::RuntimeCommand` 合成一套类型。
 
 8. **持续质量门槛**
    - 每个 wave 保持 `cargo test --workspace --locked`；
@@ -1195,11 +1196,11 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 payload** | `event_type` 与 Console 分发已中性；payload 仍是 ACP JSON |
-| 产品面灵活度 | Wave 16 | 两套 RuntimeCommand 仍会让 CLI/Cloud 行为分叉 |
+| 当前最大杠杆 | **Wave 16 RuntimeCommand** | 时间线 payload 已中性；两套 command 仍会让 CLI/Cloud 行为分叉 |
+| 剩余事件语义 | Wave 16 | 非时间线帧（审批、session、usage）仍是 ACP JSON |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**继续 Wave 16 收口事件语义**，最后才用 Wave 14 把 `Agent` 收成 wiring。不要先搬 runtime crate。
+推荐组合：**继续 Wave 16 收口 RuntimeCommand 与剩余 ACP payload**，最后才用 Wave 14 把 `Agent` 收成 wiring。不要先搬 runtime crate。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1258,7 +1259,7 @@ Wave 16  统一 transport command/event  ← 当前工作
 - `ApprovalWaiters` 挂在 runtime actor 上；`RuntimeOwnedBroker` 发 `ApprovalRequested` 并等待 oneshot。
 - `RuntimeCommand::Approval` 在 active turn 中 `resolve` waiter；Cancel/Shutdown 会 `cancel_all`。
 - ACP 不再注入 `AcpApprovalBroker`：事件循环看到 `ApprovalRequested` 后发 `session/request_permission`，再 `runtime.approve`。
-- CLI 未开 waiter 时仍走旧同步 prompter。Cloud 审批回复已用中性 `ApprovalDecision`；`event_type` 已分类，Console 按 kind 分发；payload 仍待去 ACP JSON。
+- CLI 未开 waiter 时仍走旧同步 prompter。Cloud 审批回复已用中性 `ApprovalDecision`；`event_type` 已分类，Console 按 kind 分发；时间线 payload 已去 ACP JSON。
 - 未做：pending tool 自动 replay、把 Agent actor 搬出 core、完整 Event Sourcing。
 
 ### 2026-08-13 — Cloud ApprovalDecision
@@ -1266,7 +1267,7 @@ Wave 16  统一 transport command/event  ← 当前工作
 - `zene-cloud-runtime-client::ApprovalDecision` 与 core 同为 AllowOnce / AllowSession / Deny。
 - `RuntimeCommand::RespondApproval` 和 `RuntimeClient::respond_approval` 不再接受 ACP result JSON。
 - ACP `optionId` 只在 adapter / `PermissionDecision::to_result` 内构造。
-- 未做：payload 去 ACP JSON、Cloud 与 `zene-runtime::RuntimeCommand` 合成同一类型。
+- 未做：非时间线 payload 去 ACP JSON、Cloud 与 `zene-runtime::RuntimeCommand` 合成同一类型。
 
 ### 2026-08-13 — Cloud event_type
 
@@ -1278,5 +1279,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 - Console 时间线按 `event_type` 分发（`text_delta` → 助手文本，`tool_call` / `tool_result` 等）。
 - legacy `acp` / `runtime` 仍读 `payload.params.update.sessionUpdate`。不迁移已存 payload。
-- 未做：payload 去 ACP JSON、Cloud 与 `zene-runtime::RuntimeCommand` 合成同一类型。
+
+### 2026-08-13 — Cloud 时间线 payload
+
+- RuntimeClient 把 `text_delta` / `thought_delta` / `tool_call` / `tool_result` 存成产品字段（`text`、`toolCallId` 等），不再存 jsonrpc 信封。
+- Console 优先读产品 payload；legacy `params.update` 仍可回放。不迁移已存记录。
+- 未做：非时间线帧去 ACP JSON、Cloud 与 `zene-runtime::RuntimeCommand` 合成同一类型。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #65 让 Console 按 `event_type` 分发时间线，但新产品事件的 `payload` 仍是 ACP jsonrpc 信封。

本 PR 是 Wave 16 下一刀：RuntimeClient 把 `text_delta` / `thought_delta` / `tool_call` / `tool_result` 存成产品字段（`text`、`toolCallId` 等）。Console 优先读这些字段；legacy `params.update` 仍可回放。不迁移已存记录。不改布局。

非时间线帧（审批、session、usage）仍为 ACP JSON。不合并两套 `RuntimeCommand`。

`cd cloud && cargo test -p zene-cloud-runtime-client -p zene-cloud-worker --locked` 与 `cd cloud/apps/web && npm run typecheck` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

