### PR TITLE
feat: Cloud 存库/API 审批决策使用枚举

### DIFF
--- a/cloud/apps/api/src/routes.rs
+++ b/cloud/apps/api/src/routes.rs
@@ -956,13 +956,13 @@ async fn decide_approval(
     {
         return Err(AppError::conflict(format!(
             "decision {} not allowed",
-            req.decision
+            req.decision.as_str()
         )));
     }
     Ok(Json(
         state
             .db
-            .decide_approval(approval_id, &req.decision, Some(&user.id.to_string()))
+            .decide_approval(approval_id, req.decision, Some(&user.id.to_string()))
             .await?,
     ))
 }

--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -22,11 +22,10 @@ use zene_cloud_runtime_client::{
     RuntimeEvent, RuntimeNotification, RuntimeRequest,
 };
 use zene_cloud_domain::{
-    ApprovalRequest, ApprovalStatus, ClaimedRun, CloneAuthResponse, CreateApprovalRequest,
-    LlmAuthResponse, RunStatus, WorkerCommand, WorkerCommandAckRequest, WorkerCommandKind,
-    WorkerCommandsResponse,
-    WorkerEventRequest, WorkerFence, WorkerStatusRequest, WorkerTitleRequest,
-    WorkerAcpSessionRequest,
+    ApprovalDecision as StoredApprovalDecision, ApprovalRequest, ApprovalStatus, ClaimedRun,
+    CloneAuthResponse, CreateApprovalRequest, LlmAuthResponse, RunStatus, WorkerCommand,
+    WorkerCommandAckRequest, WorkerCommandKind, WorkerCommandsResponse, WorkerEventRequest,
+    WorkerFence, WorkerStatusRequest, WorkerTitleRequest, WorkerAcpSessionRequest,
 };
 
 #[derive(Debug, Clone, Parser)]
@@ -1206,6 +1205,14 @@ async fn run_with_real_acp(
     Ok(outcome_for_hold(true, hold_exit))
 }
 
+fn runtime_approval_decision(decision: StoredApprovalDecision) -> ApprovalDecision {
+    match decision {
+        StoredApprovalDecision::AllowOnce => ApprovalDecision::AllowOnce,
+        StoredApprovalDecision::AllowSession => ApprovalDecision::AllowSession,
+        StoredApprovalDecision::Deny => ApprovalDecision::Deny,
+    }
+}
+
 async fn resolve_permission(
     client: &reqwest::Client,
     api_url: &str,
@@ -1223,9 +1230,9 @@ async fn resolve_permission(
         risk: "medium".into(),
         payload: payload.clone(),
         allowed_decisions: vec![
-            "allow-once".into(),
-            "allow-always".into(),
-            "reject-once".into(),
+            StoredApprovalDecision::AllowOnce,
+            StoredApprovalDecision::AllowSession,
+            StoredApprovalDecision::Deny,
         ],
         expires_at: None,
     };
@@ -1242,8 +1249,8 @@ async fn resolve_permission(
 
     let approval_id = created.id;
     if created.status != ApprovalStatus::Pending {
-        return Ok(ApprovalDecision::from_stored(
-            created.decision.as_deref().unwrap_or("allow-once"),
+        return Ok(runtime_approval_decision(
+            created.decision.unwrap_or(StoredApprovalDecision::AllowOnce),
         ));
     }
 
@@ -1261,8 +1268,8 @@ async fn resolve_permission(
             .json()
             .await?;
         if approval.status != ApprovalStatus::Pending {
-            return Ok(ApprovalDecision::from_stored(
-                approval.decision.as_deref().unwrap_or("allow-once"),
+            return Ok(runtime_approval_decision(
+                approval.decision.unwrap_or(StoredApprovalDecision::AllowOnce),
             ));
         }
     }

--- a/cloud/crates/db/src/github.rs
+++ b/cloud/crates/db/src/github.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use chrono::{Duration, Utc};
 use uuid::Uuid;
 use zene_cloud_domain::{
-    ApprovalRequest, AuditLog, GitOperation, GitOperationKind, GitOperationStatus,
+    ApprovalDecision, ApprovalRequest, AuditLog, GitOperation, GitOperationKind, GitOperationStatus,
     GithubAccount, GithubInstallation, GithubRepoSummary, OauthState, PullRequest, Repository,
 };
 
@@ -392,7 +392,7 @@ impl Db {
         &self,
         approval_id: Uuid,
         resolved_by: Uuid,
-        decision: &str,
+        decision: ApprovalDecision,
     ) -> Result<ApprovalRequest> {
         self.decide_approval(approval_id, decision, Some(&resolved_by.to_string()))
             .await

--- a/cloud/crates/db/src/lib.rs
+++ b/cloud/crates/db/src/lib.rs
@@ -14,10 +14,10 @@ use sqlx::SqlitePool;
 use std::str::FromStr;
 use uuid::Uuid;
 use zene_cloud_domain::{
-    ApprovalRequest, ApprovalStatus, AuthResponse, CloneAuthResponse, CreateApprovalRequest,
-    CreateRepositoryRequest, CreateRunRequest, LoginRequest, Organization, QueueActive, QueueHold,
-    QueueStats, RegisterRequest, Repository, Run, RunEvent, RunMessage, RunStatus, User,
-    WorkerCommand, WorkerFence,
+    ApprovalDecision, ApprovalRequest, ApprovalStatus, AuthResponse, CloneAuthResponse,
+    CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest, LoginRequest, Organization,
+    QueueActive, QueueHold, QueueStats, RegisterRequest, Repository, Run, RunEvent, RunMessage,
+    RunStatus, User, WorkerCommand, WorkerFence,
 };
 
 #[derive(Clone)]
@@ -1570,7 +1570,7 @@ impl Db {
             ApprovalStatus::Pending
         };
         let decision = if auto {
-            Some("allow-once".to_string())
+            Some(ApprovalDecision::AllowOnce)
         } else {
             None
         };
@@ -1602,7 +1602,7 @@ impl Db {
         .bind(req.expires_at.map(|t| t.to_rfc3339()))
         .bind(if auto { Some("system") } else { None })
         .bind(resolved_at)
-        .bind(&decision)
+        .bind(decision.map(|d| d.as_str()))
         .execute(&self.pool)
         .await?;
 
@@ -1629,7 +1629,7 @@ impl Db {
                 "event": "approval.created",
                 "approvalId": id,
                 "status": status.as_str(),
-                "decision": decision,
+                "decision": decision.map(|d| d.as_str()),
                 "kind": req.kind,
             }),
         )
@@ -1702,7 +1702,7 @@ impl Db {
     pub async fn decide_approval(
         &self,
         approval_id: Uuid,
-        decision: &str,
+        decision: ApprovalDecision,
         resolved_by: Option<&str>,
     ) -> Result<ApprovalRequest> {
         let existing = self
@@ -1713,20 +1713,14 @@ impl Db {
             return Ok(existing);
         }
         let now = Utc::now();
-        let status = if decision.starts_with("reject") || decision == "deny" {
-            ApprovalStatus::Denied
-        } else if decision.starts_with("allow") || decision == "allow" {
-            ApprovalStatus::Approved
-        } else {
-            ApprovalStatus::Resolved
-        };
+        let status = decision.status();
         let updated = sqlx::query(
             "UPDATE approval_requests
              SET status = ?, decision = ?, resolved_by = ?, resolved_at = ?
              WHERE id = ? AND status = 'pending'",
         )
         .bind(status.as_str())
-        .bind(decision)
+        .bind(decision.as_str())
         .bind(resolved_by)
         .bind(now.to_rfc3339())
         .bind(approval_id.to_string())
@@ -1760,7 +1754,7 @@ impl Db {
             serde_json::json!({
                 "event": "approval.decided",
                 "approvalId": approval_id,
-                "decision": decision,
+                "decision": decision.as_str(),
             }),
         )
         .await?;
@@ -2034,7 +2028,11 @@ pub(crate) fn map_approval_full_row(
         Option<String>,
     ),
 ) -> ApprovalRequest {
-    let allowed: Vec<String> = serde_json::from_str(&row.8).unwrap_or_default();
+    let allowed: Vec<ApprovalDecision> = serde_json::from_str::<Vec<String>>(&row.8)
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|value| ApprovalDecision::parse(&value))
+        .collect();
     ApprovalRequest {
         id: Uuid::parse_str(&row.0).unwrap(),
         run_id: Uuid::parse_str(&row.1).unwrap(),
@@ -2045,7 +2043,7 @@ pub(crate) fn map_approval_full_row(
         payload: serde_json::from_str(&row.6).unwrap_or(serde_json::json!({})),
         status: ApprovalStatus::parse(&row.7).unwrap_or(ApprovalStatus::Pending),
         allowed_decisions: allowed,
-        decision: row.9,
+        decision: row.9.as_deref().and_then(ApprovalDecision::parse),
         created_at: parse_time(&row.10),
         expires_at: row.11.as_deref().map(parse_time),
         resolved_by: row.12,

--- a/cloud/crates/db/tests/smoke.rs
+++ b/cloud/crates/db/tests/smoke.rs
@@ -2,7 +2,7 @@ use sqlx::sqlite::SqlitePoolOptions;
 use uuid::Uuid;
 use zene_cloud_db::Db;
 use zene_cloud_domain::{
-    ApprovalStatus, CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest,
+    ApprovalDecision, ApprovalStatus, CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest,
     RegisterRequest, RunStatus, WorkerCommandKind, WorkerFence,
 };
 
@@ -347,7 +347,7 @@ fn approval_request(request_key: &str) -> CreateApprovalRequest {
         kind: "permission".into(),
         risk: "medium".into(),
         payload: serde_json::json!({"path": "notes.txt"}),
-        allowed_decisions: vec!["allow-once".into(), "reject-once".into()],
+        allowed_decisions: vec![ApprovalDecision::AllowOnce, ApprovalDecision::Deny],
         expires_at: None,
     }
 }
@@ -390,8 +390,8 @@ async fn concurrent_approval_decisions_have_one_winner_event() {
     let left_db = db.clone();
     let right_db = db.clone();
     let (left, right) = tokio::join!(
-        left_db.decide_approval(approval.id, "allow-once", Some("user-a")),
-        right_db.decide_approval(approval.id, "reject-once", Some("user-b")),
+        left_db.decide_approval(approval.id, ApprovalDecision::AllowOnce, Some("user-a")),
+        right_db.decide_approval(approval.id, ApprovalDecision::Deny, Some("user-b")),
     );
     let left = left.unwrap();
     let right = right.unwrap();

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -315,7 +315,8 @@ pub struct WorkerEventRequest {
 #[cfg(test)]
 mod tests {
     use super::{
-        WorkerCommand, WorkerCommandAckRequest, WorkerCommandKind, WorkerEventRequest, WorkerFence,
+        ApprovalDecision, WorkerCommand, WorkerCommandAckRequest, WorkerCommandKind,
+        WorkerEventRequest, WorkerFence,
     };
 
     #[test]
@@ -367,6 +368,29 @@ mod tests {
 
         let parsed: WorkerCommand = serde_json::from_value(encoded).expect("cancel should deserialize");
         assert_eq!(parsed.kind, WorkerCommandKind::Cancel);
+    }
+
+    #[test]
+    fn approval_decision_round_trips_console_strings() {
+        let encoded = serde_json::to_value(ApprovalDecision::AllowOnce).expect("serialize");
+        assert_eq!(encoded, serde_json::json!("allow-once"));
+        let encoded = serde_json::to_value(ApprovalDecision::AllowSession).expect("serialize");
+        assert_eq!(encoded, serde_json::json!("allow-always"));
+        let encoded = serde_json::to_value(ApprovalDecision::Deny).expect("serialize");
+        assert_eq!(encoded, serde_json::json!("reject-once"));
+
+        let parsed: ApprovalDecision =
+            serde_json::from_value(serde_json::json!("allow-once")).expect("allow-once");
+        assert_eq!(parsed, ApprovalDecision::AllowOnce);
+        let parsed: ApprovalDecision =
+            serde_json::from_value(serde_json::json!("allow")).expect("allow alias");
+        assert_eq!(parsed, ApprovalDecision::AllowSession);
+        let parsed: ApprovalDecision =
+            serde_json::from_value(serde_json::json!("deny")).expect("deny alias");
+        assert_eq!(parsed, ApprovalDecision::Deny);
+        let parsed: ApprovalDecision =
+            serde_json::from_value(serde_json::json!("reject-once")).expect("reject-once");
+        assert_eq!(parsed, ApprovalDecision::Deny);
     }
 }
 
@@ -473,6 +497,45 @@ pub struct WorkerCommandAckRequest {
     pub fence: WorkerFence,
 }
 
+/// Product approval outcome stored by Cloud and sent by Console.
+/// Wire JSON stays `allow-once` / `allow-always` / `reject-once`.
+/// ACP `optionId` mapping stays in the runtime-client adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ApprovalDecision {
+    #[serde(rename = "allow-once")]
+    AllowOnce,
+    #[serde(rename = "allow-always", alias = "allow")]
+    AllowSession,
+    #[serde(rename = "reject-once", alias = "deny")]
+    Deny,
+}
+
+impl ApprovalDecision {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::AllowOnce => "allow-once",
+            Self::AllowSession => "allow-always",
+            Self::Deny => "reject-once",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "allow-once" => Self::AllowOnce,
+            "allow-always" | "allow" => Self::AllowSession,
+            "reject-once" | "deny" => Self::Deny,
+            _ => return None,
+        })
+    }
+
+    pub fn status(self) -> ApprovalStatus {
+        match self {
+            Self::Deny => ApprovalStatus::Denied,
+            Self::AllowOnce | Self::AllowSession => ApprovalStatus::Approved,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateApprovalRequest {
@@ -483,7 +546,7 @@ pub struct CreateApprovalRequest {
     pub risk: String,
     pub payload: serde_json::Value,
     #[serde(default = "default_allowed_decisions")]
-    pub allowed_decisions: Vec<String>,
+    pub allowed_decisions: Vec<ApprovalDecision>,
     #[serde(default)]
     pub expires_at: Option<DateTime<Utc>>,
 }
@@ -492,13 +555,11 @@ fn default_risk() -> String {
     "medium".into()
 }
 
-fn default_allowed_decisions() -> Vec<String> {
+fn default_allowed_decisions() -> Vec<ApprovalDecision> {
     vec![
-        "allow-once".into(),
-        "allow-always".into(),
-        "reject-once".into(),
-        "allow".into(),
-        "deny".into(),
+        ApprovalDecision::AllowOnce,
+        ApprovalDecision::AllowSession,
+        ApprovalDecision::Deny,
     ]
 }
 
@@ -549,24 +610,24 @@ pub struct ApprovalRequest {
     pub risk: String,
     pub payload: serde_json::Value,
     pub status: ApprovalStatus,
-    pub allowed_decisions: Vec<String>,
+    pub allowed_decisions: Vec<ApprovalDecision>,
     pub created_at: DateTime<Utc>,
     pub expires_at: Option<DateTime<Utc>>,
     pub resolved_by: Option<String>,
     pub resolved_at: Option<DateTime<Utc>>,
-    pub decision: Option<String>,
+    pub decision: Option<ApprovalDecision>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DecideApprovalRequest {
-    pub decision: String,
+    pub decision: ApprovalDecision,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolveApprovalRequest {
-    pub decision: String,
+    pub decision: ApprovalDecision,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `e87fa7b`（PR #72 已合并）。**
+> **进度快照：2026-08-13，基线 `9d25228`（PR #73 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 已分类 event/审批 payload 已中性。当前工作是 API→worker `WorkerCommand` kind 枚举。
+> Wave 16 已分类 event/审批 payload 与 WorkerCommand 已中性。当前工作是 Cloud 存库/API 审批决策枚举。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -32,7 +32,7 @@
 3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。Cloud `RuntimeCommand::Approval` 已与 core 同形（`request_id` + `ApprovalDecision`），但 Cloud 仍无 Steer/SetMode 等变体，也未依赖 `zene-runtime`。已分类 Cloud payload 已是产品字段；未识别帧仍为 ACP JSON。
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者，但 Agent-specific actor 仍在 `zene-core`，ACP 仍保留 transport 层 session bookkeeping。
-6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 与 option 列表只留在 adapter。已分类 Cloud payload 与审批表 payload 已是产品字段；未识别帧仍为 ACP JSON。API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。
+6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 与 option 列表只留在 adapter。已分类 Cloud payload 与审批表 payload 已是产品字段；未识别帧仍为 ACP JSON。API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举。Cloud 存库/API 审批决策是 `ApprovalDecision` 枚举，wire JSON 仍为 `allow-once` / `allow-always` / `reject-once`。
 7. `ToolRegistry` 仍同时承担目录与执行；`RuntimeScope` 尚未成为 Subagent 的正式差异注入面。
 
 本文目标不是立刻重写 runtime，而是建立一个可以渐进落地的目标架构：
@@ -104,7 +104,7 @@ RuntimeHandle → Agent → TurnEngine
 | Subagent | `crates/core/src/subagent.rs` | 直接实现 `TurnEnginePorts`；仍用独立 `ChatBackend` 和内存消息，尚未 `RuntimeScope` |
 | Runtime | `crates/runtime` + `crates/core/src/agent_runtime.rs` | 公共 command/event 在 `zene-runtime`；Agent actor 仍在 core |
 | ACP | `apps/cli/src/acp/server.rs` | transport adapter；创建/加载 session，并把请求接入 `RuntimeHandle` |
-| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；API→worker `WorkerCommand` 为 Prompt/Cancel；已分类事件与审批表 payload 已是产品字段，未识别帧仍为 ACP JSON |
+| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；API→worker `WorkerCommand` 为 Prompt/Cancel；存库/API 审批决策为 `ApprovalDecision`；已分类事件与审批表 payload 已是产品字段，未识别帧仍为 ACP JSON |
 
 ## 3. 核心概念边界
 
@@ -952,7 +952,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 2. **`Agent` 仍是 God Object**：它同时持有 model、tools、sandbox、permission、hooks、MCP、todos、plan mode。下一步是把它变成 wiring，而不是继续实现 step。
 3. **模型抽象仍偏 provider**：`ModelExecutor` 吃 `ChatRequest`；Subagent 另有 `ChatBackend`。目标是 Turn 只看见 `PreparedContext` → `ModelRequest`。
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
-5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
+5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。Cloud 存库/API 审批决策是 `ApprovalDecision` 枚举。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
 6. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
 Conversation event 与 materialized `messages` cache 的双轨可以保留，直到 legacy session 可证明无损迁移。不要为了架构干净上完整 Event Sourcing。
@@ -1050,7 +1050,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          Cloud usage/state payload 使用产品字段
          Cloud projection/plan payload 使用产品字段
          Cloud 审批表 payload 使用产品字段
-         API→worker WorkerCommand kind 使用 Prompt/Cancel 枚举（本轮）
+         API→worker WorkerCommand kind 使用 Prompt/Cancel 枚举
+         Cloud 存库/API 审批决策使用 ApprovalDecision 枚举（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1075,13 +1076,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | 已分类 event/审批 payload、`RuntimeCommand::Approval` 与 API→worker `WorkerCommand` 已中性；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | 已分类 event/审批 payload、`RuntimeCommand::Approval`、API→worker `WorkerCommand` 与存库/API 审批决策已中性；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；API→worker `WorkerCommand` 为 Prompt/Cancel；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；API→worker `WorkerCommand` 为 Prompt/Cancel；存库/API 审批决策为 `ApprovalDecision`；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1110,7 +1111,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - pending tool / approval 的任意副作用自动 replay：继续采用 inspection/manual intervention，避免重复写操作。
    - `Agent` 从 step orchestrator 完全退回 composition root。
    - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor` / ModelExecutor，而不是并行 `ChatBackend`。
-   - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Cancel/Approval/Shutdown；API→worker 已是 Prompt/Cancel；仍缺 Steer/SetMode，且不依赖 `zene-runtime`）。未识别 Cloud 帧仍为 ACP JSON。
+   - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Cancel/Approval/Shutdown；API→worker 已是 Prompt/Cancel；存库/API 审批决策已是 `ApprovalDecision`；仍缺 Steer/SetMode，且不依赖 `zene-runtime`）。未识别 Cloud 帧仍为 ACP JSON。
    - Agent-specific actor 从 `zene-core` 移入独立 runtime implementation crate（应在 ports/审批稳定之后）。
    - 跨 VM outbox 的共享持久化实现；当前部署文档要求共享 POSIX volume 或后续 DB/object spool。
 
@@ -1179,6 +1180,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - RuntimeClient 把 ACP `sessionUpdate` 分类为中性 `event_type`；已分类 payload 存产品字段。
    - Console 按 `event_type` 分发；新产品 payload 直接渲染，legacy `params.update` 仍可回放。
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
+   - Cloud 存库/API 审批决策是 `ApprovalDecision` 枚举，wire JSON 仍为 `allow-once` / `allow-always` / `reject-once`（兼容 `allow` / `deny` 别名）。ACP `optionId` 仍只在 adapter 内映射。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1204,7 +1206,7 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | API→worker 与 JobRunner command 已中性；Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | 存库/API 审批决策已中性；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
 推荐组合：**事件语义已收口到未识别帧**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
@@ -1325,4 +1327,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 - API→worker `WorkerCommand.kind` 从字符串改为 `Prompt` / `Cancel` 枚举；serde `snake_case`，wire JSON 仍为 `"prompt"` / `"cancel"`。
 - 不把 Approval/Shutdown/Steer 放进 `WorkerCommandKind`（那些不是 API→worker 命令）。
 - 不把 `zene-runtime` 引入 Cloud。
+
+### 2026-08-13 — Cloud 存库/API 审批决策
+
+- Cloud domain `ApprovalDecision` 覆盖存库、Decide API 与 worker 创建审批；wire JSON 仍为 `allow-once` / `allow-always` / `reject-once`，并接受 `allow` / `deny` 别名。
+- Console 仍发送这些字符串，不改布局。不把 `zene-runtime` 引入 Cloud，也不合并 runtime-client 的 `ApprovalDecision`。
+- 不补 Steer/SetMode。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #73 把 API→worker `WorkerCommand.kind` 收成枚举后，Cloud 存库和 Decide API 的审批决策仍是 `"allow-once"` / `"reject-once"` 字符串。JobRunner 已经用 runtime-client 的 `ApprovalDecision` 回复 runtime。

本 PR 是 Wave 16 下一刀：domain 增加产品面 `ApprovalDecision`，DB / Decide API / worker 创建审批都用它。wire JSON 仍为 `allow-once` / `allow-always` / `reject-once`，并接受 `allow` / `deny` 别名。ACP `optionId` 仍只在 adapter 内映射。Console 继续发送这些字符串，不改布局。

不把 runtime-client 的 `ApprovalDecision` 合并进 domain。不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-db -p zene-cloud-api -p zene-cloud-worker --locked` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

