### PR TITLE
feat: Cloud projection/plan payload 使用产品字段

### DIFF
--- a/cloud/crates/runtime-client/src/lib.rs
+++ b/cloud/crates/runtime-client/src/lib.rs
@@ -126,10 +126,10 @@ pub enum RuntimeCommand {
 
 /// A runtime notification with the stable fields persisted by the worker.
 ///
-/// `event_type` is the product kind. Timeline, control, usage, and state
-/// kinds store a denormalized product payload. Other frames keep the original
-/// ACP JSON. Records written before this change still have ACP JSON; Console
-/// falls back to `params.update`.
+/// `event_type` is the product kind. Classified kinds store a denormalized
+/// product payload. Unrecognized frames stay `acp` with the original ACP JSON.
+/// Records written before this change still have ACP JSON; Console falls back
+/// to `params.update`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeNotification {
     pub source_event_id: String,
@@ -236,6 +236,9 @@ fn product_payload(kind: RuntimeEventKind, raw: &Value) -> Value {
         RuntimeEventKind::SessionStarted => session_started_product(raw),
         RuntimeEventKind::StateChanged => state_product(raw),
         RuntimeEventKind::UsageUpdate => usage_product(raw),
+        RuntimeEventKind::ProjectionReady => projection_product(raw),
+        RuntimeEventKind::Plan => plan_product(raw),
+        RuntimeEventKind::AvailableCommands => commands_product(raw),
         _ => raw.clone(),
     }
 }
@@ -302,6 +305,30 @@ fn usage_product(raw: &Value) -> Value {
         ));
     }
     Value::Object(map)
+}
+
+fn projection_product(raw: &Value) -> Value {
+    let Some(update) = raw.pointer("/params/update") else {
+        return raw.clone();
+    };
+    match update.get("_meta") {
+        Some(meta) if meta.is_object() => meta.clone(),
+        _ => serde_json::json!({}),
+    }
+}
+
+fn plan_product(raw: &Value) -> Value {
+    let Some(update) = raw.pointer("/params/update") else {
+        return raw.clone();
+    };
+    Value::Object(take_fields(update, &["entries"]))
+}
+
+fn commands_product(raw: &Value) -> Value {
+    let Some(update) = raw.pointer("/params/update") else {
+        return raw.clone();
+    };
+    Value::Object(take_fields(update, &["availableCommands"]))
 }
 
 fn take_fields(update: &Value, keys: &[&str]) -> serde_json::Map<String, Value> {
@@ -737,24 +764,93 @@ mod tests {
     }
 
     #[test]
-    fn unclassified_session_updates_keep_original_payload() {
-        let cases = [
-            ("projection_update", "projection_ready"),
-            ("unknown_update", "acp"),
-        ];
-        for (session_update, event_type) in cases {
-            let raw = serde_json::json!({
-                "jsonrpc": "2.0",
-                "method": "session/update",
-                "params": {
-                    "sessionId": "session-1",
-                    "update": { "sessionUpdate": session_update }
+    fn projection_ready_lifts_meta_to_product_payload() {
+        let raw = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "update": {
+                    "sessionUpdate": "projection_update",
+                    "_meta": {
+                        "sourceMessageCount": 4,
+                        "projectedMessageCount": 3,
+                        "delivery": "strict",
+                        "contextEpoch": 2
+                    }
                 }
-            });
-            let event = runtime_notification(AcpEvent::from_notification(&raw));
-            assert_eq!(event.event_type, event_type, "{session_update}");
-            assert_eq!(event.payload, raw);
-        }
+            }
+        });
+        let event = runtime_notification(AcpEvent::from_notification(&raw));
+        assert_eq!(event.event_type, "projection_ready");
+        assert_eq!(
+            event.payload,
+            serde_json::json!({
+                "sourceMessageCount": 4,
+                "projectedMessageCount": 3,
+                "delivery": "strict",
+                "contextEpoch": 2
+            })
+        );
+        assert!(event.payload.get("sessionUpdate").is_none());
+        assert!(event.payload.get("method").is_none());
+    }
+
+    #[test]
+    fn plan_stores_entries() {
+        let raw = serde_json::json!({
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "plan",
+                    "entries": [{ "content": "edit", "status": "pending", "priority": "medium" }]
+                }
+            }
+        });
+        let event = runtime_notification(AcpEvent::from_notification(&raw));
+        assert_eq!(event.event_type, "plan");
+        assert_eq!(
+            event.payload,
+            serde_json::json!({
+                "entries": [{ "content": "edit", "status": "pending", "priority": "medium" }]
+            })
+        );
+    }
+
+    #[test]
+    fn available_commands_stores_command_list() {
+        let raw = serde_json::json!({
+            "method": "session/update",
+            "params": {
+                "update": {
+                    "sessionUpdate": "available_commands_update",
+                    "availableCommands": [{ "name": "compact", "description": "Compact context" }]
+                }
+            }
+        });
+        let event = runtime_notification(AcpEvent::from_notification(&raw));
+        assert_eq!(event.event_type, "available_commands");
+        assert_eq!(
+            event.payload,
+            serde_json::json!({
+                "availableCommands": [{ "name": "compact", "description": "Compact context" }]
+            })
+        );
+    }
+
+    #[test]
+    fn unclassified_session_updates_keep_original_payload() {
+        let raw = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": "session-1",
+                "update": { "sessionUpdate": "unknown_update" }
+            }
+        });
+        let event = runtime_notification(AcpEvent::from_notification(&raw));
+        assert_eq!(event.event_type, "acp");
+        assert_eq!(event.payload, raw);
     }
 
     #[test]

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `00edf38`（PR #68 已合并）。**
+> **进度快照：2026-08-13，基线 `b76421d`（PR #69 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 控制事件 payload 已中性。当前工作是 usage / state / user_message payload 去 ACP JSON。
+> Wave 16 usage/state payload 已中性。当前工作是 projection / plan payload 去 ACP JSON。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -29,10 +29,10 @@
 
 1. `TurnEngine` 已统一主 Agent 和 Subagent 的循环，ports 也已抽出；Wave 13 起默认路径必须真正把 `prepare_context` 的 `PreparedContext` 交给 `run_model`，而不是在 model 步骤里重新组装上下文。
 2. `Provider`、`ChatClient`、`ChatBackend` 仍存在相近但不统一的模型抽象；`zene-model-executor` 已可注入，但请求类型仍是 `zene-llm::ChatRequest`，Turn 还看不到中性 `ModelRequest`。
-3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。Cloud `RuntimeCommand::Approval` 已与 core 同形（`request_id` + `ApprovalDecision`），但 Cloud 仍无 Steer/SetMode 等变体，也未依赖 `zene-runtime`。时间线、控制、usage/state payload 已是产品字段；projection/plan 等帧仍为 ACP JSON。
+3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。Cloud `RuntimeCommand::Approval` 已与 core 同形（`request_id` + `ApprovalDecision`），但 Cloud 仍无 Steer/SetMode 等变体，也未依赖 `zene-runtime`。已分类 Cloud payload 已是产品字段；未识别帧仍为 ACP JSON。
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者，但 Agent-specific actor 仍在 `zene-core`，ACP 仍保留 transport 层 session bookkeeping。
-6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 只留在 RuntimeClient adapter。时间线、控制、usage/state payload 已是产品字段；projection/plan 等帧仍为 ACP JSON。
+6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 只留在 RuntimeClient adapter。已分类 Cloud payload 已是产品字段；未识别帧仍为 ACP JSON。
 7. `ToolRegistry` 仍同时承担目录与执行；`RuntimeScope` 尚未成为 Subagent 的正式差异注入面。
 
 本文目标不是立刻重写 runtime，而是建立一个可以渐进落地的目标架构：
@@ -77,7 +77,7 @@ Cloud API
 zene-cloud-worker  (JobRunner)
    │  claim / workspace / heartbeat / approval / cancel
    ▼
-zene-cloud-runtime-client  (send RuntimeCommand；时间线/控制/usage/state 产品 payload；projection 等仍是 ACP JSON)
+zene-cloud-runtime-client  (send RuntimeCommand；已分类事件为产品 payload；未识别帧仍是 ACP JSON)
    │
    ▼
 zene acp
@@ -104,7 +104,7 @@ RuntimeHandle → Agent → TurnEngine
 | Subagent | `crates/core/src/subagent.rs` | 直接实现 `TurnEnginePorts`；仍用独立 `ChatBackend` 和内存消息，尚未 `RuntimeScope` |
 | Runtime | `crates/runtime` + `crates/core/src/agent_runtime.rs` | 公共 command/event 在 `zene-runtime`；Agent actor 仍在 core |
 | ACP | `apps/cli/src/acp/server.rs` | transport adapter；创建/加载 session，并把请求接入 `RuntimeHandle` |
-| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；时间线、控制、usage/state payload 已是产品字段，projection/plan 等仍为 ACP JSON |
+| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；已分类事件 payload 已是产品字段，未识别帧仍为 ACP JSON |
 
 ## 3. 核心概念边界
 
@@ -1047,7 +1047,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          Cloud 时间线 payload 使用产品字段
          Cloud RuntimeCommand::Approval 与 core 同形
          Cloud 控制事件 payload 使用产品字段
-         Cloud usage/state payload 使用产品字段（本轮）
+         Cloud usage/state payload 使用产品字段
+         Cloud projection/plan payload 使用产品字段（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1072,13 +1073,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | 审批 command、时间线/控制/usage/state payload、`RuntimeCommand::Approval` 已中性；Steer/SetMode 与 projection/plan payload 仍待统一 |
+| Wave 16 | 进行中 | 已分类 event payload 与 `RuntimeCommand::Approval` 已中性；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；时间线、控制、usage/state payload 已是产品字段；projection/plan 等帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 已是产品字段；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1107,7 +1108,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - pending tool / approval 的任意副作用自动 replay：继续采用 inspection/manual intervention，避免重复写操作。
    - `Agent` 从 step orchestrator 完全退回 composition root。
    - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor` / ModelExecutor，而不是并行 `ChatBackend`。
-   - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Cancel/Approval/Shutdown；仍缺 Steer/SetMode，且不依赖 `zene-runtime`）。projection/plan 等 Cloud payload 仍为 ACP JSON。
+   - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Cancel/Approval/Shutdown；仍缺 Steer/SetMode，且不依赖 `zene-runtime`）。未识别 Cloud 帧仍为 ACP JSON。
    - Agent-specific actor 从 `zene-core` 移入独立 runtime implementation crate（应在 ports/审批稳定之后）。
    - 跨 VM outbox 的共享持久化实现；当前部署文档要求共享 POSIX volume 或后续 DB/object spool。
 
@@ -1173,9 +1174,9 @@ Wave 16  统一 transport command/event  ← 当前工作
 7. **Wave 16：统一 command/event（进行中）**
    - JobRunner 经 `RuntimeClient::send` 发送 Prompt/Cancel/Approval/Shutdown；`Approval` 携带 `request_id` + `ApprovalDecision`。
    - ACP jsonrpc id 与 `optionId` 只留在 RuntimeClient adapter。
-   - RuntimeClient 把 ACP `sessionUpdate` 分类为中性 `event_type`；时间线、控制、usage/state payload 存产品字段。
+   - RuntimeClient 把 ACP `sessionUpdate` 分类为中性 `event_type`；已分类 payload 存产品字段。
    - Console 按 `event_type` 分发；新产品 payload 直接渲染，legacy `params.update` 仍可回放。
-   - 未做：projection/plan 等帧去 ACP JSON；Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
+   - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
    - 每个 wave 保持 `cargo test --workspace --locked`；
@@ -1200,11 +1201,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 payload** | usage/state 已中性；projection/plan 仍是 ACP JSON |
-| 剩余 command | Wave 16 | Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | 已分类 payload 已中性；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**继续 Wave 16 收口剩余 ACP payload**，最后才用 Wave 14 把 `Agent` 收成 wiring。不要先搬 runtime crate。
+推荐组合：**事件语义已收口到未识别帧**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1271,7 +1271,7 @@ Wave 16  统一 transport command/event  ← 当前工作
 - `zene-cloud-runtime-client::ApprovalDecision` 与 core 同为 AllowOnce / AllowSession / Deny。
 - `RuntimeCommand::RespondApproval` 和 `RuntimeClient::respond_approval` 不再接受 ACP result JSON。
 - ACP `optionId` 只在 adapter / `PermissionDecision::to_result` 内构造。
-- 未做：projection/plan payload 去 ACP JSON、Cloud 与 `zene-runtime::RuntimeCommand` 合成同一类型。
+- 未做：Cloud 与 `zene-runtime::RuntimeCommand` 合成同一类型。
 
 ### 2026-08-13 — Cloud event_type
 
@@ -1293,7 +1293,7 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 - Cloud `RuntimeCommand` 为 Prompt / Cancel / Approval / Shutdown。`Approval` 与 core 同为 `request_id` + `ApprovalDecision`。
 - JobRunner 只 `send` 这些命令。ACP jsonrpc id 留在 adapter 的 pending map；不支持的 reverse request 在 adapter 内拒绝。
-- 未把 `zene-runtime` 引入 Cloud。未做：Steer/SetMode、projection/plan payload 去 ACP JSON。
+- 未把 `zene-runtime` 引入 Cloud。未做：Steer/SetMode。
 
 ### 2026-08-13 — Cloud 控制事件 payload
 
@@ -1304,6 +1304,11 @@ Wave 16  统一 transport command/event  ← 当前工作
 ### 2026-08-13 — Cloud usage/state payload
 
 - `user_message` 存 `text`；`state_changed` 把 ACP `modeId` 收成 `state`；`usage_update` 把 `used`/`size` 与 `_meta` token 字段提到顶层。
-- 不迁移已存记录。projection/plan/available_commands 仍为 ACP JSON。
+- 不迁移已存记录。
+
+### 2026-08-13 — Cloud projection/plan payload
+
+- `projection_ready` 把 `_meta` 解释字段提到顶层；`plan` 存 `entries`；`available_commands` 存 `availableCommands`。
+- 未识别帧仍为 `acp` 并保留原始 JSON。不迁移已存记录。
 - 未做：Steer/SetMode、把 `zene-runtime` 引入 Cloud。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #69 让 usage/state/user_message 改存产品字段，但 `projection_ready` / `plan` / `available_commands` 仍是 ACP jsonrpc 信封。

本 PR 是 Wave 16 下一刀：`projection_ready` 把 `_meta` 解释字段提到顶层；`plan` 存 `entries`；`available_commands` 存命令列表。未识别帧仍为 `acp` 并保留原始 JSON。不迁移已存记录。不改 Console 布局。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。

`cd cloud && cargo test -p zene-cloud-runtime-client -p zene-cloud-worker --locked` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

