### PR TITLE
feat: Console 时间线按产品 event_type 渲染

### DIFF
--- a/cloud/apps/web/components/RunView.tsx
+++ b/cloud/apps/web/components/RunView.tsx
@@ -31,8 +31,8 @@ import {
   saveSelectedModel,
 } from "@/lib/models";
 import { allowsDeny, allowsOnce, extraDecisions } from "@/lib/approval";
-import type { AcpSessionUpdate, Approval, ApprovalDecision, LlmSettingsView, Repo, Run, RunEvent, RunMessage } from "@/lib/types";
-import { timelineUpdateFromEvent } from "@/lib/runtimeEvent";
+import type { Approval, ApprovalDecision, LlmSettingsView, Repo, Run, RunEvent, RunMessage } from "@/lib/types";
+import { timelineProductFromEvent, timelineToolOutput, type TimelineProduct } from "@/lib/runtimeEvent";
 import { CodePanel, useCodePanelWidth } from "./CodePanel";
 import { Markdown } from "./Markdown";
 import { repoLabel } from "./Sidebar";
@@ -185,11 +185,11 @@ function draftAppendThought(draft: TimelineDraft, text: string) {
   });
 }
 
-function draftUpsertTool(draft: TimelineDraft, update: AcpSessionUpdate) {
-  const toolCallId = update.toolCallId || `tool-${draft.nextId}`;
-  const title = update.title || update.toolName || "tool";
-  const status = update.status || "pending";
-  const input = formatJsonish(update.rawInput);
+function draftUpsertTool(draft: TimelineDraft, product: TimelineProduct) {
+  const toolCallId = product.toolCallId || `tool-${draft.nextId}`;
+  const title = product.title || product.toolName || "tool";
+  const status = product.status || "pending";
+  const input = formatJsonish(product.rawInput);
   draft.hasAssistantTail = false;
   const idx = draft.items.findIndex((it) => it.kind === "tool" && it.toolCallId === toolCallId);
   if (idx >= 0) {
@@ -197,7 +197,7 @@ function draftUpsertTool(draft: TimelineDraft, update: AcpSessionUpdate) {
     draft.items[idx] = {
       ...cur,
       title: title || cur.title,
-      toolKind: update.kind || cur.toolKind,
+      toolKind: product.toolKind || cur.toolKind,
       status,
       input: input || cur.input,
     };
@@ -209,18 +209,18 @@ function draftUpsertTool(draft: TimelineDraft, update: AcpSessionUpdate) {
     id: draft.nextId++,
     toolCallId,
     title,
-    toolKind: update.kind,
+    toolKind: product.toolKind,
     status,
     input: input || undefined,
     expanded: false,
   });
 }
 
-function draftApplyToolUpdate(draft: TimelineDraft, update: AcpSessionUpdate) {
-  const toolCallId = update.toolCallId;
+function draftApplyToolUpdate(draft: TimelineDraft, product: TimelineProduct) {
+  const toolCallId = product.toolCallId;
   if (!toolCallId) return;
-  const status = update.status || "completed";
-  const output = toolOutputText(update);
+  const status = product.status || "completed";
+  const output = timelineToolOutput(product);
   draft.hasAssistantTail = false;
   const idx = draft.items.findIndex((it) => it.kind === "tool" && it.toolCallId === toolCallId);
   if (idx < 0) {
@@ -229,8 +229,8 @@ function draftApplyToolUpdate(draft: TimelineDraft, update: AcpSessionUpdate) {
       kind: "tool",
       id: draft.nextId++,
       toolCallId,
-      title: update.title || update.toolName || "tool",
-      toolKind: update.kind,
+      title: product.title || product.toolName || "tool",
+      toolKind: product.toolKind,
       status,
       output: output || undefined,
       expanded: false,
@@ -240,27 +240,24 @@ function draftApplyToolUpdate(draft: TimelineDraft, update: AcpSessionUpdate) {
   const cur = draft.items[idx] as Extract<TimelineItem, { kind: "tool" }>;
   draft.items[idx] = {
     ...cur,
-    title: update.title || cur.title,
-    toolKind: update.kind || cur.toolKind,
+    title: product.title || cur.title,
+    toolKind: product.toolKind || cur.toolKind,
     status,
     output: output || cur.output,
   };
 }
 
-function applySessionUpdateToDraft(draft: TimelineDraft, update: AcpSessionUpdate) {
-  if (!update.sessionUpdate) return;
-  if (update.sessionUpdate === "agent_message_chunk") {
-    const text =
-      update.content && !Array.isArray(update.content) ? update.content.text || "" : "";
-    draftAppendAssistant(draft, text);
-  } else if (update.sessionUpdate === "agent_thought_chunk") {
-    const text =
-      update.content && !Array.isArray(update.content) ? update.content.text || "" : "";
-    draftAppendThought(draft, text);
-  } else if (update.sessionUpdate === "tool_call") {
-    draftUpsertTool(draft, update);
-  } else if (update.sessionUpdate === "tool_call_update") {
-    draftApplyToolUpdate(draft, update);
+function applyTimelineProductToDraft(draft: TimelineDraft, product: TimelineProduct) {
+  if (product.kind === "text_delta") {
+    draftAppendAssistant(draft, product.text || "");
+  } else if (product.kind === "thought_delta") {
+    draftAppendThought(draft, product.text || "");
+  } else if (product.kind === "user_message") {
+    draftAppendUser(draft, product.text || "");
+  } else if (product.kind === "tool_call") {
+    draftUpsertTool(draft, product);
+  } else if (product.kind === "tool_result") {
+    draftApplyToolUpdate(draft, product);
   }
 }
 
@@ -297,8 +294,8 @@ function buildTimelineFromEvents(events: RunEvent[]): TimelineDraft {
   const draft: TimelineDraft = { items: [], nextId: 1, hasAssistantTail: false };
   for (const event of events) {
     applyPlatformEventToDraft(draft, event.payload || {});
-    const update = timelineUpdateFromEvent(event);
-    if (update) applySessionUpdateToDraft(draft, update);
+    const product = timelineProductFromEvent(event);
+    if (product) applyTimelineProductToDraft(draft, product);
   }
   draft.items = finalizeTimelineDraft(draft);
   return draft;
@@ -312,21 +309,6 @@ function formatJsonish(value: unknown): string {
   } catch {
     return String(value);
   }
-}
-
-function toolOutputText(update: AcpSessionUpdate): string {
-  if (update.rawOutput?.text) return update.rawOutput.text;
-  const content = update.content;
-  if (Array.isArray(content)) {
-    return content
-      .map((c) => c.content?.text || c.text || "")
-      .filter(Boolean)
-      .join("\n");
-  }
-  if (content && typeof content === "object" && "text" in content) {
-    return content.text || "";
-  }
-  return "";
 }
 
 type MetaItem = Extract<TimelineItem, { kind: "thought" | "tool" }>;
@@ -1040,12 +1022,29 @@ export function RunView({
     [scrollMessages, sealOpenMeta],
   );
 
+  const appendUserBubble = useCallback(
+    (text: string) => {
+      if (!text) return;
+      hasAssistantTail.current = false;
+      setItems((prev) => {
+        for (let i = prev.length - 1; i >= 0; i--) {
+          const it = prev[i];
+          if (it.kind === "bubble" && it.role === "user" && it.text === text) return prev;
+          if (it.kind === "bubble" && it.role === "assistant") break;
+        }
+        return [...prev, { kind: "bubble", id: nextId.current++, role: "user", text }];
+      });
+      scrollMessages();
+    },
+    [scrollMessages],
+  );
+
   const upsertToolCall = useCallback(
-    (update: AcpSessionUpdate) => {
-      const toolCallId = update.toolCallId || `tool-${nextId.current}`;
-      const title = update.title || update.toolName || "tool";
-      const status = update.status || "pending";
-      const input = formatJsonish(update.rawInput);
+    (product: TimelineProduct) => {
+      const toolCallId = product.toolCallId || `tool-${nextId.current}`;
+      const title = product.title || product.toolName || "tool";
+      const status = product.status || "pending";
+      const input = formatJsonish(product.rawInput);
       hasAssistantTail.current = false;
       setItems((prev) => {
         const idx = prev.findIndex((it) => it.kind === "tool" && it.toolCallId === toolCallId);
@@ -1055,7 +1054,7 @@ export function RunView({
           copy[idx] = {
             ...cur,
             title: title || cur.title,
-            toolKind: update.kind || cur.toolKind,
+            toolKind: product.toolKind || cur.toolKind,
             status,
             input: input || cur.input,
           };
@@ -1068,7 +1067,7 @@ export function RunView({
             id: nextId.current++,
             toolCallId,
             title,
-            toolKind: update.kind,
+            toolKind: product.toolKind,
             status,
             input: input || undefined,
             expanded: false,
@@ -1081,11 +1080,11 @@ export function RunView({
   );
 
   const applyToolUpdate = useCallback(
-    (update: AcpSessionUpdate) => {
-      const toolCallId = update.toolCallId;
+    (product: TimelineProduct) => {
+      const toolCallId = product.toolCallId;
       if (!toolCallId) return;
-      const status = update.status || "completed";
-      const output = toolOutputText(update);
+      const status = product.status || "completed";
+      const output = timelineToolOutput(product);
       hasAssistantTail.current = false;
       setItems((prev) => {
         const idx = prev.findIndex((it) => it.kind === "tool" && it.toolCallId === toolCallId);
@@ -1096,8 +1095,8 @@ export function RunView({
               kind: "tool",
               id: nextId.current++,
               toolCallId,
-              title: update.title || update.toolName || "tool",
-              toolKind: update.kind,
+              title: product.title || product.toolName || "tool",
+              toolKind: product.toolKind,
               status,
               output: output || undefined,
               expanded: false,
@@ -1108,8 +1107,8 @@ export function RunView({
         const cur = copy[idx] as Extract<TimelineItem, { kind: "tool" }>;
         copy[idx] = {
           ...cur,
-          title: update.title || cur.title,
-          toolKind: update.kind || cur.toolKind,
+          title: product.title || cur.title,
+          toolKind: product.toolKind || cur.toolKind,
           status,
           output: output || cur.output,
         };
@@ -1206,41 +1205,28 @@ export function RunView({
       if (payload.event === "message.created") {
         const role = (payload as { role?: string }).role;
         const text = (payload as { text?: string }).text || "";
-        if (bubbleRole(role) === "user" && text) {
-          hasAssistantTail.current = false;
-          setItems((prev) => {
-            // Avoid duplicating the optimistic bubble from sendFollowUp.
-            for (let i = prev.length - 1; i >= 0; i--) {
-              const it = prev[i];
-              if (it.kind === "bubble" && it.role === "user" && it.text === text) return prev;
-              if (it.kind === "bubble" && it.role === "assistant") break;
-            }
-            return [...prev, { kind: "bubble", id: nextId.current++, role: "user", text }];
-          });
-          scrollMessages();
-        }
+        if (bubbleRole(role) === "user" && text) appendUserBubble(text);
       }
 
-      const update = timelineUpdateFromEvent(event);
-      if (!update?.sessionUpdate) return;
+      const product = timelineProductFromEvent(event);
+      if (!product) return;
 
-      if (update.sessionUpdate === "agent_message_chunk") {
-        const text =
-          update.content && !Array.isArray(update.content) ? update.content.text || "" : "";
-        appendAssistantChunk(text);
-      } else if (update.sessionUpdate === "agent_thought_chunk") {
-        const text =
-          update.content && !Array.isArray(update.content) ? update.content.text || "" : "";
-        appendThoughtChunk(text);
-      } else if (update.sessionUpdate === "tool_call") {
-        upsertToolCall(update);
-      } else if (update.sessionUpdate === "tool_call_update") {
-        applyToolUpdate(update);
+      if (product.kind === "text_delta") {
+        appendAssistantChunk(product.text || "");
+      } else if (product.kind === "thought_delta") {
+        appendThoughtChunk(product.text || "");
+      } else if (product.kind === "user_message") {
+        appendUserBubble(product.text || "");
+      } else if (product.kind === "tool_call") {
+        upsertToolCall(product);
+      } else if (product.kind === "tool_result") {
+        applyToolUpdate(product);
       }
     },
     [
       appendAssistantChunk,
       appendThoughtChunk,
+      appendUserBubble,
       upsertToolCall,
       applyToolUpdate,
       onRunsChanged,

--- a/cloud/apps/web/lib/runtimeEvent.ts
+++ b/cloud/apps/web/lib/runtimeEvent.ts
@@ -1,60 +1,127 @@
-import type { AcpSessionUpdate, RunEvent } from "@/lib/types";
+import type { AcpSessionUpdate, CloudEventKind, RunEvent } from "@/lib/types";
 
-/** Product event kinds from Cloud RuntimeClient. Unknown/legacy frames stay `acp`. */
-export const TIMELINE_KIND_TO_SESSION_UPDATE = {
-  text_delta: "agent_message_chunk",
-  thought_delta: "agent_thought_chunk",
-  tool_call: "tool_call",
-  tool_result: "tool_call_update",
-} as const;
+/** Classified product kinds that already have a Console timeline surface. */
+export const TIMELINE_EVENT_KINDS = [
+  "text_delta",
+  "thought_delta",
+  "user_message",
+  "tool_call",
+  "tool_result",
+] as const satisfies readonly CloudEventKind[];
 
-export type TimelineEventKind = keyof typeof TIMELINE_KIND_TO_SESSION_UPDATE;
+export type TimelineEventKind = (typeof TIMELINE_EVENT_KINDS)[number];
+
+export interface TimelineProduct {
+  kind: TimelineEventKind;
+  text?: string;
+  toolCallId?: string;
+  title?: string;
+  toolName?: string;
+  toolKind?: string;
+  status?: string;
+  rawInput?: unknown;
+  rawOutput?: { text?: string; isError?: boolean };
+  isError?: boolean;
+}
 
 export function eventKind(event: Pick<RunEvent, "eventType" | "event_type">): string {
   return (event.eventType || event.event_type || "acp").toLowerCase();
 }
 
-/**
- * Resolve the ACP-shaped update used to render a timeline item.
- *
- * New timeline kinds store a denormalized product payload (`text`,
- * `toolCallId`, …). Records that still have `params.update` (legacy `acp` /
- * `runtime`, and classified events from before payload denormalization) keep
- * that path. Classified kinds overwrite `sessionUpdate`.
- */
-export function timelineUpdateFromEvent(event: RunEvent): AcpSessionUpdate | undefined {
-  const kind = eventKind(event);
-  const mapped = TIMELINE_KIND_TO_SESSION_UPDATE[kind as TimelineEventKind];
-  const legacy = event.payload?.params?.update;
-  if (legacy) {
-    if (!mapped) return legacy;
-    return { ...legacy, sessionUpdate: mapped };
-  }
-  if (!mapped || !event.payload) return undefined;
-  return productToSessionUpdate(mapped, event.payload);
+function isTimelineKind(kind: string): kind is TimelineEventKind {
+  return (TIMELINE_EVENT_KINDS as readonly string[]).includes(kind);
 }
 
-function productToSessionUpdate(
-  sessionUpdate: (typeof TIMELINE_KIND_TO_SESSION_UPDATE)[TimelineEventKind],
-  payload: NonNullable<RunEvent["payload"]>,
-): AcpSessionUpdate {
-  const text = typeof payload.text === "string" ? payload.text : undefined;
-  const update: AcpSessionUpdate = {
-    sessionUpdate,
+function contentText(update: AcpSessionUpdate): string {
+  const content = update.content;
+  if (Array.isArray(content)) {
+    return content
+      .map((item) => item.content?.text || item.text || "")
+      .filter(Boolean)
+      .join("\n");
+  }
+  if (content && typeof content === "object" && "text" in content) {
+    return content.text || "";
+  }
+  return "";
+}
+
+function toolOutputText(product: TimelineProduct): string {
+  if (product.rawOutput?.text) return product.rawOutput.text;
+  if (product.text) return product.text;
+  return "";
+}
+
+function productFromPayload(kind: TimelineEventKind, payload: NonNullable<RunEvent["payload"]>): TimelineProduct {
+  return {
+    kind,
+    text: typeof payload.text === "string" ? payload.text : undefined,
     toolCallId: payload.toolCallId,
     title: payload.title,
     toolName: payload.toolName,
-    kind: payload.kind,
+    toolKind: payload.kind,
     status: payload.status,
     rawInput: payload.rawInput,
     rawOutput: payload.rawOutput,
+    isError: payload.isError,
   };
-  if (payload.rawOutput == null && (text != null || payload.isError != null)) {
-    update.rawOutput = { text, isError: payload.isError };
+}
+
+function productFromLegacy(update: AcpSessionUpdate): TimelineProduct | undefined {
+  switch (update.sessionUpdate) {
+    case "agent_message_chunk":
+      return { kind: "text_delta", text: contentText(update) };
+    case "agent_thought_chunk":
+      return { kind: "thought_delta", text: contentText(update) };
+    case "user_message_chunk":
+      return { kind: "user_message", text: contentText(update) };
+    case "tool_call":
+      return {
+        kind: "tool_call",
+        toolCallId: update.toolCallId,
+        title: update.title,
+        toolName: update.toolName,
+        toolKind: update.kind,
+        status: update.status,
+        rawInput: update.rawInput,
+      };
+    case "tool_call_update":
+      return {
+        kind: "tool_result",
+        text: contentText(update),
+        toolCallId: update.toolCallId,
+        title: update.title,
+        toolName: update.toolName,
+        toolKind: update.kind,
+        status: update.status,
+        rawOutput: update.rawOutput,
+      };
+    default:
+      return undefined;
   }
-  if (text != null) {
-    update.content =
-      sessionUpdate === "tool_call_update" ? [{ content: { text }, text }] : { text };
+}
+
+/**
+ * Resolve the product fields used to render a timeline item.
+ *
+ * Classified kinds store denormalized product fields (`text`, `toolCallId`, …).
+ * Records that still have `params.update` keep that ACP path. `user_message`
+ * uses the existing user bubble; other classified kinds stay off the timeline.
+ */
+export function timelineProductFromEvent(event: RunEvent): TimelineProduct | undefined {
+  const kind = eventKind(event);
+  const legacy = event.payload?.params?.update;
+  if (legacy) {
+    const fromLegacy = productFromLegacy(legacy);
+    if (fromLegacy && isTimelineKind(kind)) {
+      return { ...fromLegacy, kind };
+    }
+    return fromLegacy;
   }
-  return update;
+  if (!isTimelineKind(kind) || !event.payload) return undefined;
+  return productFromPayload(kind, event.payload);
+}
+
+export function timelineToolOutput(product: TimelineProduct): string {
+  return toolOutputText(product);
 }

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -64,6 +64,24 @@ export interface RunMessage {
   createdAt: string;
 }
 
+/** Classified product kinds written by RuntimeClient. `platform` / legacy `runtime` stay outside this union. */
+export type CloudEventKind =
+  | "text_delta"
+  | "thought_delta"
+  | "user_message"
+  | "tool_call"
+  | "tool_result"
+  | "state_changed"
+  | "usage_update"
+  | "projection_ready"
+  | "plan"
+  | "available_commands"
+  | "session_started"
+  | "approval_requested"
+  | "acp";
+
+export type RunEventType = CloudEventKind | "platform" | "runtime";
+
 export interface AcpSessionUpdate {
   sessionUpdate?: string;
   content?: { text?: string } | Array<{ type?: string; content?: { text?: string }; text?: string }>;
@@ -81,8 +99,8 @@ export interface RunEvent {
   /** Optional provider/runtime cursor; `seq` remains the server ordering. */
   cursor?: number;
   createdAt: string;
-  eventType?: string;
-  event_type?: string;
+  eventType?: RunEventType;
+  event_type?: RunEventType;
   payload?: {
     event?: string;
     status?: string;

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -150,6 +150,66 @@ pub struct UpdateRunRequest {
     pub archived: Option<bool>,
 }
 
+/// Product `event_type` written by RuntimeClient for classified frames.
+/// Unrecognized ACP frames are `acp`. Platform / legacy `runtime` rows stay
+/// plain strings on `RunEvent`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CloudEventKind {
+    TextDelta,
+    ThoughtDelta,
+    UserMessage,
+    ToolCall,
+    ToolResult,
+    StateChanged,
+    UsageUpdate,
+    ProjectionReady,
+    Plan,
+    AvailableCommands,
+    SessionStarted,
+    ApprovalRequested,
+    Acp,
+}
+
+impl CloudEventKind {
+    pub fn as_event_type(self) -> &'static str {
+        match self {
+            Self::TextDelta => "text_delta",
+            Self::ThoughtDelta => "thought_delta",
+            Self::UserMessage => "user_message",
+            Self::ToolCall => "tool_call",
+            Self::ToolResult => "tool_result",
+            Self::StateChanged => "state_changed",
+            Self::UsageUpdate => "usage_update",
+            Self::ProjectionReady => "projection_ready",
+            Self::Plan => "plan",
+            Self::AvailableCommands => "available_commands",
+            Self::SessionStarted => "session_started",
+            Self::ApprovalRequested => "approval_requested",
+            Self::Acp => "acp",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "text_delta" => Self::TextDelta,
+            "thought_delta" => Self::ThoughtDelta,
+            "user_message" => Self::UserMessage,
+            "tool_call" => Self::ToolCall,
+            "tool_result" => Self::ToolResult,
+            "state_changed" => Self::StateChanged,
+            "usage_update" => Self::UsageUpdate,
+            "projection_ready" => Self::ProjectionReady,
+            "plan" => Self::Plan,
+            "available_commands" => Self::AvailableCommands,
+            "session_started" => Self::SessionStarted,
+            "approval_requested" => Self::ApprovalRequested,
+            "acp" => Self::Acp,
+            _ => return None,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RunEvent {
@@ -315,8 +375,8 @@ pub struct WorkerEventRequest {
 #[cfg(test)]
 mod tests {
     use super::{
-        ApprovalDecision, ApprovalKind, ApprovalRisk, CreateApprovalRequest, WorkerCommand,
-        WorkerCommandAckRequest, WorkerCommandKind, WorkerEventRequest, WorkerFence,
+        ApprovalDecision, ApprovalKind, ApprovalRisk, CloudEventKind, CreateApprovalRequest,
+        WorkerCommand, WorkerCommandAckRequest, WorkerCommandKind, WorkerEventRequest, WorkerFence,
     };
 
     #[test]
@@ -420,6 +480,31 @@ mod tests {
         assert_eq!(ApprovalRisk::parse("high"), Some(ApprovalRisk::High));
         assert_eq!(ApprovalKind::parse("other"), None);
         assert_eq!(ApprovalDecision::parse("unknown"), None);
+    }
+
+    #[test]
+    fn cloud_event_kind_round_trips_classified_strings() {
+        for kind in [
+            CloudEventKind::TextDelta,
+            CloudEventKind::ThoughtDelta,
+            CloudEventKind::UserMessage,
+            CloudEventKind::ToolCall,
+            CloudEventKind::ToolResult,
+            CloudEventKind::StateChanged,
+            CloudEventKind::UsageUpdate,
+            CloudEventKind::ProjectionReady,
+            CloudEventKind::Plan,
+            CloudEventKind::AvailableCommands,
+            CloudEventKind::SessionStarted,
+            CloudEventKind::ApprovalRequested,
+            CloudEventKind::Acp,
+        ] {
+            let encoded = serde_json::to_value(kind).expect("serialize");
+            assert_eq!(encoded, serde_json::json!(kind.as_event_type()));
+            assert_eq!(CloudEventKind::parse(kind.as_event_type()), Some(kind));
+        }
+        assert_eq!(CloudEventKind::parse("platform"), None);
+        assert_eq!(CloudEventKind::parse("runtime"), None);
     }
 }
 

--- a/cloud/crates/runtime-client/src/lib.rs
+++ b/cloud/crates/runtime-client/src/lib.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use tokio::sync::{mpsc, Mutex};
 use zene_cloud_acp_bridge::{AcpBridge, AcpEvent, BridgeMsg, PermissionDecision};
 
-pub use zene_cloud_domain::ApprovalDecision;
+pub use zene_cloud_domain::{ApprovalDecision, CloudEventKind};
 
 /// ACP `optionId` mapping stays inside this adapter.
 pub fn to_permission_decision(decision: ApprovalDecision) -> PermissionDecision {
@@ -23,47 +23,9 @@ fn acp_permission_result(decision: ApprovalDecision) -> Value {
     to_permission_decision(decision).to_result()
 }
 
-/// Transport-neutral runtime event kind. Names align with
-/// `zene_turn::RuntimeEventKind` where the ACP update has a counterpart.
-/// ACP `sessionUpdate` strings stay inside this adapter.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RuntimeEventKind {
-    TextDelta,
-    ThoughtDelta,
-    UserMessage,
-    ToolCall,
-    ToolResult,
-    StateChanged,
-    UsageUpdate,
-    ProjectionReady,
-    Plan,
-    AvailableCommands,
-    SessionStarted,
-    ApprovalRequested,
-    Unknown,
-}
-
-impl RuntimeEventKind {
-    pub fn as_event_type(self) -> &'static str {
-        match self {
-            Self::TextDelta => "text_delta",
-            Self::ThoughtDelta => "thought_delta",
-            Self::UserMessage => "user_message",
-            Self::ToolCall => "tool_call",
-            Self::ToolResult => "tool_result",
-            Self::StateChanged => "state_changed",
-            Self::UsageUpdate => "usage_update",
-            Self::ProjectionReady => "projection_ready",
-            Self::Plan => "plan",
-            Self::AvailableCommands => "available_commands",
-            Self::SessionStarted => "session_started",
-            Self::ApprovalRequested => "approval_requested",
-            Self::Unknown => "acp",
-        }
-    }
-}
-
-fn classify_payload(payload: &Value) -> RuntimeEventKind {
+/// ACP `sessionUpdate` strings stay inside this adapter; product kinds live on
+/// `CloudEventKind`.
+fn classify_payload(payload: &Value) -> CloudEventKind {
     if let Some(update) = payload
         .pointer("/params/update/sessionUpdate")
         .and_then(Value::as_str)
@@ -71,25 +33,25 @@ fn classify_payload(payload: &Value) -> RuntimeEventKind {
         return map_session_update(update);
     }
     match payload.get("method").and_then(Value::as_str) {
-        Some("session/request_permission") => RuntimeEventKind::ApprovalRequested,
-        Some("session/new") | Some("session/resume") => RuntimeEventKind::SessionStarted,
-        _ => RuntimeEventKind::Unknown,
+        Some("session/request_permission") => CloudEventKind::ApprovalRequested,
+        Some("session/new") | Some("session/resume") => CloudEventKind::SessionStarted,
+        _ => CloudEventKind::Acp,
     }
 }
 
-fn map_session_update(update: &str) -> RuntimeEventKind {
+fn map_session_update(update: &str) -> CloudEventKind {
     match update {
-        "agent_message_chunk" => RuntimeEventKind::TextDelta,
-        "agent_thought_chunk" => RuntimeEventKind::ThoughtDelta,
-        "user_message_chunk" => RuntimeEventKind::UserMessage,
-        "tool_call" => RuntimeEventKind::ToolCall,
-        "tool_call_update" => RuntimeEventKind::ToolResult,
-        "current_mode_update" => RuntimeEventKind::StateChanged,
-        "usage_update" => RuntimeEventKind::UsageUpdate,
-        "projection_update" => RuntimeEventKind::ProjectionReady,
-        "plan" => RuntimeEventKind::Plan,
-        "available_commands_update" => RuntimeEventKind::AvailableCommands,
-        _ => RuntimeEventKind::Unknown,
+        "agent_message_chunk" => CloudEventKind::TextDelta,
+        "agent_thought_chunk" => CloudEventKind::ThoughtDelta,
+        "user_message_chunk" => CloudEventKind::UserMessage,
+        "tool_call" => CloudEventKind::ToolCall,
+        "tool_call_update" => CloudEventKind::ToolResult,
+        "current_mode_update" => CloudEventKind::StateChanged,
+        "usage_update" => CloudEventKind::UsageUpdate,
+        "projection_update" => CloudEventKind::ProjectionReady,
+        "plan" => CloudEventKind::Plan,
+        "available_commands_update" => CloudEventKind::AvailableCommands,
+        _ => CloudEventKind::Acp,
     }
 }
 
@@ -186,17 +148,17 @@ fn runtime_notification(event: AcpEvent) -> RuntimeNotification {
     }
 }
 
-fn product_payload(kind: RuntimeEventKind, raw: &Value) -> Value {
+fn product_payload(kind: CloudEventKind, raw: &Value) -> Value {
     match kind {
-        RuntimeEventKind::TextDelta
-        | RuntimeEventKind::ThoughtDelta
-        | RuntimeEventKind::UserMessage => {
+        CloudEventKind::TextDelta
+        | CloudEventKind::ThoughtDelta
+        | CloudEventKind::UserMessage => {
             let Some(update) = raw.pointer("/params/update") else {
                 return raw.clone();
             };
             serde_json::json!({ "text": text_from_update(update) })
         }
-        RuntimeEventKind::ToolCall => {
+        CloudEventKind::ToolCall => {
             let Some(update) = raw.pointer("/params/update") else {
                 return raw.clone();
             };
@@ -205,7 +167,7 @@ fn product_payload(kind: RuntimeEventKind, raw: &Value) -> Value {
                 &["toolCallId", "title", "toolName", "kind", "status", "rawInput"],
             ))
         }
-        RuntimeEventKind::ToolResult => {
+        CloudEventKind::ToolResult => {
             let Some(update) = raw.pointer("/params/update") else {
                 return raw.clone();
             };
@@ -229,13 +191,13 @@ fn product_payload(kind: RuntimeEventKind, raw: &Value) -> Value {
             }
             Value::Object(map)
         }
-        RuntimeEventKind::ApprovalRequested => approval_product(raw),
-        RuntimeEventKind::SessionStarted => session_started_product(raw),
-        RuntimeEventKind::StateChanged => state_product(raw),
-        RuntimeEventKind::UsageUpdate => usage_product(raw),
-        RuntimeEventKind::ProjectionReady => projection_product(raw),
-        RuntimeEventKind::Plan => plan_product(raw),
-        RuntimeEventKind::AvailableCommands => commands_product(raw),
+        CloudEventKind::ApprovalRequested => approval_product(raw),
+        CloudEventKind::SessionStarted => session_started_product(raw),
+        CloudEventKind::StateChanged => state_product(raw),
+        CloudEventKind::UsageUpdate => usage_product(raw),
+        CloudEventKind::ProjectionReady => projection_product(raw),
+        CloudEventKind::Plan => plan_product(raw),
+        CloudEventKind::AvailableCommands => commands_product(raw),
         _ => raw.clone(),
     }
 }

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `bf8bdfa`（PR #76 已合并）。**
+> **进度快照：2026-08-13，基线 `1d53100`（PR #77 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是收口 Cloud 审批产品面（决策/kind/risk 一套类型，Console 到 RuntimeCommand）。
+> Wave 16 当前工作是 Console 时间线直接消费产品事件（`CloudEventKind`）；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -953,7 +953,8 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 3. **模型抽象仍偏 provider**：`ModelExecutor` 吃 `ChatRequest`；Subagent 另有 `ChatBackend`。目标是 Turn 只看见 `PreparedContext` → `ModelRequest`。
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
 5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision` / `ApprovalKind` / `ApprovalRisk`。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
-6. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
+6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection 等不进时间线。未识别帧仍为 `acp`。
+7. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
 Conversation event 与 materialized `messages` cache 的双轨可以保留，直到 legacy session 可证明无损迁移。不要为了架构干净上完整 Event Sourcing。
 
@@ -1053,7 +1054,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          API→worker WorkerCommand kind 使用 Prompt/Cancel 枚举
          Cloud 存库/API 审批决策使用 ApprovalDecision 枚举
          Cloud 产品审批类型不再携带 jsonrpc_id
-         Cloud 审批产品面（决策/kind/risk）从 Console 到 RuntimeCommand 收口（本轮）
+         Cloud 审批产品面（决策/kind/risk）从 Console 到 RuntimeCommand 收口
+         Console 时间线按 event_type 消费产品字段（含 user_message；本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1078,13 +1080,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | Cloud 审批产品面已收口；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | Console 已按产品 `event_type` 渲染时间线；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1179,8 +1181,8 @@ Wave 16  统一 transport command/event  ← 当前工作
 7. **Wave 16：统一 command/event（进行中）**
    - JobRunner 经 `RuntimeClient::send` 发送 Prompt/Cancel/Approval/Shutdown；`Approval` 携带 `request_id` + `ApprovalDecision`。
    - ACP jsonrpc id 与 `optionId` 只留在 RuntimeClient adapter。审批表 payload 存产品字段，不再存 ACP params。Cloud 产品审批类型不再携带 `jsonrpc_id`；DB 列保留但不读写。
-   - RuntimeClient 把 ACP `sessionUpdate` 分类为中性 `event_type`；已分类 payload 存产品字段。
-   - Console 按 `event_type` 分发；新产品 payload 直接渲染，legacy `params.update` 仍可回放。
+   - RuntimeClient 把 ACP `sessionUpdate` 分类为 domain `CloudEventKind`；已分类 payload 存产品字段。
+   - Console 按 `event_type` 分发时间线：`text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result` 直接渲染产品字段，legacy `params.update` 仍可回放。plan/usage/projection/session_started/approval_requested 不进时间线。
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
    - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
@@ -1208,10 +1210,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | Cloud 审批产品面已收口；Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | Console 已按产品事件渲染时间线；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**事件语义已收口到未识别帧**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
+推荐组合：**事件语义已收到 Console 时间线**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #77 收口了 Cloud 审批产品面。本 PR 把 **Cloud 事件产品面** 接到 Console 时间线。

domain `CloudEventKind` 是 RuntimeClient 的分类结果（未识别帧仍为 `acp`）。`platform` / legacy `runtime` 仍是 `RunEvent.event_type` 上的普通字符串。Console 时间线直接消费 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result` 的产品字段；旧记录仍走 `params.update`。`user_message` 与平台 `message.created` 按相同用户气泡文本去重。plan / usage / projection / session_started / approval_requested 不进时间线、不加新 UI。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不改 Console 布局 IA。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-runtime-client --locked` 已通过。`cd cloud/apps/web && npm run typecheck` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

