### PR TITLE
feat: Cloud RuntimeCommand::Approval 与 core 同形

### DIFF
--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -18,8 +18,8 @@ use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 use zene_cloud_acp_bridge::{resolve_zene_bin, MockAgent, MockMsg, PermissionDecision};
 use zene_cloud_runtime_client::{
-    AcpRuntimeClient, ApprovalDecision, RuntimeClient, RuntimeEvent, RuntimeNotification,
-    RuntimeRequest,
+    AcpRuntimeClient, ApprovalDecision, RuntimeClient, RuntimeCommand, RuntimeEvent,
+    RuntimeNotification, RuntimeRequest,
 };
 use zene_cloud_domain::{
     ApprovalRequest, ApprovalStatus, ClaimedRun, CloneAuthResponse, CreateApprovalRequest,
@@ -1020,38 +1020,28 @@ async fn run_with_real_acp(
                         *event_error_pump.lock().await = Some(err.to_string());
                         break;
                     }
-                    match request {
-                        RuntimeRequest::Approval {
-                            id,
-                            request_key,
-                            context,
-                        } => {
-                            let decision = match resolve_permission(
-                                &client_bg,
-                                &cli_api,
-                                &token,
-                                run_id,
-                                &request_key,
-                                Some(&id_to_string(&id)),
-                                "permission",
-                                &context,
-                            )
-                            .await
-                            {
-                                Ok(d) => d,
-                                Err(err) => {
-                                    warn!(error = %err, "permission resolve failed");
-                                    ApprovalDecision::Deny
-                                }
-                            };
-                            let _ = runtime_bg.respond_approval(&id, decision).await;
+                    let RuntimeRequest::Approval { request_id, context } = request;
+                    let decision = match resolve_permission(
+                        &client_bg,
+                        &cli_api,
+                        &token,
+                        run_id,
+                        &request_id,
+                        None,
+                        "permission",
+                        &context,
+                    )
+                    .await
+                    {
+                        Ok(d) => d,
+                        Err(err) => {
+                            warn!(error = %err, "permission resolve failed");
+                            ApprovalDecision::Deny
                         }
-                        RuntimeRequest::Unsupported { id } => {
-                            let _ = runtime_bg
-                                .reject_request(&id, -32601, "unsupported runtime request")
-                                .await;
-                        }
-                    }
+                    };
+                    let _ = runtime_bg
+                        .send(RuntimeCommand::Approval { request_id, decision })
+                        .await;
                 }
                 RuntimeEvent::ChildExited => {
                     info!(run_id = %run_id, "runtime child exited");
@@ -1077,7 +1067,7 @@ async fn run_with_real_acp(
                     for cmd in commands {
                         if cmd.kind == "cancel" {
                             cancel_flag.store(true, std::sync::atomic::Ordering::SeqCst);
-                            let _ = runtime_cancel.cancel().await;
+                            let _ = runtime_cancel.send(RuntimeCommand::Cancel).await;
                             return;
                         }
                         if cmd.kind == "prompt" {
@@ -1095,7 +1085,7 @@ async fn run_with_real_acp(
                                     RunStatus::Running,
                                 )
                                 .await;
-                                match runtime_cancel.prompt(&text).await {
+                                match runtime_cancel.send(RuntimeCommand::Prompt { text }).await {
                                     Ok(()) => {
                                         if let Some(message_id) = cmd.message_id {
                                             if let Err(err) = ack_command(
@@ -1141,7 +1131,12 @@ async fn run_with_real_acp(
         }
     });
 
-    runtime.prompt(&claimed.run.prompt).await.context("session/prompt")?;
+    runtime
+        .send(RuntimeCommand::Prompt {
+            text: claimed.run.prompt.clone(),
+        })
+        .await
+        .context("session/prompt")?;
     {
         let mut ts = last_activity.lock().await;
         *ts = tokio::time::Instant::now();
@@ -1194,7 +1189,7 @@ async fn run_with_real_acp(
     };
 
     cmd_task.abort();
-    let _ = runtime.shutdown().await;
+    let _ = runtime.send(RuntimeCommand::Shutdown).await;
     let _ = pump.await;
 
     if let Some(err) = event_error.lock().await.clone() {
@@ -1346,14 +1341,6 @@ fn event_to_req(event: RuntimeNotification) -> WorkerEventRequest {
         event_type: event.event_type,
         payload: event.payload,
         fence: None,
-    }
-}
-
-fn id_to_string(id: &serde_json::Value) -> String {
-    match id {
-        serde_json::Value::Number(n) => n.to_string(),
-        serde_json::Value::String(s) => s.clone(),
-        other => other.to_string(),
     }
 }
 

--- a/cloud/crates/runtime-client/src/lib.rs
+++ b/cloud/crates/runtime-client/src/lib.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use serde_json::Value;
 use tokio::sync::{mpsc, Mutex};
@@ -111,12 +112,16 @@ fn map_session_update(update: &str) -> RuntimeEventKind {
     }
 }
 
+/// Transport-neutral command accepted by Cloud's runtime client.
+///
+/// Variant names match `zene_runtime::RuntimeCommand` where Cloud has a
+/// counterpart. ACP JSON-RPC ids stay inside this adapter.
 #[derive(Debug, Clone)]
 pub enum RuntimeCommand {
     Prompt { text: String },
     Cancel,
-    RespondApproval { id: Value, decision: ApprovalDecision },
-    RejectRequest { id: Value, code: i64, message: String },
+    Approval { request_id: String, decision: ApprovalDecision },
+    Shutdown,
 }
 
 /// A runtime notification with the stable fields persisted by the worker.
@@ -148,37 +153,30 @@ pub enum RuntimeEvent {
 }
 
 /// Runtime-level meaning of a request requiring user approval. Protocol method
-/// names and parameter paths stay inside this adapter instead of leaking into
-/// workers. `context` is opaque request context retained for existing approval
+/// names, JSON-RPC ids, and parameter paths stay inside this adapter.
+/// `context` is opaque request context retained for existing approval
 /// resolution and compatibility with stored payloads.
 #[derive(Debug)]
 pub enum RuntimeRequest {
     Approval {
-        id: Value,
-        request_key: String,
+        request_id: String,
         context: Value,
-    },
-    Unsupported {
-        id: Value,
     },
 }
 
 #[async_trait]
 pub trait RuntimeClient: Send + Sync {
     async fn session_id(&self) -> Result<String>;
-    async fn prompt(&self, text: &str) -> Result<()>;
-    async fn cancel(&self) -> Result<()>;
-    async fn respond_approval(&self, id: &Value, decision: ApprovalDecision) -> Result<()>;
-    async fn reject_request(&self, id: &Value, code: i64, message: &str) -> Result<()>;
+    async fn send(&self, command: RuntimeCommand) -> Result<()>;
     async fn next_event(&self) -> Option<RuntimeEvent>;
     async fn is_alive(&self) -> bool;
-    async fn shutdown(&self) -> Result<()>;
 }
 
 pub struct AcpRuntimeClient {
     bridge: Arc<Mutex<Option<AcpBridge>>>,
     session_id: String,
     events: Arc<Mutex<mpsc::UnboundedReceiver<RuntimeEvent>>>,
+    pending_approvals: Arc<Mutex<HashMap<String, Value>>>,
 }
 
 fn runtime_notification(event: AcpEvent) -> RuntimeNotification {
@@ -278,16 +276,14 @@ fn content_array_text(content: &Value) -> String {
         .join("\n")
 }
 
-fn runtime_request(id: &Value, method: &str, params: &Value) -> RuntimeRequest {
+fn runtime_request(method: &str, params: &Value) -> Option<RuntimeRequest> {
     if method == "session/request_permission" {
-        let request_key = permission_request_key(params);
-        RuntimeRequest::Approval {
-            id: id.clone(),
-            request_key,
+        Some(RuntimeRequest::Approval {
+            request_id: permission_request_key(params),
             context: params.clone(),
-        }
+        })
     } else {
-        RuntimeRequest::Unsupported { id: id.clone() }
+        None
     }
 }
 
@@ -347,6 +343,9 @@ impl AcpRuntimeClient {
             let _ = events_tx.send(RuntimeEvent::Initialized { session_id: session_id.clone(), event });
         }
         let event_tx = events_tx.clone();
+        let pending_approvals = Arc::new(Mutex::new(HashMap::new()));
+        let pending = pending_approvals.clone();
+        let pump_bridge = bridge.clone();
         tokio::spawn(async move {
             while let Some(message) = messages.recv().await {
                 let event = match message {
@@ -355,50 +354,85 @@ impl AcpRuntimeClient {
                     }
                     BridgeMsg::ReverseRequest { id, method, params } => {
                         let event = runtime_notification(AcpEvent::from_reverse_request(&id, &method, &params));
-                        let request = runtime_request(&id, &method, &params);
-                        RuntimeEvent::Request { request, event }
+                        match runtime_request(&method, &params) {
+                            Some(request) => {
+                                let RuntimeRequest::Approval { request_id, .. } = &request;
+                                pending.lock().await.insert(request_id.clone(), id);
+                                RuntimeEvent::Request { request, event }
+                            }
+                            None => {
+                                if let Some(bridge) = pump_bridge.lock().await.as_ref() {
+                                    let _ = bridge
+                                        .respond_error(&id, -32601, "unsupported runtime request")
+                                        .await;
+                                }
+                                RuntimeEvent::Notification(event)
+                            }
+                        }
                     }
                 };
                 if event_tx.send(event).is_err() { break; }
             }
             let _ = event_tx.send(RuntimeEvent::ChildExited);
         });
-        Ok(Self { bridge, session_id, events: Arc::new(Mutex::new(events_rx)) })
+        Ok(Self {
+            bridge,
+            session_id,
+            events: Arc::new(Mutex::new(events_rx)),
+            pending_approvals,
+        })
     }
 }
 
 #[async_trait]
 impl RuntimeClient for AcpRuntimeClient {
     async fn session_id(&self) -> Result<String> { Ok(self.session_id.clone()) }
-    async fn prompt(&self, text: &str) -> Result<()> {
-        let guard = self.bridge.lock().await;
-        guard.as_ref().context("runtime bridge missing")?.prompt(&self.session_id, text).await.map(|_| ())
-    }
-    async fn cancel(&self) -> Result<()> {
-        let guard = self.bridge.lock().await;
-        guard.as_ref().context("runtime bridge missing")?.cancel(&self.session_id).await
-    }
-    async fn respond_approval(&self, id: &Value, decision: ApprovalDecision) -> Result<()> {
-        let guard = self.bridge.lock().await;
-        guard
-            .as_ref()
-            .context("runtime bridge missing")?
-            .respond(id, acp_permission_result(decision))
-            .await
-    }
-    async fn reject_request(&self, id: &Value, code: i64, message: &str) -> Result<()> {
-        let guard = self.bridge.lock().await;
-        guard.as_ref().context("runtime bridge missing")?.respond_error(id, code, message).await
+    async fn send(&self, command: RuntimeCommand) -> Result<()> {
+        match command {
+            RuntimeCommand::Prompt { text } => {
+                let guard = self.bridge.lock().await;
+                guard
+                    .as_ref()
+                    .context("runtime bridge missing")?
+                    .prompt(&self.session_id, &text)
+                    .await
+                    .map(|_| ())
+            }
+            RuntimeCommand::Cancel => {
+                let guard = self.bridge.lock().await;
+                guard
+                    .as_ref()
+                    .context("runtime bridge missing")?
+                    .cancel(&self.session_id)
+                    .await
+            }
+            RuntimeCommand::Approval { request_id, decision } => {
+                let id = self
+                    .pending_approvals
+                    .lock()
+                    .await
+                    .remove(&request_id)
+                    .ok_or_else(|| anyhow!("unknown approval request_id {request_id}"))?;
+                let guard = self.bridge.lock().await;
+                guard
+                    .as_ref()
+                    .context("runtime bridge missing")?
+                    .respond(&id, acp_permission_result(decision))
+                    .await
+            }
+            RuntimeCommand::Shutdown => {
+                let mut guard = self.bridge.lock().await;
+                if let Some(bridge) = guard.take() {
+                    bridge.kill().await?;
+                }
+                Ok(())
+            }
+        }
     }
     async fn next_event(&self) -> Option<RuntimeEvent> { self.events.lock().await.recv().await }
     async fn is_alive(&self) -> bool {
         let mut guard = self.bridge.lock().await;
         guard.as_mut().is_some_and(|bridge| !bridge.child_exited())
-    }
-    async fn shutdown(&self) -> Result<()> {
-        let mut guard = self.bridge.lock().await;
-        if let Some(bridge) = guard.take() { bridge.kill().await?; }
-        Ok(())
     }
 }
 
@@ -409,13 +443,12 @@ mod tests {
     #[test]
     fn permission_request_is_normalized_without_exposing_method_paths() {
         let request = runtime_request(
-            &serde_json::json!(42),
             "session/request_permission",
             &serde_json::json!({"toolCall": {"toolCallId": "call-7"}}),
         );
         assert!(matches!(
             request,
-            RuntimeRequest::Approval { request_key, .. } if request_key == "call-7"
+            Some(RuntimeRequest::Approval { request_id, .. }) if request_id == "call-7"
         ));
     }
 
@@ -426,13 +459,13 @@ mod tests {
             "_meta": {"eventId": "permission-event-3", "sequence": 3},
             "reason": "write"
         });
-        let first = runtime_request(&serde_json::json!(42), "session/request_permission", &params);
-        let second = runtime_request(&serde_json::json!(99), "session/request_permission", &params);
+        let first = runtime_request("session/request_permission", &params);
+        let second = runtime_request("session/request_permission", &params);
         assert!(matches!(
             (first, second),
             (
-                RuntimeRequest::Approval { request_key: first, .. },
-                RuntimeRequest::Approval { request_key: second, .. }
+                Some(RuntimeRequest::Approval { request_id: first, .. }),
+                Some(RuntimeRequest::Approval { request_id: second, .. })
             ) if first == second && first.starts_with("permission-")
         ));
     }
@@ -440,32 +473,25 @@ mod tests {
     #[test]
     fn permission_request_metadata_changes_identity() {
         let first = runtime_request(
-            &serde_json::json!(1),
             "session/request_permission",
             &serde_json::json!({"sessionId": "session-1", "_meta": {"sequence": 3}}),
         );
         let second = runtime_request(
-            &serde_json::json!(1),
             "session/request_permission",
             &serde_json::json!({"sessionId": "session-1", "_meta": {"sequence": 4}}),
         );
         assert!(matches!(
             (first, second),
             (
-                RuntimeRequest::Approval { request_key: first, .. },
-                RuntimeRequest::Approval { request_key: second, .. }
+                Some(RuntimeRequest::Approval { request_id: first, .. }),
+                Some(RuntimeRequest::Approval { request_id: second, .. })
             ) if first != second
         ));
     }
 
     #[test]
     fn unsupported_reverse_request_is_classified_at_adapter_boundary() {
-        let request = runtime_request(
-            &serde_json::json!(42),
-            "session/unknown",
-            &serde_json::json!({}),
-        );
-        assert!(matches!(request, RuntimeRequest::Unsupported { id } if id == serde_json::json!(42)));
+        assert!(runtime_request("session/unknown", &serde_json::json!({})).is_none());
     }
 
     #[test]
@@ -616,13 +642,11 @@ mod tests {
             "toolCall": { "toolCallId": "call-7" },
             "reason": "write"
         });
-        let request = runtime_request(&serde_json::json!(42), "session/request_permission", &params);
+        let request = runtime_request("session/request_permission", &params);
         assert!(matches!(
             request,
-            RuntimeRequest::Approval { id, request_key, context }
-                if id == serde_json::json!(42)
-                    && request_key == "call-7"
-                    && context == params
+            Some(RuntimeRequest::Approval { request_id, context })
+                if request_id == "call-7" && context == params
         ));
     }
 
@@ -636,16 +660,16 @@ mod tests {
     fn runtime_commands_are_transport_neutral() {
         let command = RuntimeCommand::Prompt { text: "hello".into() };
         assert!(matches!(command, RuntimeCommand::Prompt { text } if text == "hello"));
-        let command = RuntimeCommand::RespondApproval {
-            id: serde_json::json!(42),
+        let command = RuntimeCommand::Approval {
+            request_id: "call-7".into(),
             decision: ApprovalDecision::AllowOnce,
         };
         assert!(matches!(
             command,
-            RuntimeCommand::RespondApproval {
+            RuntimeCommand::Approval {
+                request_id,
                 decision: ApprovalDecision::AllowOnce,
-                ..
-            }
+            } if request_id == "call-7"
         ));
     }
 

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `b1bb24b`（PR #65 已合并）。**
+> **进度快照：2026-08-13，基线 `fca3377`（PR #66 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 审批 command、`event_type`、Console 分发已中性。当前工作是时间线 payload 去 ACP JSON。
+> Wave 16 时间线 payload 已中性。当前工作是 Cloud `RuntimeCommand` 与 core 对齐（不引入 `zene-runtime` 依赖）。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -29,10 +29,10 @@
 
 1. `TurnEngine` 已统一主 Agent 和 Subagent 的循环，ports 也已抽出；Wave 13 起默认路径必须真正把 `prepare_context` 的 `PreparedContext` 交给 `run_model`，而不是在 model 步骤里重新组装上下文。
 2. `Provider`、`ChatClient`、`ChatBackend` 仍存在相近但不统一的模型抽象；`zene-model-executor` 已可注入，但请求类型仍是 `zene-llm::ChatRequest`，Turn 还看不到中性 `ModelRequest`。
-3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。本地 `zene-runtime::RuntimeCommand` 与 Cloud `RuntimeCommand` 是两套类型。Cloud 时间线 `event_type` 与 payload 已是产品字段；未分类帧仍为 ACP JSON。
+3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。Cloud `RuntimeCommand::Approval` 已与 core 同形（`request_id` + `ApprovalDecision`），但 Cloud 仍无 Steer/SetMode 等变体，也未依赖 `zene-runtime`。时间线 payload 已是产品字段；未分类帧仍为 ACP JSON。
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者，但 Agent-specific actor 仍在 `zene-core`，ACP 仍保留 transport 层 session bookkeeping。
-6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 用同一套 `ApprovalDecision` 回复审批；ACP `optionId` JSON 只留在 RuntimeClient adapter。Cloud 时间线 payload 已是产品字段；非时间线帧仍为 ACP JSON。
+6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 只留在 RuntimeClient adapter。时间线 payload 已是产品字段；非时间线帧仍为 ACP JSON。
 7. `ToolRegistry` 仍同时承担目录与执行；`RuntimeScope` 尚未成为 Subagent 的正式差异注入面。
 
 本文目标不是立刻重写 runtime，而是建立一个可以渐进落地的目标架构：
@@ -77,7 +77,7 @@ Cloud API
 zene-cloud-worker  (JobRunner)
    │  claim / workspace / heartbeat / approval / cancel
    ▼
-zene-cloud-runtime-client  (时间线 event_type + 产品 payload；其余帧仍是 ACP JSON)
+zene-cloud-runtime-client  (send RuntimeCommand；时间线产品 payload；其余帧仍是 ACP JSON)
    │
    ▼
 zene acp
@@ -104,7 +104,7 @@ RuntimeHandle → Agent → TurnEngine
 | Subagent | `crates/core/src/subagent.rs` | 直接实现 `TurnEnginePorts`；仍用独立 `ChatBackend` 和内存消息，尚未 `RuntimeScope` |
 | Runtime | `crates/runtime` + `crates/core/src/agent_runtime.rs` | 公共 command/event 在 `zene-runtime`；Agent actor 仍在 core |
 | ACP | `apps/cli/src/acp/server.rs` | transport adapter；创建/加载 session，并把请求接入 `RuntimeHandle` |
-| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 生命周期与 RuntimeClient 已分层；时间线 `event_type` 与 payload 已是产品字段，未分类帧仍为 ACP JSON |
+| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；时间线 payload 已是产品字段，未分类帧仍为 ACP JSON |
 
 ## 3. 核心概念边界
 
@@ -952,7 +952,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 2. **`Agent` 仍是 God Object**：它同时持有 model、tools、sandbox、permission、hooks、MCP、todos、plan mode。下一步是把它变成 wiring，而不是继续实现 step。
 3. **模型抽象仍偏 provider**：`ModelExecutor` 吃 `ChatRequest`；Subagent 另有 `ChatBackend`。目标是 Turn 只看见 `PreparedContext` → `ModelRequest`。
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
-5. **Cloud 审批 command 已中性化（Wave 16 第一刀）**：JobRunner 用 `ApprovalDecision` 回复审批，不再构造 ACP `outcome.optionId`。时间线 `event_type` 与 payload 已是产品字段；未分类帧仍为 ACP JSON。Cloud `RuntimeCommand` 仍不是 `zene-runtime::RuntimeCommand`。
+5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
 6. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
 Conversation event 与 materialized `messages` cache 的双轨可以保留，直到 legacy session 可证明无损迁移。不要为了架构干净上完整 Event Sourcing。
@@ -1044,7 +1044,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          Cloud 审批 command 使用 ApprovalDecision
          Cloud event_type 使用中性 kind
          Console 按 event_type 分发时间线
-         Cloud 时间线 payload 使用产品字段（本轮）
+         Cloud 时间线 payload 使用产品字段
+         Cloud RuntimeCommand::Approval 与 core 同形（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1069,13 +1070,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | 审批 command、`event_type`、Console 分发、时间线 payload 已中性；其余帧与整型 RuntimeCommand 仍待统一 |
+| Wave 16 | 进行中 | 审批 command、`event_type`、Console、时间线 payload、`RuntimeCommand::Approval` 已中性；Steer/SetMode 与非时间线 payload 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `ApprovalDecision`；Cloud 时间线 `event_type` 与 payload 已是产品字段；未分类帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；时间线 `event_type` 与 payload 已是产品字段；未分类帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1104,7 +1105,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - pending tool / approval 的任意副作用自动 replay：继续采用 inspection/manual intervention，避免重复写操作。
    - `Agent` 从 step orchestrator 完全退回 composition root。
    - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor` / ModelExecutor，而不是并行 `ChatBackend`。
-   - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`；非时间线 Cloud payload 不再以 ACP JSON 为产品语义（时间线 kind 与 payload 已中性）。
+   - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Cancel/Approval/Shutdown；仍缺 Steer/SetMode，且不依赖 `zene-runtime`）。非时间线 Cloud payload 仍为 ACP JSON。
    - Agent-specific actor 从 `zene-core` 移入独立 runtime implementation crate（应在 ports/审批稳定之后）。
    - 跨 VM outbox 的共享持久化实现；当前部署文档要求共享 POSIX volume 或后续 DB/object spool。
 
@@ -1168,10 +1169,11 @@ Wave 16  统一 transport command/event  ← 当前工作
    - Cloud JobRunner 用 `ApprovalDecision` 回复审批；ACP JSON 只在 RuntimeClient adapter 内构造。
 
 7. **Wave 16：统一 command/event（进行中）**
-   - JobRunner 不再构造 ACP `outcome.optionId`；`RuntimeCommand::RespondApproval` 携带 `ApprovalDecision`。
-   - RuntimeClient 把 ACP `sessionUpdate` 分类为中性 `event_type`；时间线 payload 存产品字段（`text`、`toolCallId` 等）。
+   - JobRunner 经 `RuntimeClient::send` 发送 Prompt/Cancel/Approval/Shutdown；`Approval` 携带 `request_id` + `ApprovalDecision`。
+   - ACP jsonrpc id 与 `optionId` 只留在 RuntimeClient adapter。
+   - RuntimeClient 把 ACP `sessionUpdate` 分类为中性 `event_type`；时间线 payload 存产品字段。
    - Console 按 `event_type` 分发；新产品 payload 直接渲染，legacy `params.update` 仍可回放。
-   - 未做：非时间线帧去 ACP JSON；Cloud `RuntimeCommand` 与 `zene-runtime::RuntimeCommand` 合成一套类型。
+   - 未做：非时间线帧去 ACP JSON；Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
    - 每个 wave 保持 `cargo test --workspace --locked`；
@@ -1196,11 +1198,11 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 RuntimeCommand** | 时间线 payload 已中性；两套 command 仍会让 CLI/Cloud 行为分叉 |
-| 剩余事件语义 | Wave 16 | 非时间线帧（审批、session、usage）仍是 ACP JSON |
+| 当前最大杠杆 | **Wave 16 剩余 command** | Approval 已同形；Steer/SetMode 与整型 crate 仍分叉 |
+| 剩余事件语义 | Wave 16 | 非时间线帧（审批事件、session、usage）仍是 ACP JSON |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**继续 Wave 16 收口 RuntimeCommand 与剩余 ACP payload**，最后才用 Wave 14 把 `Agent` 收成 wiring。不要先搬 runtime crate。
+推荐组合：**继续 Wave 16 收口剩余 ACP payload 与 command 变体**，最后才用 Wave 14 把 `Agent` 收成 wiring。不要先搬 runtime crate。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1284,5 +1286,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 - RuntimeClient 把 `text_delta` / `thought_delta` / `tool_call` / `tool_result` 存成产品字段（`text`、`toolCallId` 等），不再存 jsonrpc 信封。
 - Console 优先读产品 payload；legacy `params.update` 仍可回放。不迁移已存记录。
-- 未做：非时间线帧去 ACP JSON、Cloud 与 `zene-runtime::RuntimeCommand` 合成同一类型。
+
+### 2026-08-13 — Cloud RuntimeCommand::Approval
+
+- Cloud `RuntimeCommand` 为 Prompt / Cancel / Approval / Shutdown。`Approval` 与 core 同为 `request_id` + `ApprovalDecision`。
+- JobRunner 只 `send` 这些命令。ACP jsonrpc id 留在 adapter 的 pending map；不支持的 reverse request 在 adapter 内拒绝。
+- 未把 `zene-runtime` 引入 Cloud。未做：Steer/SetMode、非时间线 payload 去 ACP JSON。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #66 让时间线 payload 成为产品字段。Cloud JobRunner 仍通过 ACP jsonrpc id 调用 `respond_approval`，`RuntimeCommand::RespondApproval` 与 core 的 `Approval { request_id, decision }` 不同形。

本 PR 是 Wave 16 下一刀：Cloud `RuntimeCommand` 收成 Prompt / Cancel / Approval / Shutdown。JobRunner 只 `send` 这些命令。`Approval` 使用 `request_id` + `ApprovalDecision`；ACP jsonrpc id 留在 adapter pending map。不支持的 reverse request 在 adapter 内拒绝。

不把 `zene-runtime` 引入 Cloud。不补 Steer/SetMode。不改非时间线 payload，不改布局。

`cd cloud && cargo test -p zene-cloud-runtime-client -p zene-cloud-worker --locked` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

