### PR TITLE
docs: Context Engine 前缀稳定与 Prefix Cache 方案

### DIFF
--- a/apps/cli/src/acp/server.rs
+++ b/apps/cli/src/acp/server.rs
@@ -864,6 +864,7 @@ fn project_runtime_event(
             delivery_tail_start,
             estimate_tokens,
             context_epoch,
+            prefix_cache,
         } => Some(projection_ready_update_with_provenance(
             *source_message_count,
             *projected_message_count,
@@ -907,6 +908,15 @@ fn project_runtime_event(
             *delivery_tail_start,
             *estimate_tokens,
             *context_epoch,
+            &json!({
+                "prefixEnd": prefix_cache.prefix_end,
+                "bodyEnd": prefix_cache.body_end,
+                "tailDecorationCount": prefix_cache.tail_decoration_count,
+                "prefixFingerprint": prefix_cache.prefix_fingerprint,
+                "breakKind": prefix_cache.break_kind,
+                "cachedTokens": prefix_cache.cached_tokens,
+                "unchangedReprocessedEst": prefix_cache.unchanged_reprocessed_est,
+            }),
         )),
         RuntimeEventKind::TurnStarted
         | RuntimeEventKind::StepStarted { .. }

--- a/apps/cli/src/acp/updates.rs
+++ b/apps/cli/src/acp/updates.rs
@@ -357,6 +357,7 @@ pub fn projection_ready_update(
         delivery_tail_start,
         estimate_tokens,
         context_epoch,
+        &json!({}),
     )
 }
 
@@ -383,6 +384,7 @@ pub fn projection_ready_update_with_provenance(
     delivery_tail_start: Option<usize>,
     estimate_tokens: u32,
     context_epoch: u64,
+    prefix_cache: &Value,
 ) -> Value {
     json!({
         "sessionUpdate": "projection_update",
@@ -409,6 +411,7 @@ pub fn projection_ready_update_with_provenance(
             "deliveryTailStart": delivery_tail_start,
             "estimateTokens": estimate_tokens,
             "contextEpoch": context_epoch,
+            "prefixCache": prefix_cache,
         },
     })
 }

--- a/crates/context/src/compaction.rs
+++ b/crates/context/src/compaction.rs
@@ -1159,8 +1159,8 @@ fn apply_full_replace_to_session<S: ContextSession + ?Sized>(
     compacted_count: usize,
     reason: &str,
     tokens_before: u32,
-    hooks: Option<&dyn ContextHooks>,
-    memory_block: Option<&str>,
+    _hooks: Option<&dyn ContextHooks>,
+    _memory_block: Option<&str>,
 ) {
     let messages = projected_messages(session);
     let system = messages.first().filter(|m| m.role == Role::System).cloned();
@@ -1177,13 +1177,10 @@ fn apply_full_replace_to_session<S: ContextSession + ?Sized>(
         }
         None => (None, messages[tail_start..].to_vec()),
     };
-    let extra = hooks
-        .map(|h| h.compaction_reminder_sections())
-        .unwrap_or_default();
-    let extra_refs: Vec<&str> = extra.iter().map(String::as_str).collect();
-    let reminder = build_compaction_reminder(&extra_refs, memory_block);
+    // Volatile todos / memory reminders are projected at the request tail.
+    // Persisting them here would freeze a resize-prone block in the body.
     let projected =
-        assemble_full_replace_history(system, last_user, recent, summary.clone(), reminder);
+        assemble_full_replace_history(system, last_user, recent, summary.clone(), None);
     session.commit_compaction_snapshot(
         reason,
         compacted_count,

--- a/crates/context/src/engine.rs
+++ b/crates/context/src/engine.rs
@@ -13,8 +13,8 @@ use crate::assemble::{
     assemble_outbound, delivery_mode_from_env, stable_system_boundary, DeliveryMode,
 };
 use crate::compaction::{
-    apply_overflow_truncate_pass, apply_steps_truncate_pass, compact_session,
-    compact_session_forced, is_context_overflow_error, CompactionResult,
+    apply_steps_truncate_pass, compact_session, compact_session_forced, is_context_overflow_error,
+    CompactionResult,
 };
 use crate::config::CompactionConfig;
 use crate::context_water::ContextWaterLevel;
@@ -25,6 +25,10 @@ use crate::gateway::gateway_configured;
 #[cfg(not(feature = "gateway"))]
 use crate::gateway_stub::gateway_configured;
 use crate::hooks::ContextHooks;
+use crate::layout::{
+    apply_tail_decorations, classify_prefix_break, content_is_reminder, prefix_fingerprint,
+    split_layout, PrefixCacheExplain,
+};
 #[cfg(feature = "memory")]
 use crate::memory;
 #[cfg(not(feature = "memory"))]
@@ -51,7 +55,7 @@ fn projection_injected_labels(messages: &[Message]) -> Vec<String> {
         message
             .content
             .as_deref()
-            .is_some_and(|content| content.contains("<system-reminder>"))
+            .is_some_and(content_is_reminder)
     }) {
         labels.push("system_reminder".to_string());
     }
@@ -147,6 +151,9 @@ fn injected_source_kind(content: &str) -> Vec<&'static str> {
     if lower.contains("background") || lower.contains("task") {
         sources.push("background_tasks");
     }
+    if lower.contains("plan mode") || lower.contains("exitplanmode") {
+        sources.push("plan");
+    }
     if sources.is_empty() {
         sources.push("system");
     }
@@ -168,7 +175,7 @@ fn projection_injected_sources(messages: &[Message]) -> Vec<InjectedSource> {
             let Some(content) = message.content.as_deref() else {
                 return Vec::new();
             };
-            if !content.contains("<system-reminder>") {
+            if !content_is_reminder(content) {
                 return Vec::new();
             }
             injected_source_kind(content)
@@ -245,6 +252,8 @@ pub struct ProjectionExplain {
     pub delivery_tail_start: Option<usize>,
     pub estimate_tokens: u32,
     pub context_epoch: u64,
+    /// Prefix-cache layout and predicted break versus the previous outbound call.
+    pub prefix_cache: PrefixCacheExplain,
 }
 
 /// Result of [`ContextEngine::prepare_step`].
@@ -301,6 +310,12 @@ pub struct ContextEngine {
     pending_publish: bool,
     gateway_prefix_len: usize,
     initial_publish_done: bool,
+    tail_sections: Vec<String>,
+    last_prefix_fingerprint: Option<String>,
+    last_prefix_tokens: u32,
+    last_epoch_bump_reason: Option<&'static str>,
+    last_cached_tokens: Option<u64>,
+    last_unchanged_reprocessed_est: Option<u64>,
 }
 
 #[cfg(test)]
@@ -347,6 +362,58 @@ mod projection_tests {
         assert_eq!(sources[1].source, "memory");
         assert_eq!(sources[2].source, "todos");
     }
+
+    #[test]
+    fn tail_decorations_keep_prefix_fingerprint_stable() {
+        use crate::tokens::TokenEstimator;
+        use zene_session::SessionRecord;
+
+        let mut engine = ContextEngine::new(128_000);
+        let mut session = SessionRecord::new(std::path::Path::new("/tmp"));
+        session.ensure_system_message("frozen system");
+        session.push_message(Message::user("hello"));
+        session.push_message(Message::assistant("hi"));
+        let estimator = TokenEstimator::default();
+        let tools = [];
+
+        let first = engine.assemble_step(&session, &tools, &estimator);
+        let first_prefix = crate::layout::prefix_fingerprint(&first.messages, 1);
+        let explain_first = engine.explain_projection(&session, &tools, &estimator);
+        assert_eq!(explain_first.prefix_cache.prefix_end, 1);
+        assert_eq!(explain_first.prefix_cache.tail_decoration_count, 0);
+
+        engine.set_step_tail_decorations(vec!["Active todos:\n- [pending] ship".into()]);
+        let second = engine.assemble_step(&session, &tools, &estimator);
+        let explain_second = engine.explain_projection(&session, &tools, &estimator);
+        assert_eq!(explain_second.prefix_cache.prefix_end, 1);
+        assert_eq!(explain_second.prefix_cache.tail_decoration_count, 1);
+        assert!(second
+            .messages
+            .last()
+            .unwrap()
+            .content
+            .as_deref()
+            .unwrap()
+            .contains("ship"));
+        assert_eq!(
+            first_prefix,
+            crate::layout::prefix_fingerprint(&second.messages, 1)
+        );
+
+        engine.set_step_tail_decorations(vec!["You are in Plan mode.".into()]);
+        let third = engine.assemble_step(&session, &tools, &estimator);
+        assert_eq!(
+            first_prefix,
+            crate::layout::prefix_fingerprint(&third.messages, 1)
+        );
+        assert_eq!(
+            engine
+                .explain_projection(&session, &tools, &estimator)
+                .prefix_cache
+                .break_kind,
+            "none"
+        );
+    }
 }
 
 impl ContextEngine {
@@ -360,6 +427,12 @@ impl ContextEngine {
             pending_publish: false,
             gateway_prefix_len: 0,
             initial_publish_done: false,
+            tail_sections: Vec::new(),
+            last_prefix_fingerprint: None,
+            last_prefix_tokens: 0,
+            last_epoch_bump_reason: None,
+            last_cached_tokens: None,
+            last_unchanged_reprocessed_est: None,
         }
     }
 
@@ -425,6 +498,7 @@ impl ContextEngine {
         let old = self.epoch;
         self.epoch = self.epoch.saturating_add(1);
         self.pending_publish = true;
+        self.last_epoch_bump_reason = Some(reason);
         ContextEvent::EpochBumped {
             old,
             new: self.epoch,
@@ -432,19 +506,28 @@ impl ContextEngine {
         }
     }
 
+    /// Live tail decorations for the next `project` / `assemble_step` call.
+    /// `prepare_step` overwrites this from [`ContextHooks::step_tail_decorations`].
+    pub fn set_step_tail_decorations(&mut self, sections: Vec<String>) {
+        self.tail_sections = sections;
+    }
+
     /// Re-assemble outbound view after session mutation (e.g. overflow compact).
     pub fn assemble_step(
-        &self,
+        &mut self,
         session: &dyn ContextSession,
         tools: &[ToolDefinition],
         estimator: &TokenEstimator,
     ) -> StepContext {
-        self.project(session, tools, estimator)
+        let step = self.project(session, tools, estimator);
+        let explain = self.explain_projection_for_step(session, &step);
+        self.remember_projection(&step, &explain);
+        step
     }
 
     /// Strict event-backed variant used by new model requests.
     pub fn try_assemble_step(
-        &self,
+        &mut self,
         session: &dyn ContextSession,
         tools: &[ToolDefinition],
         estimator: &TokenEstimator,
@@ -455,7 +538,7 @@ impl ContextEngine {
                 reason.as_str()
             )
         })?;
-        Ok(self.project(session, tools, estimator))
+        Ok(self.assemble_step(session, tools, estimator))
     }
 
     /// Observe session pressure without mutating the session.
@@ -491,9 +574,11 @@ impl ContextEngine {
             )
         })?;
         let observation = self.observe(deps.session, tools, deps.estimator, deps.compaction_config);
+        self.capture_tail_sections(deps.hooks);
         let commit = self.commit(deps, tools, &observation).await?;
         let step = self.project(deps.session, tools, deps.estimator);
         let explain = self.explain_projection_for_step(deps.session, &step);
+        self.remember_projection(&step, &explain);
         Ok(PrepareStepResult {
             step,
             compaction: commit.compaction,
@@ -608,12 +693,16 @@ impl ContextEngine {
     ) -> Result<ContextUsageUpdate> {
         self.water.record_usage(usage);
         if let Some(cached) = usage.cached_tokens {
+            let prefix = u64::from(self.last_prefix_tokens);
+            self.last_cached_tokens = Some(cached);
+            self.last_unchanged_reprocessed_est = Some(prefix.saturating_sub(cached));
             let effective = self.water.effective_tokens();
             if effective > 0 {
                 tracing::info!(
                     cached_tokens = cached,
                     prompt_tokens = usage.prompt_tokens,
                     effective_tokens = effective,
+                    unchanged_reprocessed_est = self.last_unchanged_reprocessed_est,
                     cache_pct = (cached * 100 / u64::from(effective.max(1))),
                     "provider prompt cache usage"
                 );
@@ -707,7 +796,7 @@ impl ContextEngine {
         }
     }
 
-    /// Handle provider context-overflow: truncate then full compact. Returns true if retry.
+    /// Handle provider context-overflow: steps-first tail truncate, then full compact.
     pub async fn handle_overflow(
         &mut self,
         deps: &mut ContextDeps<'_>,
@@ -716,15 +805,13 @@ impl ContextEngine {
         overflow_summarized: &mut bool,
     ) -> Result<OverflowHandleResult> {
         let mut events = Vec::new();
+        self.capture_tail_sections(deps.hooks);
         if !*overflow_truncated {
             *overflow_truncated = true;
-            if apply_overflow_truncate_pass(
-                deps.session,
-                deps.compaction_config,
-                tools,
-                deps.estimator,
-            ) {
-                info!("context overflow: applied truncate pass before retry");
+            let mut steps_config = deps.compaction_config.clone();
+            steps_config.intra_steps_first = true;
+            if apply_steps_truncate_pass(deps.session, &steps_config) {
+                info!("context overflow: applied steps-first truncate before retry");
                 deps.session.ensure_system_message(deps.system_prompt);
                 return Ok(OverflowHandleResult {
                     retry: true,
@@ -732,6 +819,9 @@ impl ContextEngine {
                     events,
                 });
             }
+            info!(
+                "context overflow: no current-turn tool tail to truncate; compacting instead of rewriting older bodies"
+            );
         }
         if !*overflow_summarized {
             *overflow_summarized = true;
@@ -914,7 +1004,52 @@ impl ContextEngine {
             delivery_tail_start: step.metadata.tail_start,
             estimate_tokens: step.estimate_tokens,
             context_epoch: step.metadata.context_epoch,
+            prefix_cache: self.prefix_cache_explain(step),
         }
+    }
+
+    fn prefix_cache_explain(&self, step: &StepContext) -> PrefixCacheExplain {
+        let layout = split_layout(&step.messages);
+        let fingerprint = prefix_fingerprint(&step.messages, layout.prefix_end);
+        let epoch_reason = self.last_epoch_bump_reason;
+        let epoch_bumped = epoch_reason.is_some();
+        let break_kind = classify_prefix_break(
+            self.last_prefix_fingerprint.as_deref(),
+            fingerprint.as_deref(),
+            epoch_bumped,
+            epoch_reason,
+        );
+        PrefixCacheExplain {
+            prefix_end: layout.prefix_end,
+            body_end: layout.body_end,
+            tail_decoration_count: layout.tail_decoration_count,
+            prefix_fingerprint: fingerprint,
+            break_kind: break_kind.as_str().to_string(),
+            cached_tokens: self.last_cached_tokens,
+            unchanged_reprocessed_est: self.last_unchanged_reprocessed_est,
+        }
+    }
+
+    fn capture_tail_sections(&mut self, hooks: Option<&dyn ContextHooks>) {
+        if let Some(hooks) = hooks {
+            self.tail_sections = hooks.step_tail_decorations();
+        }
+    }
+
+    fn remember_projection(&mut self, step: &StepContext, explain: &ProjectionExplain) {
+        self.last_prefix_fingerprint = explain.prefix_cache.prefix_fingerprint.clone();
+        let prefix_end = explain.prefix_cache.prefix_end.min(step.messages.len());
+        self.last_prefix_tokens = if prefix_end == 0 {
+            0
+        } else {
+            // Cheap standing estimate: chars/4 of the frozen prefix.
+            let chars: usize = step.messages[..prefix_end]
+                .iter()
+                .map(|message| message.content.as_deref().unwrap_or("").chars().count())
+                .sum();
+            u32::try_from((chars / 4).max(1)).unwrap_or(u32::MAX)
+        };
+        self.last_epoch_bump_reason = None;
     }
 
     fn project(
@@ -925,7 +1060,9 @@ impl ContextEngine {
     ) -> StepContext {
         let mode = delivery_mode_from_env();
         let view = session.view();
-        let assembled = assemble_outbound(&view.messages, self.gateway_prefix_len, mode);
+        let mut messages = view.messages;
+        apply_tail_decorations(&mut messages, &self.tail_sections);
+        let assembled = assemble_outbound(&messages, self.gateway_prefix_len, mode);
         let metadata = self.metadata_for_outbound(session, &assembled);
         let estimate_tokens =
             tokens::estimate_context(&assembled.messages, tools, estimator) as u32;
@@ -1056,6 +1193,7 @@ impl ContextEngine {
     ) -> Result<()> {
         let old = self.epoch;
         self.epoch = self.epoch.saturating_add(1);
+        self.last_epoch_bump_reason = Some(reason);
         let view = deps.session.view();
         self.gateway_prefix_len = view.messages.len();
         info!(

--- a/crates/context/src/hooks.rs
+++ b/crates/context/src/hooks.rs
@@ -6,6 +6,15 @@ pub trait ContextHooks: Send + Sync {
     fn compaction_reminder_sections(&self) -> Vec<String> {
         Vec::new()
     }
+
+    /// Live decorations projected at the **tail** of each LLM request.
+    ///
+    /// Must not be written into the frozen system prefix. Defaults to the same
+    /// sections as compaction reminders so todos / background status stay visible
+    /// without resizing the cacheable prefix.
+    fn step_tail_decorations(&self) -> Vec<String> {
+        self.compaction_reminder_sections()
+    }
 }
 
 /// No-op hooks for tests and minimal integrations.

--- a/crates/context/src/layout.rs
+++ b/crates/context/src/layout.rs
@@ -1,0 +1,273 @@
+//! Outbound projection layout: frozen prefix, append-only body, tail decorations.
+//!
+//! Prefix cache only survives when bytes to the left of the first change stay
+//! identical. Volatile reminders therefore belong at the tail, never between
+//! the system prefix and conversation history. See `docs/context-engine-prefix-cache.md`.
+
+use serde::{Deserialize, Serialize};
+use zene_llm::{Message, Role};
+
+use crate::assemble::stable_system_boundary;
+use crate::two_pass::fingerprint_messages;
+
+const REMINDER_OPEN_HYPHEN: &str = "<system-reminder>";
+const REMINDER_OPEN_UNDERSCORE: &str = "<system_reminder>";
+
+/// Why the stable prefix likely missed provider cache versus the previous call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PrefixCacheBreakKind {
+    #[default]
+    None,
+    Compact,
+    SystemResize,
+    InjectedResize,
+    BodyMutate,
+    Unknown,
+}
+
+impl PrefixCacheBreakKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::None => "none",
+            Self::Compact => "compact",
+            Self::SystemResize => "system_resize",
+            Self::InjectedResize => "injected_resize",
+            Self::BodyMutate => "body_mutate",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Zone boundaries of one outbound `messages[]` (indices are exclusive ends).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ProjectionLayout {
+    pub prefix_end: usize,
+    pub body_end: usize,
+    pub tail_decoration_count: usize,
+}
+
+impl ProjectionLayout {
+    pub fn tail_start(&self) -> usize {
+        self.body_end
+    }
+}
+
+/// Cache-oriented explain fields for one projection.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PrefixCacheExplain {
+    pub prefix_end: usize,
+    pub body_end: usize,
+    pub tail_decoration_count: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefix_fingerprint: Option<String>,
+    pub break_kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cached_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub unchanged_reprocessed_est: Option<u64>,
+}
+
+pub fn is_step_decoration(message: &Message) -> bool {
+    if message.role != Role::User {
+        return false;
+    }
+    message.content.as_deref().is_some_and(content_is_reminder)
+}
+
+pub fn content_is_reminder(content: &str) -> bool {
+    content.contains(REMINDER_OPEN_HYPHEN) || content.contains(REMINDER_OPEN_UNDERSCORE)
+}
+
+pub fn split_layout(messages: &[Message]) -> ProjectionLayout {
+    let prefix_end = stable_system_boundary(messages).min(messages.len());
+    let mut tail_decoration_count = 0usize;
+    while tail_decoration_count < messages.len().saturating_sub(prefix_end)
+        && is_step_decoration(&messages[messages.len() - 1 - tail_decoration_count])
+    {
+        tail_decoration_count += 1;
+    }
+    let body_end = messages.len().saturating_sub(tail_decoration_count);
+    ProjectionLayout {
+        prefix_end,
+        body_end,
+        tail_decoration_count,
+    }
+}
+
+/// Drop trailing live decorations, then append a single reminder from `sections`.
+///
+/// Historical reminders that sit in the body (from older compact snapshots) are
+/// left untouched so their bytes stay frozen.
+pub fn apply_tail_decorations(messages: &mut Vec<Message>, sections: &[String]) {
+    while messages.last().is_some_and(is_step_decoration) {
+        messages.pop();
+    }
+    let mut parts = Vec::new();
+    for section in sections {
+        let trimmed = inner_reminder_text(section.trim());
+        if !trimmed.is_empty() {
+            parts.push(trimmed);
+        }
+    }
+    if parts.is_empty() {
+        return;
+    }
+    messages.push(Message::user(format!(
+        "{REMINDER_OPEN_HYPHEN}\n{}\n</system-reminder>",
+        parts.join("\n\n")
+    )));
+}
+
+pub fn prefix_fingerprint(messages: &[Message], prefix_end: usize) -> Option<String> {
+    let end = prefix_end.min(messages.len());
+    if end == 0 {
+        return None;
+    }
+    Some(format!("{:016x}", fingerprint_messages(&messages[..end])))
+}
+
+pub fn classify_prefix_break(
+    previous_fingerprint: Option<&str>,
+    current_fingerprint: Option<&str>,
+    epoch_bumped: bool,
+    epoch_reason: Option<&str>,
+) -> PrefixCacheBreakKind {
+    match (previous_fingerprint, current_fingerprint) {
+        (None, _) => PrefixCacheBreakKind::Unknown,
+        (_, None) => PrefixCacheBreakKind::Unknown,
+        (Some(prev), Some(cur)) if prev == cur => PrefixCacheBreakKind::None,
+        (Some(_), Some(_)) if epoch_bumped => match epoch_reason {
+            Some("compaction") | Some("manual_compaction") | Some("overflow_compaction") => {
+                PrefixCacheBreakKind::Compact
+            }
+            Some(reason) if reason.contains("system") || reason == "plan_mode" => {
+                PrefixCacheBreakKind::SystemResize
+            }
+            _ => PrefixCacheBreakKind::Compact,
+        },
+        (Some(_), Some(_)) => PrefixCacheBreakKind::InjectedResize,
+    }
+}
+
+fn inner_reminder_text(section: &str) -> String {
+    let trimmed = section.trim();
+    for (open, close) in [
+        (REMINDER_OPEN_HYPHEN, "</system-reminder>"),
+        (REMINDER_OPEN_UNDERSCORE, "</system_reminder>"),
+    ] {
+        if let Some(start) = trimmed.find(open) {
+            let inner_start = start + open.len();
+            let inner = if let Some(rel) = trimmed[inner_start..].find(close) {
+                &trimmed[inner_start..inner_start + rel]
+            } else {
+                &trimmed[inner_start..]
+            };
+            return inner.trim().to_string();
+        }
+    }
+    trimmed.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zene_llm::Message;
+
+    #[test]
+    fn decorations_only_count_at_tail() {
+        let messages = vec![
+            Message::system("sys"),
+            Message::user("hello"),
+            Message::assistant("ok"),
+            Message::user("<system-reminder>\nActive todos\n</system-reminder>"),
+        ];
+        let layout = split_layout(&messages);
+        assert_eq!(layout.prefix_end, 1);
+        assert_eq!(layout.body_end, 3);
+        assert_eq!(layout.tail_decoration_count, 1);
+    }
+
+    #[test]
+    fn mid_body_reminder_stays_in_body_zone() {
+        let messages = vec![
+            Message::system("sys"),
+            Message::user("<system-reminder>\nold compact note\n</system-reminder>"),
+            Message::user("next"),
+            Message::assistant("go"),
+        ];
+        let layout = split_layout(&messages);
+        assert_eq!(layout.prefix_end, 1);
+        assert_eq!(layout.body_end, 4);
+        assert_eq!(layout.tail_decoration_count, 0);
+    }
+
+    #[test]
+    fn apply_replaces_trailing_decoration_without_touching_prefix() {
+        let mut messages = vec![
+            Message::system("sys"),
+            Message::user("hello"),
+            Message::user("<system-reminder>\nold todos\n</system-reminder>"),
+        ];
+        let before = prefix_fingerprint(&messages, 1);
+        apply_tail_decorations(&mut messages, &["Active todos:\n- [pending] ship".into()]);
+        let after = prefix_fingerprint(&messages, 1);
+        assert_eq!(before, after);
+        let layout = split_layout(&messages);
+        assert_eq!(layout.tail_decoration_count, 1);
+        assert!(messages
+            .last()
+            .unwrap()
+            .content
+            .as_deref()
+            .unwrap()
+            .contains("ship"));
+        assert!(!messages
+            .last()
+            .unwrap()
+            .content
+            .as_deref()
+            .unwrap()
+            .contains("old todos"));
+    }
+
+    #[test]
+    fn changing_tail_does_not_change_prefix_fingerprint() {
+        let mut messages = vec![
+            Message::system("frozen"),
+            Message::compaction_summary("summary"),
+            Message::user("task"),
+        ];
+        let first = prefix_fingerprint(&messages, split_layout(&messages).prefix_end);
+        apply_tail_decorations(&mut messages, &["plan mode on".into()]);
+        let second = prefix_fingerprint(&messages, split_layout(&messages).prefix_end);
+        apply_tail_decorations(&mut messages, &["plan mode off".into()]);
+        let third = prefix_fingerprint(&messages, split_layout(&messages).prefix_end);
+        assert_eq!(first, second);
+        assert_eq!(second, third);
+    }
+
+    #[test]
+    fn classify_same_prefix_as_none() {
+        assert_eq!(
+            classify_prefix_break(Some("aaa"), Some("aaa"), false, None),
+            PrefixCacheBreakKind::None
+        );
+    }
+
+    #[test]
+    fn classify_epoch_compaction_as_compact() {
+        assert_eq!(
+            classify_prefix_break(Some("aaa"), Some("bbb"), true, Some("compaction")),
+            PrefixCacheBreakKind::Compact
+        );
+    }
+
+    #[test]
+    fn classify_prefix_change_without_epoch_as_injected_resize() {
+        assert_eq!(
+            classify_prefix_break(Some("aaa"), Some("bbb"), false, None),
+            PrefixCacheBreakKind::InjectedResize
+        );
+    }
+}

--- a/crates/context/src/lib.rs
+++ b/crates/context/src/lib.rs
@@ -6,6 +6,7 @@ mod engine;
 mod event_handler;
 mod events;
 mod hooks;
+mod layout;
 mod input_ladder;
 mod memory_store;
 mod segment_store;
@@ -49,6 +50,10 @@ pub use engine::{
     ContextDeps, ContextEngine, ContextObservation, ContextUsageUpdate, ForcedCompactResult,
     InjectedSource, OverflowHandleResult, PrefireClientFactory, PrepareStepResult,
     ProjectionExplain, StepContext, ToolOutputProvenance,
+};
+pub use layout::{
+    apply_tail_decorations, classify_prefix_break, content_is_reminder, is_step_decoration,
+    prefix_fingerprint, split_layout, PrefixCacheBreakKind, PrefixCacheExplain, ProjectionLayout,
 };
 pub use event_handler::{
     write_compaction_segment_via, ContextEventHandler, EventOutcome, NoopContextEventHandler,

--- a/crates/core/src/context_hooks.rs
+++ b/crates/core/src/context_hooks.rs
@@ -4,13 +4,23 @@ use zene_context::ContextHooks;
 use zene_session::{SessionRecord, TodoStatus};
 use zene_tools::{BackgroundTask, BackgroundTaskKind, BackgroundTaskStatus};
 
+use crate::plan_mode::plan_mode_tail_section;
+
 pub struct ZeneContextHooks {
     sections: Vec<String>,
 }
 
 impl ZeneContextHooks {
-    pub fn new(session: &SessionRecord, background_tasks: &[BackgroundTask]) -> Self {
+    pub fn new(
+        session: &SessionRecord,
+        background_tasks: &[BackgroundTask],
+        plan_active: bool,
+    ) -> Self {
         let mut sections = Vec::new();
+
+        if let Some(plan) = plan_mode_tail_section(plan_active) {
+            sections.push(plan.to_string());
+        }
 
         let actionable: Vec<_> = session
             .todos
@@ -52,6 +62,10 @@ impl ZeneContextHooks {
 
 impl ContextHooks for ZeneContextHooks {
     fn compaction_reminder_sections(&self) -> Vec<String> {
+        self.sections.clone()
+    }
+
+    fn step_tail_decorations(&self) -> Vec<String> {
         self.sections.clone()
     }
 }

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
-use zene_context::{InjectedSource, ToolOutputProvenance};
+use zene_context::{InjectedSource, PrefixCacheExplain, ToolOutputProvenance};
 use zene_llm::TokenUsage;
 
 use zene_turn::{
-    EventSequence, ProjectionInjectedSource, ProjectionToolOutput, RuntimeEvent,
-    RuntimeEventHandler, RuntimeEventKind, SessionId, StepId, ToolCallId, TurnId,
+    EventSequence, ProjectionInjectedSource, ProjectionPrefixCache, ProjectionToolOutput,
+    RuntimeEvent, RuntimeEventHandler, RuntimeEventKind, SessionId, StepId, ToolCallId, TurnId,
 };
 
 pub type EventHandler = Arc<dyn Fn(AgentEvent) + Send + Sync>;
@@ -142,6 +142,7 @@ pub fn runtime_event_handler(
                 delivery_tail_start,
                 estimate_tokens,
                 context_epoch,
+                prefix_cache,
             } => (
                 current_turn,
                 current_step,
@@ -184,6 +185,15 @@ pub fn runtime_event_handler(
                     delivery_tail_start: *delivery_tail_start,
                     estimate_tokens: *estimate_tokens,
                     context_epoch: *context_epoch,
+                    prefix_cache: ProjectionPrefixCache {
+                        prefix_end: prefix_cache.prefix_end,
+                        body_end: prefix_cache.body_end,
+                        tail_decoration_count: prefix_cache.tail_decoration_count,
+                        prefix_fingerprint: prefix_cache.prefix_fingerprint.clone(),
+                        break_kind: prefix_cache.break_kind.clone(),
+                        cached_tokens: prefix_cache.cached_tokens,
+                        unchanged_reprocessed_est: prefix_cache.unchanged_reprocessed_est,
+                    },
                 },
             ),
             AgentEvent::TurnEnd { turn_id, steps } => (
@@ -284,6 +294,7 @@ pub enum AgentEvent {
         delivery_tail_start: Option<usize>,
         estimate_tokens: u32,
         context_epoch: u64,
+        prefix_cache: PrefixCacheExplain,
     },
     TurnEnd {
         turn_id: TurnId,
@@ -360,6 +371,15 @@ mod tests {
             delivery_tail_start: None,
             estimate_tokens: 128,
             context_epoch: 2,
+            prefix_cache: PrefixCacheExplain {
+                prefix_end: 1,
+                body_end: 3,
+                tail_decoration_count: 0,
+                prefix_fingerprint: Some("abc".into()),
+                break_kind: "none".into(),
+                cached_tokens: None,
+                unchanged_reprocessed_est: None,
+            },
         });
 
         let events = collected.lock().unwrap();
@@ -392,6 +412,7 @@ mod tests {
                 delivery_tail_start,
                 estimate_tokens,
                 context_epoch,
+                prefix_cache,
             } => {
                 assert_eq!(*source_message_count, 4);
                 assert_eq!(*projected_message_count, 3);
@@ -416,6 +437,7 @@ mod tests {
                 assert_eq!(*delivery_tail_start, None);
                 assert_eq!(*estimate_tokens, 128);
                 assert_eq!(*context_epoch, 2);
+                assert_eq!(prefix_cache.break_kind, "none");
             }
             other => panic!("unexpected runtime event: {other:?}"),
         }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -52,7 +52,7 @@ use crate::tool_executor::{DefaultToolExecutor, ToolExecutorDeps};
 pub use agent_builder::AgentBuilder;
 pub use events::{emit_event, runtime_event_handler, AgentEvent, EventHandler};
 pub use plan_mode::PlanApprovalPrompter;
-use plan_mode::{build_effective_system_prompt, tool_visible_in_definitions};
+use plan_mode::{tool_visible_in_definitions};
 pub use runtime::RuntimeHandle;
 pub use subagent::{run_subagent, ChatBackend, CoreSubagentRunner};
 pub use tool_dedup::{append_reminder, ToolDedup};
@@ -214,7 +214,7 @@ impl Agent {
             }
         };
         if should_sync {
-            self.sync_plan_mode_system();
+            self.session.record_mode_changed("plan");
             emit_event(
                 handler,
                 AgentEvent::ModeChanged {
@@ -235,7 +235,7 @@ impl Agent {
             }
         };
         if should_sync {
-            self.sync_plan_mode_system();
+            self.session.record_mode_changed("default");
             emit_event(
                 handler,
                 AgentEvent::ModeChanged {
@@ -251,13 +251,6 @@ impl Agent {
             return true;
         }
         self.plan_mode.lock().is_tool_allowed(tool_name)
-    }
-
-    fn sync_plan_mode_system(&mut self) {
-        let active = self.is_plan_mode_active();
-        let effective = build_effective_system_prompt(&self.system_prompt, active);
-        self.session.set_system_message(&effective);
-        let _event = self.context.on_system_prefix_changed("plan_mode");
     }
 
     fn tool_definitions_for_llm(&self) -> Vec<zene_llm::ToolDefinition> {
@@ -358,7 +351,11 @@ impl Agent {
         let tools = self.tool_definitions_for_llm();
         let estimator = self.token_estimator();
         let background_tasks = self.background.lock().list();
-        let hooks = context_hooks::ZeneContextHooks::new(&self.session, &background_tasks);
+        let hooks = context_hooks::ZeneContextHooks::new(
+            &self.session,
+            &background_tasks,
+            self.is_plan_mode_active(),
+        );
         let compaction_config = context_config::context_compaction_config(&self.config.compaction);
         let mut handler = context_events::AgentContextHandler::new(
             self.context_model.as_ref(),
@@ -481,6 +478,22 @@ impl Agent {
                     .map(|start| start.to_string())
                     .unwrap_or_else(|| "-".into()),
                 explain.estimate_tokens,
+            ),
+            format!(
+                "prefix_cache: break={} prefix_end={} tail={} cached={} reprocessed_est={}",
+                explain.prefix_cache.break_kind,
+                explain.prefix_cache.prefix_end,
+                explain.prefix_cache.tail_decoration_count,
+                explain
+                    .prefix_cache
+                    .cached_tokens
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "-".into()),
+                explain
+                    .prefix_cache
+                    .unchanged_reprocessed_est
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "-".into()),
             ),
         ]);
         if water.auto_compact_suppressed {
@@ -823,7 +836,11 @@ impl Agent {
         let tools = self.tool_definitions_for_llm();
         let estimator = self.token_estimator();
         let background_tasks = self.background.lock().list();
-        let hooks = context_hooks::ZeneContextHooks::new(&self.session, &background_tasks);
+        let hooks = context_hooks::ZeneContextHooks::new(
+            &self.session,
+            &background_tasks,
+            self.is_plan_mode_active(),
+        );
         let compaction_config = context_config::context_compaction_config(&self.config.compaction);
         let mut handler = context_events::AgentContextHandler::new(
             self.context_model.as_ref(),
@@ -871,6 +888,7 @@ impl Agent {
                 delivery_tail_start: prepared.explain.delivery_tail_start,
                 estimate_tokens: prepared.explain.estimate_tokens,
                 context_epoch: prepared.explain.context_epoch,
+                prefix_cache: prepared.explain.prefix_cache.clone(),
             },
         );
         let step = prepared.step;
@@ -987,7 +1005,11 @@ impl Agent {
         self.sync_todos_to_session();
         let estimator = self.token_estimator();
         let background_tasks = self.background.lock().list();
-        let hooks = context_hooks::ZeneContextHooks::new(&self.session, &background_tasks);
+        let hooks = context_hooks::ZeneContextHooks::new(
+            &self.session,
+            &background_tasks,
+            self.is_plan_mode_active(),
+        );
         let compaction_config = context_config::context_compaction_config(&self.config.compaction);
         let mut handler = context_events::AgentContextHandler::new(
             self.context_model.as_ref(),
@@ -1165,7 +1187,6 @@ impl Agent {
             for mode_id in &result.mode_changes {
                 self.session.record_mode_changed(mode_id);
             }
-            self.sync_plan_mode_system();
         }
         for decision in &result.permission_decisions {
             self.session.record_permission_decision(

--- a/crates/core/src/plan_mode.rs
+++ b/crates/core/src/plan_mode.rs
@@ -8,9 +8,10 @@ use serde::Deserialize;
 use zene_config::sessions_dir;
 use zene_tools::{PlanModeState, ToolResult};
 
-pub const PLAN_MODE_REMINDER: &str = r#"<system_reminder>
-You are in Plan mode. Only read-only tools (Read, Grep, Glob, Skill, WebSearch, FetchUrl) and ExitPlanMode are available. Do not use Write, Edit, Bash, or Task until you call ExitPlanMode with your plan and the user approves it.
-</system_reminder>"#;
+pub const PLAN_MODE_REMINDER_BODY: &str = "You are in Plan mode. Only read-only tools (Read, Grep, Glob, Skill, WebSearch, FetchUrl) and ExitPlanMode are available. Do not use Write, Edit, Bash, or Task until you call ExitPlanMode with your plan and the user approves it.";
+
+#[allow(dead_code)] // tagged form kept for tests; projection uses PLAN_MODE_REMINDER_BODY
+pub const PLAN_MODE_REMINDER: &str = "<system_reminder>\nYou are in Plan mode. Only read-only tools (Read, Grep, Glob, Skill, WebSearch, FetchUrl) and ExitPlanMode are available. Do not use Write, Edit, Bash, or Task until you call ExitPlanMode with your plan and the user approves it.\n</system_reminder>";
 
 pub type PlanApprovalPrompter =
     Arc<dyn Fn(&Path, &str) -> io::Result<bool> + Send + Sync>;
@@ -26,6 +27,7 @@ pub struct ExitPlanModeArgs {
     pub plan: String,
 }
 
+#[allow(dead_code)] // compatibility helper; live path uses plan_mode_tail_section
 pub fn plan_mode_system_suffix(active: bool) -> Option<&'static str> {
     if active {
         Some(PLAN_MODE_REMINDER)
@@ -34,6 +36,16 @@ pub fn plan_mode_system_suffix(active: bool) -> Option<&'static str> {
     }
 }
 
+/// Inner text for tail-projected plan decorations (not spliced into system).
+pub fn plan_mode_tail_section(active: bool) -> Option<&'static str> {
+    if active {
+        Some(PLAN_MODE_REMINDER_BODY)
+    } else {
+        None
+    }
+}
+
+#[allow(dead_code)] // old splice-into-system helper; do not use for new calls
 pub fn build_effective_system_prompt(base: &str, plan_active: bool) -> String {
     match plan_mode_system_suffix(plan_active) {
         Some(reminder) => format!("{base}\n\n{reminder}"),
@@ -188,6 +200,11 @@ mod tests {
     fn reminder_only_when_active() {
         assert!(plan_mode_system_suffix(true).is_some());
         assert!(plan_mode_system_suffix(false).is_none());
+        assert_eq!(plan_mode_tail_section(true), Some(PLAN_MODE_REMINDER_BODY));
+        assert!(plan_mode_tail_section(false).is_none());
+        let spliced = build_effective_system_prompt("base", true);
+        assert!(spliced.contains("base"));
+        assert!(spliced.contains("Plan mode"));
     }
 
     #[test]

--- a/crates/turn/src/events.rs
+++ b/crates/turn/src/events.rs
@@ -34,6 +34,17 @@ pub struct ProjectionInjectedSource {
     pub source: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProjectionPrefixCache {
+    pub prefix_end: usize,
+    pub body_end: usize,
+    pub tail_decoration_count: usize,
+    pub prefix_fingerprint: Option<String>,
+    pub break_kind: String,
+    pub cached_tokens: Option<u64>,
+    pub unchanged_reprocessed_est: Option<u64>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeEvent {
     pub sequence: EventSequence,
@@ -97,6 +108,7 @@ pub enum RuntimeEventKind {
         delivery_tail_start: Option<usize>,
         estimate_tokens: u32,
         context_epoch: u64,
+        prefix_cache: ProjectionPrefixCache,
     },
     TurnEnded {
         steps: u32,

--- a/crates/turn/src/lib.rs
+++ b/crates/turn/src/lib.rs
@@ -5,8 +5,8 @@ mod state;
 mod turn_loop;
 
 pub use events::{
-    EventSequence, ProjectionInjectedSource, ProjectionToolOutput, RuntimeEvent,
-    RuntimeEventHandler, RuntimeEventKind,
+    EventSequence, ProjectionInjectedSource, ProjectionPrefixCache, ProjectionToolOutput,
+    RuntimeEvent, RuntimeEventHandler, RuntimeEventKind,
 };
 pub use turn_loop::{
     run_turn_loop, ContextAssemblerPort, EventSinkPort, LegacyTurnPorts, ModelExecutorPort,

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -1,6 +1,6 @@
 # Zene Engine Notes
 
-Core agent loop lives in `crates/core`. This document tracks engine-level behaviors (turn flow, context, permissions) beyond the milestone checklist in [ROADMAP.md](./ROADMAP.md). For the Session-vs-Context architecture model, see [session-as-source-of-truth.md](./session-as-source-of-truth.md). For Context Engine projection-oriented next steps, see [context-engine-projection.md](./context-engine-projection.md). For AgentRuntime / Turn / ports and merged implementation waves, see [agent-runtime-optimization.md](./agent-runtime-optimization.md). For Pi agent-harness comparisons, see [pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md).
+Core agent loop lives in `crates/core`. This document tracks engine-level behaviors (turn flow, context, permissions) beyond the milestone checklist in [ROADMAP.md](./ROADMAP.md). For the Session-vs-Context architecture model, see [session-as-source-of-truth.md](./session-as-source-of-truth.md). For Context Engine projection-oriented next steps, see [context-engine-projection.md](./context-engine-projection.md). For prefix-cache layout (stable prefix vs tail decorations), see [context-engine-prefix-cache.md](./context-engine-prefix-cache.md). For AgentRuntime / Turn / ports and merged implementation waves, see [agent-runtime-optimization.md](./agent-runtime-optimization.md). For Pi agent-harness comparisons, see [pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md).
 
 ## Turn flow & steer
 

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -72,8 +72,8 @@ Config (`compaction` in `config.toml`):
 
 On provider context-overflow errors in `run_llm_step`:
 
-1. **First retry** — phase-1 truncate pass only (`apply_overflow_truncate_pass`)
-2. **Second retry** — full compaction pipeline (phases 1→3) with input ladder
+1. **First retry** — steps-first truncate of the **current turn** tool tail only (`apply_steps_truncate_pass`). Older history is left byte-stable for prefix cache.
+2. **Second retry** — full compaction pipeline (phases 1→3) with input ladder (`epoch++`, a legal cache break)
 
 Avoids paying for LLM summarize when truncation alone fixes the overflow.
 
@@ -85,7 +85,7 @@ Avoids paying for LLM summarize when truncation alone fixes the overflow.
 
 LLM summarize rebuilds history as:
 
-`system + last_user_query + recent_after_query + compaction_summary + optional <system-reminder> (todos + running background tasks)`
+`system + last_user_query + recent_after_query + compaction_summary`. Volatile `<system-reminder>` (todos, plan, background, memory) is **not** persisted into history; `project()` appends it at the request tail. See [context-engine-prefix-cache.md](./context-engine-prefix-cache.md).
 
 Tail selection snaps so assistant `tool_calls` are never split from their tool results. Summarizer input steps `verbatim → fitted → lossy` (`input_ladder.rs`): fitted shrinks bodies and drops oldest whole turns; lossy flattens tool results. Summaries shorter than **500** chars are rejected (retries, then hard fail — aligned with grok-build). Manual `/compact [hint]` forces summarize and writes compaction checkpoints.
 

--- a/docs/agent-components.md
+++ b/docs/agent-components.md
@@ -2,7 +2,7 @@
 
 目标：把 Zene 拆成**可独立发布、按需组合**的 crate，第三方 runtime 不必 fork `zene-core` 也能复用 compaction、tools、sandbox 等能力。
 
-相关文档：[context-engine.md](./context-engine.md)、[context-engine-projection.md](./context-engine-projection.md)（投影化优化）、[agent-inference-context.md](./agent-inference-context.md)、[session-as-source-of-truth.md](./session-as-source-of-truth.md)（Session 事实 vs Context 投影）、[agent-runtime-optimization.md](./agent-runtime-optimization.md)（Runtime / Turn / ports）、[pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md)（Pi Harness 启发）。
+相关文档：[context-engine.md](./context-engine.md)、[context-engine-projection.md](./context-engine-projection.md)（投影化优化）、[context-engine-prefix-cache.md](./context-engine-prefix-cache.md)（前缀稳定 / prefix cache）、[agent-inference-context.md](./agent-inference-context.md)、[session-as-source-of-truth.md](./session-as-source-of-truth.md)（Session 事实 vs Context 投影）、[agent-runtime-optimization.md](./agent-runtime-optimization.md)（Runtime / Turn / ports）、[pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md)（Pi Harness 启发）。
 
 ---
 

--- a/docs/agent-inference-context.md
+++ b/docs/agent-inference-context.md
@@ -215,4 +215,15 @@
 6. **vLLM**：prefix caching 已成熟；Agent 向 RFC（RetentionDirective、release_kv_cache、Mooncake、session_id/continuation_id）演进中。
 7. 详见上文「推理引擎备注（Session 续算与业界趋势）」。
 
+### 2026-08-13 — Prefix cache 布局（Agent 侧）
+
+参与：用户 ↔ Agent（本仓库 Cloud Agent）
+
+要点：
+
+1. 厂商 prefix cache 只认字节前缀；`epoch` / `session_id` 不能替代布局约束。
+2. 一次 DeepSeek 诊断：msg[1] 注入块 resize 导致约 52k 未变更 token 重算。
+3. Zene 优先兑现本文 **A 档**（full messages + 稳定前缀）；布局契约见 [context-engine-prefix-cache.md](./context-engine-prefix-cache.md)。
+4. Compact 仍是合法的一次 miss；要消灭的是 system / 注入块 / 旧 tool 的反复 resize。
+
 ### （在此追加下一次讨论）

--- a/docs/context-engine-prefix-cache.md
+++ b/docs/context-engine-prefix-cache.md
@@ -1,0 +1,248 @@
+# Context Engine：前缀稳定与 Prefix Cache
+
+> **目标**：把「发给模型的字节前缀尽量不变」提升为与 compaction 同级的投影约束。  
+> 下一杠杆不是再堆压缩算法，而是停止在稳定前缀和历史中间插入、改写会变长的块。
+
+本文是 [context-engine-projection.md](./context-engine-projection.md) 在 **cache 友好布局** 上的续篇，衔接 [agent-inference-context.md](./agent-inference-context.md)（`session_id` / `epoch` / `cached_tokens`）和 [ENGINE.md](./ENGINE.md)（compaction、memory、system reminder）。控制面仍见 [agent-runtime-optimization.md](./agent-runtime-optimization.md)；本文不改 Turn / Permission / ACP 语义。
+
+**状态**：方案稿（2026-08-13）。Wave 9–12 已把 Session 事实与 Context 投影分开；prefix cache 的字节稳定性尚未成为硬契约。
+
+---
+
+## 1. 问题
+
+Provider prefix cache（DeepSeek / OpenAI 等）只认一件事：
+
+> 从 prompt 左侧起，连续多少 token 与上一请求 **字节级相同**。
+
+`session_id`、`context_epoch`、`prefix_hash` 是给网关 / 引擎的协议信号，**不直接决定** 厂商 cache 是否命中。epoch 没变但 msg[1] 变长，后面整段历史仍会 miss。
+
+一次 DeepSeek-V4-Pro 多轮 Agent 诊断（11 次 LLM call，最终窗口 56.2k）量化了成本：
+
+| 现象 | 数字 |
+|------|------|
+| 因 system 或注入块 resize 打断 cache | 4 / 11 次调用 |
+| 注入块本身 | 698 token（`<agent_documents_index>`） |
+| 被打断后「其实没变却重算」的 token | **52.0k** |
+| 全会话累计重算 | 121.2k |
+| 注入块 resize 次数 | 3（贡献约 51.6k 浪费） |
+| system prompt resize | 1 次 |
+
+最大的罪魁不是 context 太大（只用了 1M 窗口的 5%），而是 **可变索引块插在 system 之后、对话历史之前**。位置比体积更贵：698 token 的 resize 作废了后面几十 k 的 assistant + tool。
+
+后面几次调用前缀一旦稳住，命中接近完美（含 identical payload、0 重算）。说明 Agent 场景下 prefix cache **可以** 很好；前提是不要反复打断。
+
+对 Zene 的直接推论：
+
+```text
+可变内容的位置 ≫ 可变内容的大小
+意外打断 ≫ 一次合法 compact
+epoch 正确 ≠ 前缀字节稳定
+```
+
+Compaction 是 **允许的一次打断**（`epoch++`，付一次账，换新稳定前缀）。要防的是同一会话里 system / 注入块 / 旧 tool 被反复 resize。
+
+---
+
+## 2. 现状：已经做对的，和还没钉死的
+
+### 已经做对
+
+与这张诊断图对齐的骨架已经在：
+
+- Session 是事实、Context 是投影（[session-as-source-of-truth.md](./session-as-source-of-truth.md)）。
+- `observe → commit → project`；`stable_system_boundary` / `pinned_boundary` 标记可缓存前缀。
+- Session 开始把 memory 写入 system 的 `<memory-context>`，意图是 KV-friendly 前缀（[ENGINE.md](./ENGINE.md)）。
+- Phase D：todos / 后台任务等每步装饰 **尽量不 bump epoch**（[context-engine-projection.md](./context-engine-projection.md)）。
+- Compact 后 `<system-reminder>` 挂在 assemble 结果的 **尾巴**（`system + last_user + recent + summary + reminder`）。
+- 出站带 `prefix_hash` / `context_epoch`；`record_step_usage` 已能打 `cached_tokens` 日志。
+- Tool 超长输出 spill 成 handle，避免把大 payload 反复塞进后续请求。
+
+### 缺口
+
+Phase D 解决的是「哪些注入算事实、哪些不 bump epoch」。厂商 cache 不看 epoch，只看拼出来的 `messages[]` 左侧有没有动。
+
+因此仍可能出现「协议层稳定、字节前缀抖动」：
+
+| 当前行为 | 对应图中的打断 | 说明 |
+|----------|----------------|------|
+| Plan mode 把 reminder **拼进 system**（`build_effective_system_prompt`） | Call 2 system resized | 进出 Plan 都会改整段前缀 |
+| Overflow / phase-1 对 **旧 tool** 原地 truncate | 历史中间改字节 | 与注入块 resize 同类：后面全部 miss |
+| 未来若把目录索引 / RAG / documents 做成 msg[1] | Call 3/5/6 | 体积可以很小，位置足以毁掉 cache |
+| Memory 若中途回写 system | Call 2 | 开工注入一次是对的；变长后再改 system 就不是 |
+| `ProjectionExplain` 无 cache 断点 | 看不见 52k 浪费 | 只有日志里的 `cache_pct`，Console / ACP 无法画打断图 |
+
+`ensure_system_message` 在已有 system 时是幂等的（不覆盖）；真正改前缀的是 `update_system_prefix` 和「改历史中间某条 message」。Workspace / skills 目前在 `AgentBuilder` 开工时编进 system，这是对的，**不要**在 Agent 改文件后再刷新进 system。
+
+---
+
+## 3. 目标布局（硬契约）
+
+`project()` 产出的 LLM messages 必须遵守：
+
+```text
+[冻结 system 基座] [pinned / compaction 边界] [只追加的对话 + 工具] [本步装饰]
+        ← 稳定前缀：变了才 epoch++ →           ← 只往尾部涨 →         ← 只放尾巴 →
+```
+
+含义：
+
+- **冻结 system**：session 开始时写入的 base prompt、workspace 快照、skills 列表、`<memory-context>`。之后默认不再改长度。模式切换、todos、本步提示 **不得** 再拼进这一段。
+- **Pinned 边界**：`stable_system_boundary`（system + 已提交的 compaction summary）。越过这条边界插入变长块，视为 bug。
+- **只追加的对话体**：user / assistant / tool 只 append。需要丢掉旧细节时走 compaction 事件（合法 `epoch++`），而不是改已发出去的中间消息。
+- **本步装饰**：plan reminder、todos、后台任务、去重提示、本步 RAG 片段 → 始终在 **最后一条**（或最后一组）`<system-reminder>`。不 bump epoch。
+
+禁止的形状（图中的 `<agent_documents_index>`）：
+
+```text
+system
+user/injected: <index 本次 698 tok，下次 900 tok>   ← 打断点
+… 后面几十 k 历史全部 miss
+```
+
+允许的两种索引 / RAG 放置：
+
+- 开工时写入冻结 system（之后不再变长；必要时定长槽 / 截断到上限）。
+- 仅作为 **本步 tail** 装饰（不影响已缓存前缀）。
+
+Compact 后的目标形状与现在 assemble 一致，只是把「reminder 在尾」从实现细节升级成契约：
+
+```text
+system（冻结）
+compaction_summary（新 pinned，epoch++ 一次）
+recent tail（只追加）
+<system-reminder>（本步才变）
+```
+
+---
+
+## 4. 分阶段落地
+
+不改默认 compact 阈值，不引入新的 compress phase。验收以「意外 cache 打断次数」和 `cached_tokens` 为主，而不是更激进的 summarize。
+
+### Phase P — 布局契约（投影层）
+
+在 `zene-context` 的 `project()` / `assemble_outbound` 把三区写进类型或断言，而不是注释：
+
+- `PrefixZone`：`[..stable_system_boundary]`
+- `BodyZone`：边界到最后一个非装饰 message
+- `TailDecorations`：plan / todos / bg / dedup / 本步检索
+
+`ProjectionExplain` 增加 zone 边界（index 或 token 估计），供测试断言「装饰从未出现在 PrefixZone / BodyZone 中间」。
+
+**验收**：单测覆盖「todos 变了、plan 开关了，PrefixZone 字节不变」；故意把装饰插到 msg[1] 的路径编不过或测试失败。
+
+### Phase Q — 停掉已知前缀改写
+
+**Plan mode**：`build_effective_system_prompt` 不再把 `PLAN_MODE_REMINDER` 拼进 system。模式变更继续记 Session 事件；投影时把 reminder 放进 `TailDecorations`。进出 Plan 不得 `epoch++`（除非同时发生 compact / 真正的 system 基座变更）。
+
+**Overflow truncate**：优先 `apply_steps_truncate_pass`（只截 **当前 user 之后** 的 tool，属于 tail）。对 compactable **旧前缀** 的原地 truncate 视为 cache-hostile；能靠 steps-first 或一次完整 compact 解决就不要改更早的消息。完整 compact 仍是合法打断。
+
+**Memory**：保持开工写入 system 一次。当日新笔记不回写 system；若本步必须可见，走 tail reminder。下一 session 再把更新后的 memory 编进新的冻结前缀。
+
+**System 快照**：workspace overview / skills / AGENTS.md 只在 session start（及明确的「用户要求刷新上下文」）重编。Agent 自己 Write/Edit 文件不得隐式刷新 system。
+
+**验收**：进出 Plan、更新 todos、steps-first truncate 三条路径上，`prefix_hash`（或 PrefixZone fingerprint）与上一 LLM call 相同；仅 compact / 用户刷新 / 首次 publish 允许变化。
+
+### Phase R — Cache 断点可观测
+
+`cached_tokens` 已从 provider 回来，但只进日志。升到投影 / RuntimeEvent，才能画出与诊断图同类的打断。
+
+建议字段（可放进 `ProjectionExplain` 或并列的 `PrefixCacheExplain`）：
+
+```text
+prompt_tokens
+cached_tokens
+prefix_zone_tokens          // 估计或上次 publish 的 pinned 长度
+break_kind                  // none | compact | system_resize | injected_resize | body_mutate | unknown
+unchanged_reprocessed_est   // max(0, previous_cached_or_prefix - new_cached) 的保守估计
+```
+
+ACP `projection_update` / Cloud 时间线带上 `cached_tokens` 与 `break_kind`。Console 不需要第一版就做满彩图；能在 Run 上看到「这次 miss 是 compact 还是注入块」即可。
+
+**验收**：用夹具模拟「system 变长 vs 只追加 tool」两条请求，explain 能区分 `system_resize` 与 `none`；真实 provider 有 `cached_tokens` 时写入 session/usage，缺字段时 `break_kind=unknown` 且不谎报命中。
+
+### Phase S — 未来注入的护栏
+
+任何新的「给模型看的目录 / 代码索引 / RAG / 附件清单」必须声明 zone：`FrozenPrefix` 或 `TailDecorations`。默认拒绝 `BodyInsert`。文档索引类内容若放进 FrozenPrefix，必须有 **最大长度**（超出则截断或降级为 tool），禁止无界 resize。
+
+这项可以是 `project()` 的 debug assert + 一条 CONTRIBUTING / 本文件的约定，不必先做新存储格式。
+
+---
+
+## 5. 和现有分层的关系
+
+```text
+L0 Session Events     事实；compact 追加 CompactionApplied，不删旧事件
+L1 Active Branch      当前叶到根
+L2 Context Plan       本文件新增：三区布局 + 谁允许改 PrefixZone
+L3 Provider Request   字节前缀稳定性在这里兑现；epoch 只在 PrefixZone 变时 ++
+```
+
+[agent-inference-context.md](./agent-inference-context.md) 的三档收益仍然成立：
+
+- **A. 仅 Agent**：full messages + 稳定前缀 → 厂商 prefix cache 的大头。**本文优先兑现 A。**
+- **B. 网关 delta**：拼出与 A 相同的 full prompt 才有意义；前缀抖动时 delta 也救不了 cache。
+- **C. 引擎 KV 续算**：依赖 `(session_id, epoch)`；PrefixZone 乱跳会把续算打成反复 full prefill。
+
+A 档做不稳，B/C 都是空转。
+
+Water level / auto-compact 继续用 `max(usage, estimate)`。Cache 命中变好之后，**计费 token** 会下降，但 `prompt_tokens` 窗口水位不变；不要因为 `cached_tokens` 高就推迟 compact。Compact 触发仍看窗口占用，不看 cache 命中率。
+
+---
+
+## 6. 非目标
+
+- 新的 compaction 阶段或替换 summarize 模型。
+- 为对齐某张诊断图而改 Session 存储格式。
+- 把 permission / MCP / Turn 控制面迁进 ContextEngine。
+- 第一版就做 Console 全彩 cache 条形图（Phase R 先字段，图随后）。
+- 假设所有 BYOK 供应商都返回 `cached_tokens`（缺失时降级，不阻塞投影）。
+
+---
+
+## 7. 建议实现落点
+
+| 变更 | 主要位置 |
+|------|----------|
+| 三区布局 + 断言 | `crates/context`：`project` / `assemble` / `ProjectionExplain` |
+| Plan reminder 移出 system | `crates/core/src/plan_mode.rs`；投影注入放 `zene-context` 或 core `context_hooks` |
+| Overflow 少改旧 body | `crates/context/src/compaction.rs`（`apply_overflow_truncate_pass` 策略） |
+| Memory 不回写 system | `crates/context` memory 注入 + `AgentBuilder` 开工路径 |
+| `cached_tokens` 进 explain / 事件 | `ContextEngine::record_step_usage` → RuntimeEvent / ACP `projection_update` |
+| 文档约定 | 本文 Phase S；新注入点 code review 对照三区 |
+
+`zene-core` 仍是 composition root。布局契约属于 `zene-context`，避免只在 Agent 里约定、第三方 runtime 绕过。
+
+---
+
+## 8. 一句话
+
+> **Compaction 负责窗口装得下；前缀稳定负责装进去的东西能被 cache 住。**  
+> 可变块只许冻结在开工 system 里，或挂在请求尾巴上——不许再放进历史中间。
+
+---
+
+## 相关文档
+
+- [session-as-source-of-truth.md](./session-as-source-of-truth.md) — Session 事实 vs Context 投影
+- [context-engine.md](./context-engine.md) — ContextEngine API、epoch、delta、publish
+- [context-engine-projection.md](./context-engine-projection.md) — observe/commit/project 与 Phase D 注入规则
+- [agent-inference-context.md](./agent-inference-context.md) — 与推理层的 session / cache / 续算
+- [ENGINE.md](./ENGINE.md) — turn、compaction、memory、sandbox 行为
+- [agent-runtime-optimization.md](./agent-runtime-optimization.md) — 控制面；本文不替代
+
+---
+
+## 讨论记录
+
+### 2026-08-13 — 初稿
+
+参与：用户 ↔ Agent（本仓库 Cloud Agent）
+
+要点：
+
+- 以 DeepSeek-V4-Pro 一次 11 call 的 context 组成 + prefix cache 诊断为动机：注入块 698 tok 导致约 52k 未变更 token 重算。
+- 确认现有 SoT / epoch / memory-in-system / tail reminder 方向正确，但 **布局尚未成为硬契约**。
+- 优化顺序定为：投影三区 → 拆除 Plan/overflow/memory 的前缀改写 → `cached_tokens` 可观测 → 未来注入护栏。
+- 明确 compact 仍是合法的一次 `epoch++`；意外 resize 才是要消灭的 miss。

--- a/docs/context-engine-prefix-cache.md
+++ b/docs/context-engine-prefix-cache.md
@@ -5,7 +5,7 @@
 
 本文是 [context-engine-projection.md](./context-engine-projection.md) 在 **cache 友好布局** 上的续篇，衔接 [agent-inference-context.md](./agent-inference-context.md)（`session_id` / `epoch` / `cached_tokens`）和 [ENGINE.md](./ENGINE.md)（compaction、memory、system reminder）。控制面仍见 [agent-runtime-optimization.md](./agent-runtime-optimization.md)；本文不改 Turn / Permission / ACP 语义。
 
-**状态**：方案稿（2026-08-13）。Wave 9–12 已把 Session 事实与 Context 投影分开；prefix cache 的字节稳定性尚未成为硬契约。
+**状态**：落地中（2026-08-13）。Phase P 布局契约、Phase Q 已知前缀改写、Phase R 观测字段已开始进入 `zene-context` / ACP `projection_update`。
 
 ---
 

--- a/docs/context-engine-projection.md
+++ b/docs/context-engine-projection.md
@@ -278,7 +278,7 @@ function project_llm(path, policy):
 **epoch 策略收紧（对齐 gateway delta / cache）：**
 
 - 只有 **稳定 prefix 集合** 变化才 `epoch++`（system 基座、compaction 边界、pinned 区）
-- 每步都变的 reminder（todos 计数、bg task）**尽量不 bump epoch**，避免 cache 抖动
+- 每步都变的 reminder（todos 计数、bg task）**尽量不 bump epoch**，避免 cache 抖动；它们还必须放在请求 **尾巴**，不能插进稳定前缀和历史中间（见 [context-engine-prefix-cache.md](./context-engine-prefix-cache.md)）
 - `ProjectionExplain.injected` 标明本步装饰，供 UI / ACP 展示「模型额外看到了什么」；当前已识别 `compaction_summary` 和 `system_reminder`
 - RuntimeEvent / ACP `projection_update` 当前暴露 `sourceEventCount`、`activeEventCount`、`cacheDriftDetected`、分支路径、fallback、`injected`、`delivery` 和 `deliveryTailStart`
 - 完整事件日志优先于 materialized `messages` cache；cache drift 只进入 explain，不覆盖 event-backed projection；仅 legacy / incomplete event log 触发兼容 fallback
@@ -389,6 +389,7 @@ engine.record_step_usage(usage, /* … */)?;
 | **已完成** | 注入物分类 + epoch / delta 规则 | 与 gateway publish / `tail_start` 对齐 |
 | **剩余** | legacy fallback 与历史格式清理 | 仅清理可无损迁移的兼容代码 |
 | **剩余** | UI / replay 与 LLM 共享 active path 查询 | 按 Console 产品需求继续扩展 |
+| **下一杠杆** | 前缀稳定与 prefix cache | 见 [context-engine-prefix-cache.md](./context-engine-prefix-cache.md)；不改 compact 算法 |
 
 ### 6.1 与 AgentRuntime 合并后的 Wave 映射
 
@@ -448,6 +449,7 @@ engine.record_step_usage(usage, /* … */)?;
 | [session-as-source-of-truth.md](./session-as-source-of-truth.md) | 心智模型：Session 事实 vs Context 投影 |
 | [context-engine.md](./context-engine.md) | 已实现 crate 边界、`prepare_step`、gateway / delta |
 | [agent-inference-context.md](./agent-inference-context.md) | epoch、delta、与推理层协议 |
+| [context-engine-prefix-cache.md](./context-engine-prefix-cache.md) | 投影三区布局与 prefix cache（Phase D 的续篇） |
 | [ENGINE.md](./ENGINE.md) | compaction 阶段、water、steer 等运行时行为 |
 | [agent-components.md](./agent-components.md) | 可组装组件栈与发布边界 |
 | [agent-runtime-optimization.md](./agent-runtime-optimization.md) | Runtime / Turn / ports；Merged Wave |
@@ -461,7 +463,7 @@ engine.record_step_usage(usage, /* … */)?;
 
 > **Context Engine 当前已是以 Session 事件事实为输入、以 active-path projection 为默认路径、以 `ProjectionExplain` 解释每一步模型视图的投影引擎；剩余优化在兼容清理、组合边界与外部生命周期。**
 
-算法层已具备优势；下一杠杆不是继续堆 compression phase，而是收口 legacy fallback、Agent-specific runtime wiring 与部署级恢复边界。
+算法层已具备优势；Context 侧下一杠杆不是继续堆 compression phase，而是 [前缀稳定 / prefix cache](./context-engine-prefix-cache.md)。投影文档自身的剩余工作仍是 legacy fallback、Agent-specific runtime wiring 与部署级恢复边界。
 
 ---
 

--- a/docs/context-engine.md
+++ b/docs/context-engine.md
@@ -4,7 +4,7 @@
 
 相关实现：`crates/context/`（`zene-context`）、`crates/llm/`（协议字段）、`crates/core/`（Agent orchestrator）。
 
-可组装组件总览见 [agent-components.md](./agent-components.md)。Session 与 Context 的边界心智模型见 [session-as-source-of-truth.md](./session-as-source-of-truth.md)。下一阶段投影化优化见 [context-engine-projection.md](./context-engine-projection.md)。Runtime / Turn 控制面与合并 Wave 见 [agent-runtime-optimization.md](./agent-runtime-optimization.md)。Pi Harness 对照见 [pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md)。
+可组装组件总览见 [agent-components.md](./agent-components.md)。Session 与 Context 的边界心智模型见 [session-as-source-of-truth.md](./session-as-source-of-truth.md)。下一阶段投影化优化见 [context-engine-projection.md](./context-engine-projection.md)。前缀稳定与 prefix cache 见 [context-engine-prefix-cache.md](./context-engine-prefix-cache.md)。Runtime / Turn 控制面与合并 Wave 见 [agent-runtime-optimization.md](./agent-runtime-optimization.md)。Pi Harness 对照见 [pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md)。
 
 ---
 

--- a/docs/session-as-source-of-truth.md
+++ b/docs/session-as-source-of-truth.md
@@ -372,5 +372,6 @@ Wave 12    Safe resume 与 Cloud RuntimeClient                 已完成 reconne
 - [context-engine-projection.md](./context-engine-projection.md) — Context 投影化优化路线
 - [agent-runtime-optimization.md](./agent-runtime-optimization.md) — AgentRuntime / Turn / ports（控制面）
 - [agent-inference-context.md](./agent-inference-context.md) — 推理上下文装配
+- [context-engine-prefix-cache.md](./context-engine-prefix-cache.md) — 投影布局与 prefix cache
 - [agent-components.md](./agent-components.md) — 可组装组件栈
 - [pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md) — Pi Agent Harness 对照与启发总览


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Context Engine 按 `docs/context-engine-prefix-cache.md` 落地前缀稳定，避免可变注入块打断 provider prefix cache。

`project()` 把 todos / plan / 后台任务挂在请求尾巴，不再改冻结 system。进出 Plan 只记 Session 事件，不 `epoch++`。Overflow 先截当前 turn 的 tool 尾巴，截不掉再完整 compact。Compact 快照不再写入 volatile reminder。`ProjectionExplain` 和 ACP `projection_update._meta.prefixCache` 带上 zone 边界、`breakKind`、`cachedTokens`。

相关测试：`zene-context` layout / projection、`zene-core` plan mode、ACP projection_update。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26fba7b9-7080-4260-a190-8c2f10863683?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26fba7b9-7080-4260-a190-8c2f10863683&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

