### PR TITLE
feat: Cloud 产品审批类型去掉 jsonrpc_id

### DIFF
--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -694,7 +694,6 @@ async fn run_with_mock(
                         &token,
                         run_id,
                         &request_key,
-                        None,
                         "tool",
                         &approval_payload(&params),
                     )
@@ -1027,7 +1026,6 @@ async fn run_with_real_acp(
                         &token,
                         run_id,
                         &request_id,
-                        None,
                         "permission",
                         &context,
                     )
@@ -1219,13 +1217,11 @@ async fn resolve_permission(
     token: &str,
     run_id: Uuid,
     request_key: &str,
-    jsonrpc_id: Option<&str>,
     kind: &str,
     payload: &serde_json::Value,
 ) -> Result<ApprovalDecision> {
     let body = CreateApprovalRequest {
         request_key: request_key.to_string(),
-        jsonrpc_id: jsonrpc_id.map(|s| s.to_string()),
         kind: kind.to_string(),
         risk: "medium".into(),
         payload: payload.clone(),

--- a/cloud/crates/db/src/github.rs
+++ b/cloud/crates/db/src/github.rs
@@ -403,7 +403,6 @@ impl Db {
             String,
             String,
             String,
-            Option<String>,
             String,
             String,
             String,
@@ -415,7 +414,7 @@ impl Db {
             Option<String>,
             Option<String>,
         )> = sqlx::query_as(
-            "SELECT id, run_id, request_key, jsonrpc_id, kind, risk, payload_json, status,
+            "SELECT id, run_id, request_key, kind, risk, payload_json, status,
                     allowed_decisions, decision, created_at, expires_at, resolved_by, resolved_at
              FROM approval_requests
              WHERE run_id = ? AND status = 'pending'

--- a/cloud/crates/db/src/lib.rs
+++ b/cloud/crates/db/src/lib.rs
@@ -1584,15 +1584,14 @@ impl Db {
 
         let inserted = sqlx::query(
             "INSERT INTO approval_requests
-             (id, run_id, request_key, jsonrpc_id, kind, risk, payload_json, status,
+             (id, run_id, request_key, kind, risk, payload_json, status,
               allowed_decisions, created_at, expires_at, resolved_by, resolved_at, decision)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT(run_id, request_key) DO NOTHING",
         )
         .bind(id.to_string())
         .bind(run_id.to_string())
         .bind(&req.request_key)
-        .bind(&req.jsonrpc_id)
         .bind(&req.kind)
         .bind(&req.risk)
         .bind(&payload)
@@ -1645,7 +1644,6 @@ impl Db {
             String,
             String,
             String,
-            Option<String>,
             String,
             String,
             String,
@@ -1657,7 +1655,7 @@ impl Db {
             Option<String>,
             Option<String>,
         )> = sqlx::query_as(
-            "SELECT id, run_id, request_key, jsonrpc_id, kind, risk, payload_json, status,
+            "SELECT id, run_id, request_key, kind, risk, payload_json, status,
                     allowed_decisions, decision, created_at, expires_at, resolved_by, resolved_at
              FROM approval_requests WHERE id = ?",
         )
@@ -1676,7 +1674,6 @@ impl Db {
             String,
             String,
             String,
-            Option<String>,
             String,
             String,
             String,
@@ -1688,7 +1685,7 @@ impl Db {
             Option<String>,
             Option<String>,
         )> = sqlx::query_as(
-            "SELECT id, run_id, request_key, jsonrpc_id, kind, risk, payload_json, status,
+            "SELECT id, run_id, request_key, kind, risk, payload_json, status,
                     allowed_decisions, decision, created_at, expires_at, resolved_by, resolved_at
              FROM approval_requests WHERE run_id = ? AND request_key = ?",
         )
@@ -2015,7 +2012,6 @@ pub(crate) fn map_approval_full_row(
         String,
         String,
         String,
-        Option<String>,
         String,
         String,
         String,
@@ -2028,7 +2024,7 @@ pub(crate) fn map_approval_full_row(
         Option<String>,
     ),
 ) -> ApprovalRequest {
-    let allowed: Vec<ApprovalDecision> = serde_json::from_str::<Vec<String>>(&row.8)
+    let allowed: Vec<ApprovalDecision> = serde_json::from_str::<Vec<String>>(&row.7)
         .unwrap_or_default()
         .into_iter()
         .filter_map(|value| ApprovalDecision::parse(&value))
@@ -2037,17 +2033,16 @@ pub(crate) fn map_approval_full_row(
         id: Uuid::parse_str(&row.0).unwrap(),
         run_id: Uuid::parse_str(&row.1).unwrap(),
         request_key: row.2,
-        jsonrpc_id: row.3,
-        kind: row.4,
-        risk: row.5,
-        payload: serde_json::from_str(&row.6).unwrap_or(serde_json::json!({})),
-        status: ApprovalStatus::parse(&row.7).unwrap_or(ApprovalStatus::Pending),
+        kind: row.3,
+        risk: row.4,
+        payload: serde_json::from_str(&row.5).unwrap_or(serde_json::json!({})),
+        status: ApprovalStatus::parse(&row.6).unwrap_or(ApprovalStatus::Pending),
         allowed_decisions: allowed,
-        decision: row.9.as_deref().and_then(ApprovalDecision::parse),
-        created_at: parse_time(&row.10),
-        expires_at: row.11.as_deref().map(parse_time),
-        resolved_by: row.12,
-        resolved_at: row.13.as_deref().map(parse_time),
+        decision: row.8.as_deref().and_then(ApprovalDecision::parse),
+        created_at: parse_time(&row.9),
+        expires_at: row.10.as_deref().map(parse_time),
+        resolved_by: row.11,
+        resolved_at: row.12.as_deref().map(parse_time),
     }
 }
 

--- a/cloud/crates/db/tests/smoke.rs
+++ b/cloud/crates/db/tests/smoke.rs
@@ -343,7 +343,6 @@ async fn approval_test_run(permission_mode: &str) -> (Db, Uuid) {
 fn approval_request(request_key: &str) -> CreateApprovalRequest {
     CreateApprovalRequest {
         request_key: request_key.into(),
-        jsonrpc_id: Some("rpc-1".into()),
         kind: "permission".into(),
         risk: "medium".into(),
         payload: serde_json::json!({"path": "notes.txt"}),

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -315,8 +315,8 @@ pub struct WorkerEventRequest {
 #[cfg(test)]
 mod tests {
     use super::{
-        ApprovalDecision, WorkerCommand, WorkerCommandAckRequest, WorkerCommandKind,
-        WorkerEventRequest, WorkerFence,
+        ApprovalDecision, CreateApprovalRequest, WorkerCommand, WorkerCommandAckRequest,
+        WorkerCommandKind, WorkerEventRequest, WorkerFence,
     };
 
     #[test]
@@ -391,6 +391,21 @@ mod tests {
         let parsed: ApprovalDecision =
             serde_json::from_value(serde_json::json!("reject-once")).expect("reject-once");
         assert_eq!(parsed, ApprovalDecision::Deny);
+    }
+
+    #[test]
+    fn create_approval_request_drops_legacy_jsonrpc_id() {
+        let parsed: CreateApprovalRequest = serde_json::from_value(serde_json::json!({
+            "requestKey": "permission-1",
+            "jsonrpcId": "rpc-1",
+            "kind": "permission",
+            "payload": { "path": "notes.txt" }
+        }))
+        .expect("legacy jsonrpcId should be ignored");
+        let encoded = serde_json::to_value(&parsed).expect("serialize");
+        assert!(encoded.get("jsonrpcId").is_none());
+        assert_eq!(encoded["requestKey"], "permission-1");
+        assert_eq!(encoded["kind"], "permission");
     }
 }
 
@@ -540,7 +555,6 @@ impl ApprovalDecision {
 #[serde(rename_all = "camelCase")]
 pub struct CreateApprovalRequest {
     pub request_key: String,
-    pub jsonrpc_id: Option<String>,
     pub kind: String,
     #[serde(default = "default_risk")]
     pub risk: String,
@@ -605,7 +619,6 @@ pub struct ApprovalRequest {
     pub id: Id,
     pub run_id: Id,
     pub request_key: String,
-    pub jsonrpc_id: Option<String>,
     pub kind: String,
     pub risk: String,
     pub payload: serde_json::Value,

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `9d25228`（PR #73 已合并）。**
+> **进度快照：2026-08-13，基线 `7ee9dc6`（PR #75 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 已分类 event/审批 payload 与 WorkerCommand 已中性。当前工作是 Cloud 存库/API 审批决策枚举。
+> Wave 16 存库/API 审批决策已中性。当前工作是把 ACP `jsonrpc_id` 移出 Cloud 产品审批类型。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -32,7 +32,7 @@
 3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。Cloud `RuntimeCommand::Approval` 已与 core 同形（`request_id` + `ApprovalDecision`），但 Cloud 仍无 Steer/SetMode 等变体，也未依赖 `zene-runtime`。已分类 Cloud payload 已是产品字段；未识别帧仍为 ACP JSON。
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者，但 Agent-specific actor 仍在 `zene-core`，ACP 仍保留 transport 层 session bookkeeping。
-6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 与 option 列表只留在 adapter。已分类 Cloud payload 与审批表 payload 已是产品字段；未识别帧仍为 ACP JSON。API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举。Cloud 存库/API 审批决策是 `ApprovalDecision` 枚举，wire JSON 仍为 `allow-once` / `allow-always` / `reject-once`。
+6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 与 option 列表只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。已分类 Cloud payload 与审批表 payload 已是产品字段；未识别帧仍为 ACP JSON。API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举。Cloud 存库/API 审批决策是 `ApprovalDecision` 枚举，wire JSON 仍为 `allow-once` / `allow-always` / `reject-once`。
 7. `ToolRegistry` 仍同时承担目录与执行；`RuntimeScope` 尚未成为 Subagent 的正式差异注入面。
 
 本文目标不是立刻重写 runtime，而是建立一个可以渐进落地的目标架构：
@@ -104,7 +104,7 @@ RuntimeHandle → Agent → TurnEngine
 | Subagent | `crates/core/src/subagent.rs` | 直接实现 `TurnEnginePorts`；仍用独立 `ChatBackend` 和内存消息，尚未 `RuntimeScope` |
 | Runtime | `crates/runtime` + `crates/core/src/agent_runtime.rs` | 公共 command/event 在 `zene-runtime`；Agent actor 仍在 core |
 | ACP | `apps/cli/src/acp/server.rs` | transport adapter；创建/加载 session，并把请求接入 `RuntimeHandle` |
-| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；API→worker `WorkerCommand` 为 Prompt/Cancel；存库/API 审批决策为 `ApprovalDecision`；已分类事件与审批表 payload 已是产品字段，未识别帧仍为 ACP JSON |
+| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；API→worker `WorkerCommand` 为 Prompt/Cancel；存库/API 审批决策为 `ApprovalDecision`；产品审批类型无 `jsonrpc_id`；已分类事件与审批表 payload 已是产品字段，未识别帧仍为 ACP JSON |
 
 ## 3. 核心概念边界
 
@@ -952,7 +952,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 2. **`Agent` 仍是 God Object**：它同时持有 model、tools、sandbox、permission、hooks、MCP、todos、plan mode。下一步是把它变成 wiring，而不是继续实现 step。
 3. **模型抽象仍偏 provider**：`ModelExecutor` 吃 `ChatRequest`；Subagent 另有 `ChatBackend`。目标是 Turn 只看见 `PreparedContext` → `ModelRequest`。
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
-5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。Cloud 存库/API 审批决策是 `ApprovalDecision` 枚举。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
+5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。Cloud 存库/API 审批决策是 `ApprovalDecision` 枚举。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
 6. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
 Conversation event 与 materialized `messages` cache 的双轨可以保留，直到 legacy session 可证明无损迁移。不要为了架构干净上完整 Event Sourcing。
@@ -1051,7 +1051,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          Cloud projection/plan payload 使用产品字段
          Cloud 审批表 payload 使用产品字段
          API→worker WorkerCommand kind 使用 Prompt/Cancel 枚举
-         Cloud 存库/API 审批决策使用 ApprovalDecision 枚举（本轮）
+         Cloud 存库/API 审批决策使用 ApprovalDecision 枚举
+         Cloud 产品审批类型不再携带 jsonrpc_id（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1076,13 +1077,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | 已分类 event/审批 payload、`RuntimeCommand::Approval`、API→worker `WorkerCommand` 与存库/API 审批决策已中性；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | 已分类 event/审批 payload、command/决策枚举已中性；产品审批类型不再携带 `jsonrpc_id`；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；API→worker `WorkerCommand` 为 Prompt/Cancel；存库/API 审批决策为 `ApprovalDecision`；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；API→worker `WorkerCommand` 为 Prompt/Cancel；存库/API 审批决策为 `ApprovalDecision`；产品审批类型不再携带 `jsonrpc_id`；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1176,7 +1177,7 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 7. **Wave 16：统一 command/event（进行中）**
    - JobRunner 经 `RuntimeClient::send` 发送 Prompt/Cancel/Approval/Shutdown；`Approval` 携带 `request_id` + `ApprovalDecision`。
-   - ACP jsonrpc id 与 `optionId` 只留在 RuntimeClient adapter。审批表 payload 存产品字段，不再存 ACP params。
+   - ACP jsonrpc id 与 `optionId` 只留在 RuntimeClient adapter。审批表 payload 存产品字段，不再存 ACP params。Cloud 产品审批类型不再携带 `jsonrpc_id`；DB 列保留但不读写。
    - RuntimeClient 把 ACP `sessionUpdate` 分类为中性 `event_type`；已分类 payload 存产品字段。
    - Console 按 `event_type` 分发；新产品 payload 直接渲染，legacy `params.update` 仍可回放。
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
@@ -1332,4 +1333,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 - Cloud domain `ApprovalDecision` 覆盖存库、Decide API 与 worker 创建审批；wire JSON 仍为 `allow-once` / `allow-always` / `reject-once`，并接受 `allow` / `deny` 别名。
 - Console 仍发送这些字符串，不改布局。不把 `zene-runtime` 引入 Cloud，也不合并 runtime-client 的 `ApprovalDecision`。
 - 不补 Steer/SetMode。
+
+### 2026-08-13 — Cloud 产品审批去掉 jsonrpc_id
+
+- `CreateApprovalRequest` / `ApprovalRequest` 不再携带 ACP `jsonrpc_id`。worker 创建审批不再传入该字段。
+- 数据库列保留但不读写；不迁移、不删列。不改 Console 布局。
+- 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #75 把存库/API 审批决策收成枚举后，`CreateApprovalRequest` / `ApprovalRequest` 仍携带 ACP `jsonrpc_id`。JobRunner 两条路径已经固定传 `None`，jsonrpc id 只活在 RuntimeClient adapter 的 pending map 里。Console 也不读这个字段。

本 PR 是 Wave 16 下一刀：产品审批类型去掉 `jsonrpc_id`。worker 创建审批不再传入。数据库列保留但不读写，不迁移、不删列。不改布局。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不合并 runtime-client 的 `ApprovalDecision`。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-db -p zene-cloud-api -p zene-cloud-worker --locked` 已通过。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

