### PR TITLE
feat: Cloud 审批产品面从 Console 收到 RuntimeCommand

### DIFF
--- a/cloud/Cargo.lock
+++ b/cloud/Cargo.lock
@@ -3035,6 +3035,7 @@ dependencies = [
  "tokio",
  "uuid",
  "zene-cloud-acp-bridge",
+ "zene-cloud-domain",
 ]
 
 [[package]]

--- a/cloud/apps/web/components/RunView.tsx
+++ b/cloud/apps/web/components/RunView.tsx
@@ -30,7 +30,8 @@ import {
   modelsForPicker,
   saveSelectedModel,
 } from "@/lib/models";
-import type { AcpSessionUpdate, Approval, LlmSettingsView, Repo, Run, RunEvent, RunMessage } from "@/lib/types";
+import { allowsDeny, allowsOnce, extraDecisions } from "@/lib/approval";
+import type { AcpSessionUpdate, Approval, ApprovalDecision, LlmSettingsView, Repo, Run, RunEvent, RunMessage } from "@/lib/types";
 import { timelineUpdateFromEvent } from "@/lib/runtimeEvent";
 import { CodePanel, useCodePanelWidth } from "./CodePanel";
 import { Markdown } from "./Markdown";
@@ -104,7 +105,7 @@ type TimelineItem =
       output?: string;
       expanded: boolean;
     }
-  | { kind: "approval"; id: number; approval: Approval; decision?: string };
+  | { kind: "approval"; id: number; approval: Approval; decision?: ApprovalDecision };
 
 function bubbleRole(role?: string): "user" | "assistant" {
   return (role || "").toLowerCase() === "user" ? "user" : "assistant";
@@ -1251,7 +1252,7 @@ export function RunView({
     try {
       const list = (await api<Approval[]>(`/api/v1/runs/${runId}/approvals`)) || [];
       for (const ap of list) {
-        if ((ap.status || "").toLowerCase() === "pending" && !seenApprovals.current.has(ap.id)) {
+        if (ap.status === "pending" && !seenApprovals.current.has(ap.id)) {
           seenApprovals.current.add(ap.id);
           setItems((prev) => [...prev, { kind: "approval", id: nextId.current++, approval: ap }]);
           scrollMessages();
@@ -1538,7 +1539,7 @@ export function RunView({
   }, [runId, onRunsChanged, toast]);
 
   const decideApproval = useCallback(
-    async (itemId: number, approvalId: string, decision: string) => {
+    async (itemId: number, approvalId: string, decision: ApprovalDecision) => {
       try {
         await api(`/api/v1/runs/${runId}/approvals/${approvalId}/decide`, {
           method: "POST",
@@ -1918,9 +1919,7 @@ export function RunView({
                       ? JSON.stringify(ap.payload, null, 2)
                       : String(ap.payload || "");
                   const allowed = ap.allowedDecisions || ["allow-once", "reject-once"];
-                  const extra = allowed.filter(
-                    (d) => !["allow-once", "reject-once", "allow", "deny"].includes(d),
-                  );
+                  const extra = extraDecisions(allowed);
                   const decided = Boolean(item.decision);
                   return (
                     <div
@@ -1935,7 +1934,7 @@ export function RunView({
                         {summary}
                       </div>
                       <div className="flex flex-wrap gap-2">
-                        {(allowed.includes("allow-once") || allowed.includes("allow")) && (
+                        {allowsOnce(allowed) && (
                           <button
                             type="button"
                             className="btn btn-primary btn-sm"
@@ -1945,7 +1944,7 @@ export function RunView({
                             Allow once
                           </button>
                         )}
-                        {(allowed.includes("reject-once") || allowed.includes("deny")) && (
+                        {allowsDeny(allowed) && (
                           <button
                             type="button"
                             className="btn btn-danger btn-sm"

--- a/cloud/apps/web/lib/approval.ts
+++ b/cloud/apps/web/lib/approval.ts
@@ -1,0 +1,17 @@
+import type { ApprovalDecision } from "@/lib/types";
+
+const ALLOW_ONCE: ApprovalDecision[] = ["allow-once", "allow"];
+const DENY_ONCE: ApprovalDecision[] = ["reject-once", "deny"];
+const PRIMARY: ApprovalDecision[] = ["allow-once", "reject-once", "allow", "deny"];
+
+export function allowsOnce(allowed: ApprovalDecision[]): boolean {
+  return ALLOW_ONCE.some((decision) => allowed.includes(decision));
+}
+
+export function allowsDeny(allowed: ApprovalDecision[]): boolean {
+  return DENY_ONCE.some((decision) => allowed.includes(decision));
+}
+
+export function extraDecisions(allowed: ApprovalDecision[]): ApprovalDecision[] {
+  return allowed.filter((decision) => !PRIMARY.includes(decision));
+}

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -103,13 +103,29 @@ export interface RunEvent {
   };
 }
 
+export type ApprovalDecision =
+  | "allow-once"
+  | "allow-always"
+  | "reject-once"
+  | "allow"
+  | "deny";
+export type ApprovalKind = "permission" | "tool";
+export type ApprovalRisk = "low" | "medium" | "high";
+export type ApprovalStatus =
+  | "pending"
+  | "approved"
+  | "denied"
+  | "resolved"
+  | "expired"
+  | "cancelled";
+
 export interface Approval {
   id: string;
-  kind?: string;
-  risk?: string;
-  status?: string;
+  kind?: ApprovalKind;
+  risk?: ApprovalRisk;
+  status?: ApprovalStatus;
   payload?: unknown;
-  allowedDecisions?: string[];
+  allowedDecisions?: ApprovalDecision[];
 }
 
 export interface WorkspaceFile {

--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -18,11 +18,11 @@ use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 use zene_cloud_acp_bridge::{resolve_zene_bin, MockAgent, MockMsg, PermissionDecision};
 use zene_cloud_runtime_client::{
-    approval_payload, AcpRuntimeClient, ApprovalDecision, RuntimeClient, RuntimeCommand,
+    approval_payload, to_permission_decision, AcpRuntimeClient, RuntimeClient, RuntimeCommand,
     RuntimeEvent, RuntimeNotification, RuntimeRequest,
 };
 use zene_cloud_domain::{
-    ApprovalDecision as StoredApprovalDecision, ApprovalRequest, ApprovalStatus, ClaimedRun,
+    ApprovalDecision, ApprovalKind, ApprovalRequest, ApprovalRisk, ApprovalStatus, ClaimedRun,
     CloneAuthResponse, CreateApprovalRequest, LlmAuthResponse, RunStatus, WorkerCommand,
     WorkerCommandAckRequest, WorkerCommandKind, WorkerCommandsResponse, WorkerEventRequest,
     WorkerFence, WorkerStatusRequest, WorkerTitleRequest, WorkerAcpSessionRequest,
@@ -694,13 +694,13 @@ async fn run_with_mock(
                         &token,
                         run_id,
                         &request_key,
-                        "tool",
+                        ApprovalKind::Tool,
                         &approval_payload(&params),
                     )
                     .await
                     {
                         Ok(decision) => {
-                            let _ = respond.send(decision.into());
+                            let _ = respond.send(to_permission_decision(decision));
                         }
                         Err(err) => {
                             warn!(error = %err, "permission resolve failed");
@@ -1026,7 +1026,7 @@ async fn run_with_real_acp(
                         &token,
                         run_id,
                         &request_id,
-                        "permission",
+                        ApprovalKind::Permission,
                         &context,
                     )
                     .await
@@ -1203,32 +1203,24 @@ async fn run_with_real_acp(
     Ok(outcome_for_hold(true, hold_exit))
 }
 
-fn runtime_approval_decision(decision: StoredApprovalDecision) -> ApprovalDecision {
-    match decision {
-        StoredApprovalDecision::AllowOnce => ApprovalDecision::AllowOnce,
-        StoredApprovalDecision::AllowSession => ApprovalDecision::AllowSession,
-        StoredApprovalDecision::Deny => ApprovalDecision::Deny,
-    }
-}
-
 async fn resolve_permission(
     client: &reqwest::Client,
     api_url: &str,
     token: &str,
     run_id: Uuid,
     request_key: &str,
-    kind: &str,
+    kind: ApprovalKind,
     payload: &serde_json::Value,
 ) -> Result<ApprovalDecision> {
     let body = CreateApprovalRequest {
         request_key: request_key.to_string(),
-        kind: kind.to_string(),
-        risk: "medium".into(),
+        kind,
+        risk: ApprovalRisk::Medium,
         payload: payload.clone(),
         allowed_decisions: vec![
-            StoredApprovalDecision::AllowOnce,
-            StoredApprovalDecision::AllowSession,
-            StoredApprovalDecision::Deny,
+            ApprovalDecision::AllowOnce,
+            ApprovalDecision::AllowSession,
+            ApprovalDecision::Deny,
         ],
         expires_at: None,
     };
@@ -1245,9 +1237,7 @@ async fn resolve_permission(
 
     let approval_id = created.id;
     if created.status != ApprovalStatus::Pending {
-        return Ok(runtime_approval_decision(
-            created.decision.unwrap_or(StoredApprovalDecision::AllowOnce),
-        ));
+        return Ok(created.decision.unwrap_or(ApprovalDecision::AllowOnce));
     }
 
     // Poll until resolved.
@@ -1264,9 +1254,7 @@ async fn resolve_permission(
             .json()
             .await?;
         if approval.status != ApprovalStatus::Pending {
-            return Ok(runtime_approval_decision(
-                approval.decision.unwrap_or(StoredApprovalDecision::AllowOnce),
-            ));
+            return Ok(approval.decision.unwrap_or(ApprovalDecision::AllowOnce));
         }
     }
     bail!("approval {approval_id} timed out")

--- a/cloud/crates/db/src/lib.rs
+++ b/cloud/crates/db/src/lib.rs
@@ -14,8 +14,8 @@ use sqlx::SqlitePool;
 use std::str::FromStr;
 use uuid::Uuid;
 use zene_cloud_domain::{
-    ApprovalDecision, ApprovalRequest, ApprovalStatus, AuthResponse, CloneAuthResponse,
-    CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest, LoginRequest, Organization,
+    ApprovalDecision, ApprovalKind, ApprovalRequest, ApprovalRisk, ApprovalStatus, AuthResponse,
+    CloneAuthResponse, CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest, LoginRequest, Organization,
     QueueActive, QueueHold, QueueStats, RegisterRequest, Repository, Run, RunEvent, RunMessage,
     RunStatus, User, WorkerCommand, WorkerFence,
 };
@@ -1592,8 +1592,8 @@ impl Db {
         .bind(id.to_string())
         .bind(run_id.to_string())
         .bind(&req.request_key)
-        .bind(&req.kind)
-        .bind(&req.risk)
+        .bind(req.kind.as_str())
+        .bind(req.risk.as_str())
         .bind(&payload)
         .bind(status.as_str())
         .bind(&allowed)
@@ -1629,7 +1629,7 @@ impl Db {
                 "approvalId": id,
                 "status": status.as_str(),
                 "decision": decision.map(|d| d.as_str()),
-                "kind": req.kind,
+                "kind": req.kind.as_str(),
             }),
         )
         .await?;
@@ -2033,8 +2033,8 @@ pub(crate) fn map_approval_full_row(
         id: Uuid::parse_str(&row.0).unwrap(),
         run_id: Uuid::parse_str(&row.1).unwrap(),
         request_key: row.2,
-        kind: row.3,
-        risk: row.4,
+        kind: ApprovalKind::parse(&row.3).unwrap_or(ApprovalKind::Permission),
+        risk: ApprovalRisk::parse(&row.4).unwrap_or(ApprovalRisk::Medium),
         payload: serde_json::from_str(&row.5).unwrap_or(serde_json::json!({})),
         status: ApprovalStatus::parse(&row.6).unwrap_or(ApprovalStatus::Pending),
         allowed_decisions: allowed,

--- a/cloud/crates/db/tests/smoke.rs
+++ b/cloud/crates/db/tests/smoke.rs
@@ -2,7 +2,8 @@ use sqlx::sqlite::SqlitePoolOptions;
 use uuid::Uuid;
 use zene_cloud_db::Db;
 use zene_cloud_domain::{
-    ApprovalDecision, ApprovalStatus, CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest,
+    ApprovalDecision, ApprovalKind, ApprovalRisk, ApprovalStatus, CreateApprovalRequest,
+    CreateRepositoryRequest, CreateRunRequest,
     RegisterRequest, RunStatus, WorkerCommandKind, WorkerFence,
 };
 
@@ -343,8 +344,8 @@ async fn approval_test_run(permission_mode: &str) -> (Db, Uuid) {
 fn approval_request(request_key: &str) -> CreateApprovalRequest {
     CreateApprovalRequest {
         request_key: request_key.into(),
-        kind: "permission".into(),
-        risk: "medium".into(),
+        kind: ApprovalKind::Permission,
+        risk: ApprovalRisk::Medium,
         payload: serde_json::json!({"path": "notes.txt"}),
         allowed_decisions: vec![ApprovalDecision::AllowOnce, ApprovalDecision::Deny],
         expires_at: None,

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -315,8 +315,8 @@ pub struct WorkerEventRequest {
 #[cfg(test)]
 mod tests {
     use super::{
-        ApprovalDecision, CreateApprovalRequest, WorkerCommand, WorkerCommandAckRequest,
-        WorkerCommandKind, WorkerEventRequest, WorkerFence,
+        ApprovalDecision, ApprovalKind, ApprovalRisk, CreateApprovalRequest, WorkerCommand,
+        WorkerCommandAckRequest, WorkerCommandKind, WorkerEventRequest, WorkerFence,
     };
 
     #[test]
@@ -406,6 +406,20 @@ mod tests {
         assert!(encoded.get("jsonrpcId").is_none());
         assert_eq!(encoded["requestKey"], "permission-1");
         assert_eq!(encoded["kind"], "permission");
+    }
+
+    #[test]
+    fn approval_kind_and_risk_round_trip_wire_strings() {
+        let encoded = serde_json::to_value(ApprovalKind::Permission).expect("kind");
+        assert_eq!(encoded, serde_json::json!("permission"));
+        let encoded = serde_json::to_value(ApprovalKind::Tool).expect("kind");
+        assert_eq!(encoded, serde_json::json!("tool"));
+        let encoded = serde_json::to_value(ApprovalRisk::Medium).expect("risk");
+        assert_eq!(encoded, serde_json::json!("medium"));
+        assert_eq!(ApprovalKind::parse("tool"), Some(ApprovalKind::Tool));
+        assert_eq!(ApprovalRisk::parse("high"), Some(ApprovalRisk::High));
+        assert_eq!(ApprovalKind::parse("other"), None);
+        assert_eq!(ApprovalDecision::parse("unknown"), None);
     }
 }
 
@@ -551,13 +565,66 @@ impl ApprovalDecision {
     }
 }
 
+/// Product approval kind stored by Cloud. Wire JSON stays `permission` / `tool`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalKind {
+    Permission,
+    Tool,
+}
+
+impl ApprovalKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Permission => "permission",
+            Self::Tool => "tool",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "permission" => Some(Self::Permission),
+            "tool" => Some(Self::Tool),
+            _ => None,
+        }
+    }
+}
+
+/// Product approval risk stored by Cloud. Wire JSON stays `low` / `medium` / `high`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalRisk {
+    Low,
+    Medium,
+    High,
+}
+
+impl ApprovalRisk {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "low" => Some(Self::Low),
+            "medium" => Some(Self::Medium),
+            "high" => Some(Self::High),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateApprovalRequest {
     pub request_key: String,
-    pub kind: String,
+    pub kind: ApprovalKind,
     #[serde(default = "default_risk")]
-    pub risk: String,
+    pub risk: ApprovalRisk,
     pub payload: serde_json::Value,
     #[serde(default = "default_allowed_decisions")]
     pub allowed_decisions: Vec<ApprovalDecision>,
@@ -565,8 +632,8 @@ pub struct CreateApprovalRequest {
     pub expires_at: Option<DateTime<Utc>>,
 }
 
-fn default_risk() -> String {
-    "medium".into()
+fn default_risk() -> ApprovalRisk {
+    ApprovalRisk::Medium
 }
 
 fn default_allowed_decisions() -> Vec<ApprovalDecision> {
@@ -619,8 +686,8 @@ pub struct ApprovalRequest {
     pub id: Id,
     pub run_id: Id,
     pub request_key: String,
-    pub kind: String,
-    pub risk: String,
+    pub kind: ApprovalKind,
+    pub risk: ApprovalRisk,
     pub payload: serde_json::Value,
     pub status: ApprovalStatus,
     pub allowed_decisions: Vec<ApprovalDecision>,

--- a/cloud/crates/runtime-client/Cargo.toml
+++ b/cloud/crates/runtime-client/Cargo.toml
@@ -11,3 +11,4 @@ serde_json.workspace = true
 tokio.workspace = true
 uuid.workspace = true
 zene-cloud-acp-bridge.workspace = true
+zene-cloud-domain.workspace = true

--- a/cloud/crates/runtime-client/src/lib.rs
+++ b/cloud/crates/runtime-client/src/lib.rs
@@ -8,38 +8,19 @@ use serde_json::Value;
 use tokio::sync::{mpsc, Mutex};
 use zene_cloud_acp_bridge::{AcpBridge, AcpEvent, BridgeMsg, PermissionDecision};
 
-/// Transport-neutral approval outcome. Variants match
-/// `zene_runtime::ApprovalDecision`; ACP `optionId` strings stay inside this
-/// adapter until Cloud depends on that crate.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ApprovalDecision {
-    AllowOnce,
-    AllowSession,
-    Deny,
-}
+pub use zene_cloud_domain::ApprovalDecision;
 
-impl ApprovalDecision {
-    pub fn from_stored(decision: &str) -> Self {
-        match decision {
-            "allow-always" | "allow" => Self::AllowSession,
-            "allow-once" => Self::AllowOnce,
-            _ => Self::Deny,
-        }
-    }
-}
-
-impl From<ApprovalDecision> for PermissionDecision {
-    fn from(decision: ApprovalDecision) -> Self {
-        match decision {
-            ApprovalDecision::AllowOnce => Self::AllowOnce,
-            ApprovalDecision::AllowSession => Self::AllowSession,
-            ApprovalDecision::Deny => Self::Deny,
-        }
+/// ACP `optionId` mapping stays inside this adapter.
+pub fn to_permission_decision(decision: ApprovalDecision) -> PermissionDecision {
+    match decision {
+        ApprovalDecision::AllowOnce => PermissionDecision::AllowOnce,
+        ApprovalDecision::AllowSession => PermissionDecision::AllowSession,
+        ApprovalDecision::Deny => PermissionDecision::Deny,
     }
 }
 
 fn acp_permission_result(decision: ApprovalDecision) -> Value {
-    PermissionDecision::from(decision).to_result()
+    to_permission_decision(decision).to_result()
 }
 
 /// Transport-neutral runtime event kind. Names align with
@@ -990,20 +971,21 @@ mod tests {
     #[test]
     fn stored_console_decisions_map_to_neutral_approval() {
         assert_eq!(
-            ApprovalDecision::from_stored("allow-once"),
-            ApprovalDecision::AllowOnce
+            ApprovalDecision::parse("allow-once"),
+            Some(ApprovalDecision::AllowOnce)
         );
         assert_eq!(
-            ApprovalDecision::from_stored("allow-always"),
-            ApprovalDecision::AllowSession
+            ApprovalDecision::parse("allow-always"),
+            Some(ApprovalDecision::AllowSession)
         );
         assert_eq!(
-            ApprovalDecision::from_stored("allow"),
-            ApprovalDecision::AllowSession
+            ApprovalDecision::parse("allow"),
+            Some(ApprovalDecision::AllowSession)
         );
         assert_eq!(
-            ApprovalDecision::from_stored("reject-once"),
-            ApprovalDecision::Deny
+            ApprovalDecision::parse("reject-once"),
+            Some(ApprovalDecision::Deny)
         );
+        assert_eq!(ApprovalDecision::parse("unknown"), None);
     }
 }

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `7ee9dc6`（PR #75 已合并）。**
+> **进度快照：2026-08-13，基线 `bf8bdfa`（PR #76 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 存库/API 审批决策已中性。当前工作是把 ACP `jsonrpc_id` 移出 Cloud 产品审批类型。
+> Wave 16 当前工作是收口 Cloud 审批产品面（决策/kind/risk 一套类型，Console 到 RuntimeCommand）。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -32,7 +32,7 @@
 3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。Cloud `RuntimeCommand::Approval` 已与 core 同形（`request_id` + `ApprovalDecision`），但 Cloud 仍无 Steer/SetMode 等变体，也未依赖 `zene-runtime`。已分类 Cloud payload 已是产品字段；未识别帧仍为 ACP JSON。
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者，但 Agent-specific actor 仍在 `zene-core`，ACP 仍保留 transport 层 session bookkeeping。
-6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 与 option 列表只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。已分类 Cloud payload 与审批表 payload 已是产品字段；未识别帧仍为 ACP JSON。API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举。Cloud 存库/API 审批决策是 `ApprovalDecision` 枚举，wire JSON 仍为 `allow-once` / `allow-always` / `reject-once`。
+6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 与 option 列表只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`，并带 `ApprovalKind` / `ApprovalRisk`。已分类 Cloud payload 与审批表 payload 已是产品字段；未识别帧仍为 ACP JSON。API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举。
 7. `ToolRegistry` 仍同时承担目录与执行；`RuntimeScope` 尚未成为 Subagent 的正式差异注入面。
 
 本文目标不是立刻重写 runtime，而是建立一个可以渐进落地的目标架构：
@@ -104,7 +104,7 @@ RuntimeHandle → Agent → TurnEngine
 | Subagent | `crates/core/src/subagent.rs` | 直接实现 `TurnEnginePorts`；仍用独立 `ChatBackend` 和内存消息，尚未 `RuntimeScope` |
 | Runtime | `crates/runtime` + `crates/core/src/agent_runtime.rs` | 公共 command/event 在 `zene-runtime`；Agent actor 仍在 core |
 | ACP | `apps/cli/src/acp/server.rs` | transport adapter；创建/加载 session，并把请求接入 `RuntimeHandle` |
-| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；API→worker `WorkerCommand` 为 Prompt/Cancel；存库/API 审批决策为 `ApprovalDecision`；产品审批类型无 `jsonrpc_id`；已分类事件与审批表 payload 已是产品字段，未识别帧仍为 ACP JSON |
+| Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；API→worker `WorkerCommand` 为 Prompt/Cancel；审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；ACP `optionId` 只在 adapter 内映射 |
 
 ## 3. 核心概念边界
 
@@ -952,7 +952,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 2. **`Agent` 仍是 God Object**：它同时持有 model、tools、sandbox、permission、hooks、MCP、todos、plan mode。下一步是把它变成 wiring，而不是继续实现 step。
 3. **模型抽象仍偏 provider**：`ModelExecutor` 吃 `ChatRequest`；Subagent 另有 `ChatBackend`。目标是 Turn 只看见 `PreparedContext` → `ModelRequest`。
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
-5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。Cloud 存库/API 审批决策是 `ApprovalDecision` 枚举。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
+5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision` / `ApprovalKind` / `ApprovalRisk`。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
 6. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
 Conversation event 与 materialized `messages` cache 的双轨可以保留，直到 legacy session 可证明无损迁移。不要为了架构干净上完整 Event Sourcing。
@@ -1052,7 +1052,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          Cloud 审批表 payload 使用产品字段
          API→worker WorkerCommand kind 使用 Prompt/Cancel 枚举
          Cloud 存库/API 审批决策使用 ApprovalDecision 枚举
-         Cloud 产品审批类型不再携带 jsonrpc_id（本轮）
+         Cloud 产品审批类型不再携带 jsonrpc_id
+         Cloud 审批产品面（决策/kind/risk）从 Console 到 RuntimeCommand 收口（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1077,13 +1078,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | 已分类 event/审批 payload、command/决策枚举已中性；产品审批类型不再携带 `jsonrpc_id`；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | Cloud 审批产品面已收口；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；API→worker `WorkerCommand` 为 Prompt/Cancel；存库/API 审批决策为 `ApprovalDecision`；产品审批类型不再携带 `jsonrpc_id`；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1112,7 +1113,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - pending tool / approval 的任意副作用自动 replay：继续采用 inspection/manual intervention，避免重复写操作。
    - `Agent` 从 step orchestrator 完全退回 composition root。
    - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor` / ModelExecutor，而不是并行 `ChatBackend`。
-   - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Cancel/Approval/Shutdown；API→worker 已是 Prompt/Cancel；存库/API 审批决策已是 `ApprovalDecision`；仍缺 Steer/SetMode，且不依赖 `zene-runtime`）。未识别 Cloud 帧仍为 ACP JSON。
+   - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Cancel/Approval/Shutdown；API→worker 已是 Prompt/Cancel；审批产品面已收口；仍缺 Steer/SetMode，且不依赖 `zene-runtime`）。未识别 Cloud 帧仍为 ACP JSON。
    - Agent-specific actor 从 `zene-core` 移入独立 runtime implementation crate（应在 ports/审批稳定之后）。
    - 跨 VM outbox 的共享持久化实现；当前部署文档要求共享 POSIX volume 或后续 DB/object spool。
 
@@ -1181,7 +1182,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - RuntimeClient 把 ACP `sessionUpdate` 分类为中性 `event_type`；已分类 payload 存产品字段。
    - Console 按 `event_type` 分发；新产品 payload 直接渲染，legacy `params.update` 仍可回放。
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
-   - Cloud 存库/API 审批决策是 `ApprovalDecision` 枚举，wire JSON 仍为 `allow-once` / `allow-always` / `reject-once`（兼容 `allow` / `deny` 别名）。ACP `optionId` 仍只在 adapter 内映射。
+   - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1207,7 +1208,7 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | 存库/API 审批决策已中性；Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | Cloud 审批产品面已收口；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
 推荐组合：**事件语义已收口到未识别帧**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
@@ -1338,5 +1339,12 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 - `CreateApprovalRequest` / `ApprovalRequest` 不再携带 ACP `jsonrpc_id`。worker 创建审批不再传入该字段。
 - 数据库列保留但不读写；不迁移、不删列。不改 Console 布局。
+- 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
+
+### 2026-08-13 — Cloud 审批产品面
+
+- domain `ApprovalDecision` 成为存库、Decide API、Console 与 `RuntimeCommand::Approval` 的同一类型；runtime-client 不再另定义一份。ACP `optionId` 经 `to_permission_decision` 留在 adapter。
+- `ApprovalKind`（`permission` / `tool`）与 `ApprovalRisk`（`low` / `medium` / `high`）同样是产品枚举。
+- Console 用同一套 wire 字符串类型，审批卡片布局不变。
 - 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #73–#76 把 Cloud 审批拆成了很小的切片（WorkerCommand、存库决策、jsonrpc_id）。本 PR 把 **Cloud 审批产品面** 一次收完。

存库、Decide API、Console 与 `RuntimeCommand::Approval` 共用 domain `ApprovalDecision`。runtime-client 不再另定义一份，ACP `optionId` 只通过 `to_permission_decision` 留在 adapter。`ApprovalKind`（permission/tool）与 `ApprovalRisk`（low/medium/high）同样是产品枚举。Console 用同一套 wire 字符串类型，审批卡片布局不变。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-db -p zene-cloud-runtime-client -p zene-cloud-api -p zene-cloud-worker --locked` 已通过。`cd cloud/apps/web && npm run typecheck` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

