### PR TITLE
feat: Cloud 审批表 payload 使用产品字段

### DIFF
--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -18,8 +18,8 @@ use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 use zene_cloud_acp_bridge::{resolve_zene_bin, MockAgent, MockMsg, PermissionDecision};
 use zene_cloud_runtime_client::{
-    AcpRuntimeClient, ApprovalDecision, RuntimeClient, RuntimeCommand, RuntimeEvent,
-    RuntimeNotification, RuntimeRequest,
+    approval_payload, AcpRuntimeClient, ApprovalDecision, RuntimeClient, RuntimeCommand,
+    RuntimeEvent, RuntimeNotification, RuntimeRequest,
 };
 use zene_cloud_domain::{
     ApprovalRequest, ApprovalStatus, ClaimedRun, CloneAuthResponse, CreateApprovalRequest,
@@ -696,7 +696,7 @@ async fn run_with_mock(
                         &request_key,
                         None,
                         "tool",
-                        &params,
+                        &approval_payload(&params),
                     )
                     .await
                     {

--- a/cloud/crates/runtime-client/src/lib.rs
+++ b/cloud/crates/runtime-client/src/lib.rs
@@ -154,14 +154,30 @@ pub enum RuntimeEvent {
 
 /// Runtime-level meaning of a request requiring user approval. Protocol method
 /// names, JSON-RPC ids, and parameter paths stay inside this adapter.
-/// `context` is opaque request context retained for existing approval
-/// resolution and compatibility with stored payloads.
+/// `context` is the product payload stored on the approval row.
 #[derive(Debug)]
 pub enum RuntimeRequest {
     Approval {
         request_id: String,
         context: Value,
     },
+}
+
+/// Product payload stored on Cloud approval rows. ACP option lists and
+/// session metadata stay inside the adapter.
+pub fn approval_payload(params: &Value) -> Value {
+    let mut map = serde_json::Map::new();
+    map.insert(
+        "requestId".into(),
+        Value::String(permission_request_key(params)),
+    );
+    if let Some(tool) = params.get("toolCall") {
+        map.extend(take_fields(
+            tool,
+            &["toolCallId", "title", "toolName", "kind", "status", "rawInput"],
+        ));
+    }
+    Value::Object(map)
 }
 
 #[async_trait]
@@ -244,19 +260,7 @@ fn product_payload(kind: RuntimeEventKind, raw: &Value) -> Value {
 }
 
 fn approval_product(raw: &Value) -> Value {
-    let params = raw.get("params").unwrap_or(raw);
-    let mut map = serde_json::Map::new();
-    map.insert(
-        "requestId".into(),
-        Value::String(permission_request_key(params)),
-    );
-    if let Some(tool) = params.get("toolCall") {
-        map.extend(take_fields(
-            tool,
-            &["toolCallId", "title", "toolName", "kind", "status", "rawInput"],
-        ));
-    }
-    Value::Object(map)
+    approval_payload(raw.get("params").unwrap_or(raw))
 }
 
 fn session_started_product(raw: &Value) -> Value {
@@ -383,7 +387,7 @@ fn runtime_request(method: &str, params: &Value) -> Option<RuntimeRequest> {
     if method == "session/request_permission" {
         Some(RuntimeRequest::Approval {
             request_id: permission_request_key(params),
-            context: params.clone(),
+            context: approval_payload(params),
         })
     } else {
         None
@@ -922,14 +926,25 @@ mod tests {
     #[test]
     fn approval_contract_exposes_neutral_context_and_identity() {
         let params = serde_json::json!({
-            "toolCall": { "toolCallId": "call-7" },
-            "reason": "write"
+            "toolCall": {
+                "toolCallId": "call-7",
+                "title": "Write notes",
+                "kind": "edit"
+            },
+            "reason": "write",
+            "options": [{ "optionId": "allow-once" }]
         });
         let request = runtime_request("session/request_permission", &params);
         assert!(matches!(
             request,
             Some(RuntimeRequest::Approval { request_id, context })
-                if request_id == "call-7" && context == params
+                if request_id == "call-7"
+                    && context == serde_json::json!({
+                        "requestId": "call-7",
+                        "toolCallId": "call-7",
+                        "title": "Write notes",
+                        "kind": "edit"
+                    })
         ));
     }
 

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `b76421d`（PR #69 已合并）。**
+> **进度快照：2026-08-13，基线 `82291fd`（PR #71 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 usage/state payload 已中性。当前工作是 projection / plan payload 去 ACP JSON。
+> Wave 16 已分类 run event payload 已中性。当前工作是审批表 payload 去 ACP params。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -32,7 +32,7 @@
 3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。Cloud `RuntimeCommand::Approval` 已与 core 同形（`request_id` + `ApprovalDecision`），但 Cloud 仍无 Steer/SetMode 等变体，也未依赖 `zene-runtime`。已分类 Cloud payload 已是产品字段；未识别帧仍为 ACP JSON。
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者，但 Agent-specific actor 仍在 `zene-core`，ACP 仍保留 transport 层 session bookkeeping。
-6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 只留在 RuntimeClient adapter。已分类 Cloud payload 已是产品字段；未识别帧仍为 ACP JSON。
+6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 与 option 列表只留在 adapter。已分类 Cloud payload 与审批表 payload 已是产品字段；未识别帧仍为 ACP JSON。
 7. `ToolRegistry` 仍同时承担目录与执行；`RuntimeScope` 尚未成为 Subagent 的正式差异注入面。
 
 本文目标不是立刻重写 runtime，而是建立一个可以渐进落地的目标架构：
@@ -104,7 +104,7 @@ RuntimeHandle → Agent → TurnEngine
 | Subagent | `crates/core/src/subagent.rs` | 直接实现 `TurnEnginePorts`；仍用独立 `ChatBackend` 和内存消息，尚未 `RuntimeScope` |
 | Runtime | `crates/runtime` + `crates/core/src/agent_runtime.rs` | 公共 command/event 在 `zene-runtime`；Agent actor 仍在 core |
 | ACP | `apps/cli/src/acp/server.rs` | transport adapter；创建/加载 session，并把请求接入 `RuntimeHandle` |
-| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；已分类事件 payload 已是产品字段，未识别帧仍为 ACP JSON |
+| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；已分类事件与审批表 payload 已是产品字段，未识别帧仍为 ACP JSON |
 
 ## 3. 核心概念边界
 
@@ -1048,7 +1048,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          Cloud RuntimeCommand::Approval 与 core 同形
          Cloud 控制事件 payload 使用产品字段
          Cloud usage/state payload 使用产品字段
-         Cloud projection/plan payload 使用产品字段（本轮）
+         Cloud projection/plan payload 使用产品字段
+         Cloud 审批表 payload 使用产品字段（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1073,13 +1074,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | 已分类 event payload 与 `RuntimeCommand::Approval` 已中性；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | 已分类 event/审批 payload 与 `RuntimeCommand::Approval` 已中性；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 已是产品字段；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1173,7 +1174,7 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 7. **Wave 16：统一 command/event（进行中）**
    - JobRunner 经 `RuntimeClient::send` 发送 Prompt/Cancel/Approval/Shutdown；`Approval` 携带 `request_id` + `ApprovalDecision`。
-   - ACP jsonrpc id 与 `optionId` 只留在 RuntimeClient adapter。
+   - ACP jsonrpc id 与 `optionId` 只留在 RuntimeClient adapter。审批表 payload 存产品字段，不再存 ACP params。
    - RuntimeClient 把 ACP `sessionUpdate` 分类为中性 `event_type`；已分类 payload 存产品字段。
    - Console 按 `event_type` 分发；新产品 payload 直接渲染，legacy `params.update` 仍可回放。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
@@ -1201,7 +1202,7 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | 已分类 payload 已中性；Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | 已分类 event/审批 payload 已中性；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
 推荐组合：**事件语义已收口到未识别帧**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
@@ -1310,5 +1311,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 - `projection_ready` 把 `_meta` 解释字段提到顶层；`plan` 存 `entries`；`available_commands` 存 `availableCommands`。
 - 未识别帧仍为 `acp` 并保留原始 JSON。不迁移已存记录。
+
+### 2026-08-13 — Cloud 审批表 payload
+
+- `RuntimeRequest::Approval.context` 与 MockAgent 审批行改存产品字段（`requestId`、toolCall 字段），不再存 ACP params / `options.optionId`。
+- Console 仍展示 payload JSON，无需改布局。不迁移已存审批行。
 - 未做：Steer/SetMode、把 `zene-runtime` 引入 Cloud。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #71 让已分类 run event 都改存产品字段，但审批表仍写入 ACP `params`（含 `options.optionId`）。Console 审批卡片直接展示这份 JSON。

本 PR 是 Wave 16 下一刀：`RuntimeRequest::Approval.context` 与 MockAgent 审批行改存 `requestId` 和 toolCall 产品字段。ACP option 列表留在 adapter。不迁移已存审批行。不改布局。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。

`cd cloud && cargo test -p zene-cloud-runtime-client -p zene-cloud-worker --locked` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

