### PR TITLE
feat: JobRunner mock 路径走 RuntimeClient 产品类型

### DIFF
--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -12,14 +12,13 @@ use anyhow::{bail, Context, Result};
 use clap::Parser;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
-use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
-use zene_cloud_acp_bridge::{resolve_zene_bin, MockAgent, MockMsg, PermissionDecision};
+use zene_cloud_acp_bridge::resolve_zene_bin;
 use zene_cloud_runtime_client::{
-    approval_payload, to_permission_decision, AcpRuntimeClient, RuntimeClient, RuntimeCommand,
-    RuntimeEvent, RuntimeNotification, RuntimeRequest,
+    AcpRuntimeClient, MockRuntimeClient, RuntimeClient, RuntimeCommand, RuntimeEvent,
+    RuntimeNotification, RuntimeRequest,
 };
 use zene_cloud_domain::{
     ApprovalDecision, ApprovalKind, ApprovalRequest, ApprovalRisk, ApprovalStatus, ClaimedRun,
@@ -638,6 +637,93 @@ async fn prepare_workspace(
     Ok(())
 }
 
+fn spawn_event_pump<R: RuntimeClient + 'static>(
+    runtime: Arc<R>,
+    client: reqwest::Client,
+    api_url: String,
+    token: String,
+    run_id: Uuid,
+    fence: WorkerFence,
+    outbox: EventOutbox,
+) -> (
+    tokio::task::JoinHandle<()>,
+    Arc<tokio::sync::Mutex<Option<String>>>,
+) {
+    let event_error = Arc::new(tokio::sync::Mutex::new(None::<String>));
+    let event_error_task = event_error.clone();
+    let runtime_bg = runtime.clone();
+    let pump = tokio::spawn(async move {
+        while let Some(event) = runtime_bg.next_event().await {
+            match event {
+                RuntimeEvent::Initialized { event, .. } | RuntimeEvent::Notification(event) => {
+                    if let Err(err) = deliver_event(
+                        &outbox,
+                        &client,
+                        &api_url,
+                        &token,
+                        run_id,
+                        event_to_req(event),
+                        &fence,
+                    )
+                    .await
+                    {
+                        warn!(run_id = %run_id, error = %err, "event delivery failed");
+                        *event_error_task.lock().await = Some(err.to_string());
+                        break;
+                    }
+                }
+                RuntimeEvent::Request { request, event } => {
+                    if let Err(err) = deliver_event(
+                        &outbox,
+                        &client,
+                        &api_url,
+                        &token,
+                        run_id,
+                        event_to_req(event),
+                        &fence,
+                    )
+                    .await
+                    {
+                        warn!(run_id = %run_id, error = %err, "event delivery failed");
+                        *event_error_task.lock().await = Some(err.to_string());
+                        break;
+                    }
+                    let RuntimeRequest::Approval {
+                        request_id,
+                        kind,
+                        context,
+                    } = request;
+                    let decision = match resolve_permission(
+                        &client,
+                        &api_url,
+                        &token,
+                        run_id,
+                        &request_id,
+                        kind,
+                        &context,
+                    )
+                    .await
+                    {
+                        Ok(d) => d,
+                        Err(err) => {
+                            warn!(error = %err, "permission resolve failed");
+                            ApprovalDecision::Deny
+                        }
+                    };
+                    let _ = runtime_bg
+                        .send(RuntimeCommand::Approval { request_id, decision })
+                        .await;
+                }
+                RuntimeEvent::ChildExited => {
+                    info!(run_id = %run_id, "runtime child exited");
+                    break;
+                }
+            }
+        }
+    });
+    (pump, event_error)
+}
+
 async fn run_with_mock(
     client: &reqwest::Client,
     cli: &Cli,
@@ -653,84 +739,36 @@ async fn run_with_mock(
         .flush(client, &cli.api_url, &cli.worker_token, run_id, fence)
         .await
         .context("flush recovered event outbox")?;
-    let agent = MockAgent::new(workspace.to_path_buf());
-    let (msg_tx, mut msg_rx) = mpsc::unbounded_channel::<MockMsg>();
-
-    let client_bg = client.clone();
-    let cli_api = cli.api_url.clone();
-    let token = cli.worker_token.clone();
-    let event_fence = (*fence).clone();
-    let event_outbox = outbox.clone();
-    let event_error = Arc::new(tokio::sync::Mutex::new(None::<String>));
-    let event_error_task = event_error.clone();
-    let event_task = tokio::spawn(async move {
-        while let Some(msg) = msg_rx.recv().await {
-            match msg {
-                MockMsg::Event(event) => {
-                    if let Err(err) = deliver_event(
-                        &event_outbox,
-                        &client_bg,
-                        &cli_api,
-                        &token,
-                        run_id,
-                        event_to_req(RuntimeNotification::from_acp(event)),
-                        &event_fence,
-                    )
-                    .await
-                    {
-                        warn!(run_id = %run_id, error = %err, "event delivery failed");
-                        *event_error_task.lock().await = Some(err.to_string());
-                        break;
-                    }
-                }
-                MockMsg::Permission {
-                    request_key,
-                    params,
-                    respond,
-                } => {
-                    match resolve_permission(
-                        &client_bg,
-                        &cli_api,
-                        &token,
-                        run_id,
-                        &request_key,
-                        ApprovalKind::Tool,
-                        &approval_payload(&params),
-                    )
-                    .await
-                    {
-                        Ok(decision) => {
-                            let _ = respond.send(to_permission_decision(decision));
-                        }
-                        Err(err) => {
-                            warn!(error = %err, "permission resolve failed");
-                            let _ = respond.send(PermissionDecision::Deny);
-                        }
-                    }
-                }
-            }
-        }
-    });
+    let runtime = Arc::new(MockRuntimeClient::connect(workspace));
+    let (event_task, event_error) = spawn_event_pump(
+        runtime.clone(),
+        client.clone(),
+        cli.api_url.clone(),
+        cli.worker_token.clone(),
+        run_id,
+        (*fence).clone(),
+        outbox,
+    );
 
     let cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let cancel_flag = cancelled.clone();
+    let runtime_cancel = runtime.clone();
     let client_cmd = client.clone();
     let cli_cmd = cli.api_url.clone();
     let token_cmd = cli.worker_token.clone();
     let command_fence = (*fence).clone();
-    let command_agent = agent.clone();
-    let command_tx = msg_tx.clone();
     let cmd_task = tokio::spawn(async move {
         loop {
             if let Ok(commands) = fetch_commands(&client_cmd, &cli_cmd, &token_cmd, run_id, &command_fence).await {
                 for cmd in commands {
                     if cmd.kind == WorkerCommandKind::Cancel {
                         cancel_flag.store(true, std::sync::atomic::Ordering::SeqCst);
+                        let _ = runtime_cancel.send(RuntimeCommand::Cancel).await;
                         return;
                     }
                     if cmd.kind == WorkerCommandKind::Prompt {
                         if let (Some(text), Some(message_id)) = (cmd.text, cmd.message_id) {
-                            match command_agent.run_prompt(&text, command_tx.clone()).await {
+                            match runtime_cancel.send(RuntimeCommand::Prompt { text }).await {
                                 Ok(()) => {
                                     if let Err(err) = ack_command(
                                         &client_cmd, &cli_cmd, &token_cmd, run_id,
@@ -749,46 +787,13 @@ async fn run_with_mock(
         }
     });
 
-    let mut prompts: Vec<(String, Option<Uuid>)> = vec![(claimed.run.prompt.clone(), None)];
-    // Drain any follow-ups already waiting.
-    if let Ok(commands) = fetch_commands(client, &cli.api_url, &cli.worker_token, run_id, &fence).await {
-        for cmd in commands {
-            if cmd.kind == WorkerCommandKind::Cancel {
-                cmd_task.abort();
-                drop(msg_tx);
-                event_task.await.context("event pump")?;
-                if let Some(err) = event_error.lock().await.clone() {
-                    bail!("event delivery failed: {err}");
-                }
-                set_status(client, cli, run_id, &fence, RunStatus::Cancelled, None, None).await?;
-                return Ok(RunOutcome::Cancelled);
-            }
-            if cmd.kind == WorkerCommandKind::Prompt {
-                if let Some(text) = cmd.text {
-                    prompts.push((text, cmd.message_id));
-                }
-            }
-        }
-    }
+    runtime
+        .send(RuntimeCommand::Prompt {
+            text: claimed.run.prompt.clone(),
+        })
+        .await
+        .context("mock prompt")?;
 
-    for (prompt, message_id) in prompts {
-        if cancelled.load(std::sync::atomic::Ordering::SeqCst) {
-            break;
-        }
-        if shutdown.load(Ordering::SeqCst) {
-            drop(msg_tx);
-            cmd_task.abort();
-            event_task.await.context("event pump")?;
-            return Ok(RunOutcome::Shutdown);
-        }
-        agent.run_prompt(&prompt, msg_tx.clone()).await?;
-        if let Some(message_id) = message_id {
-            ack_command(client, &cli.api_url, &cli.worker_token, run_id, &fence, message_id)
-                .await?;
-        }
-    }
-
-    // Keep listening briefly for follow-up prompts.
     let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
     while tokio::time::Instant::now() < deadline {
         if cancelled.load(std::sync::atomic::Ordering::SeqCst)
@@ -796,30 +801,12 @@ async fn run_with_mock(
         {
             break;
         }
-        if let Ok(commands) = fetch_commands(client, &cli.api_url, &cli.worker_token, run_id, &fence).await {
-            for cmd in commands {
-                if cmd.kind == WorkerCommandKind::Cancel {
-                    cancelled.store(true, std::sync::atomic::Ordering::SeqCst);
-                    break;
-                }
-                if let Some(text) = cmd.text {
-                    if cmd.kind == WorkerCommandKind::Prompt {
-                        agent.run_prompt(&text, msg_tx.clone()).await?;
-                        if let Some(message_id) = cmd.message_id {
-                            ack_command(client, &cli.api_url, &cli.worker_token, run_id, &fence, message_id)
-                                .await?;
-                        }
-                        // extend wait window a bit after each follow-up
-                    }
-                }
-            }
-        }
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
 
-    drop(msg_tx);
-    event_task.await.context("event pump")?;
+    let _ = runtime.send(RuntimeCommand::Shutdown).await;
     cmd_task.abort();
+    let _ = event_task.await;
 
     if let Some(err) = event_error.lock().await.clone() {
         bail!("event delivery failed: {err}");
@@ -974,80 +961,15 @@ async fn run_with_real_acp(
     );
     let session_id = runtime.session_id().await?;
     persist_acp_session(client, cli, run_id, fence, &session_id).await?;
-    let client_bg = client.clone();
-    let cli_api = cli.api_url.clone();
-    let token = cli.worker_token.clone();
-    let pump_fence = (*fence).clone();
-    let pump_outbox = outbox.clone();
-    let event_error = Arc::new(tokio::sync::Mutex::new(None::<String>));
-    let event_error_pump = event_error.clone();
-    let runtime_bg = runtime.clone();
-    let pump = tokio::spawn(async move {
-        while let Some(event) = runtime_bg.next_event().await {
-            match event {
-                RuntimeEvent::Initialized { event, .. }
-                | RuntimeEvent::Notification(event) => {
-                    if let Err(err) = deliver_event(
-                        &pump_outbox,
-                        &client_bg,
-                        &cli_api,
-                        &token,
-                        run_id,
-                        event_to_req(event),
-                        &pump_fence,
-                    )
-                    .await
-                    {
-                        warn!(run_id = %run_id, error = %err, "event delivery failed");
-                        *event_error_pump.lock().await = Some(err.to_string());
-                        break;
-                    }
-                }
-                RuntimeEvent::Request { request, event } => {
-                    if let Err(err) = deliver_event(
-                        &pump_outbox,
-                        &client_bg,
-                        &cli_api,
-                        &token,
-                        run_id,
-                        event_to_req(event),
-                        &pump_fence,
-                    )
-                    .await
-                    {
-                        warn!(run_id = %run_id, error = %err, "event delivery failed");
-                        *event_error_pump.lock().await = Some(err.to_string());
-                        break;
-                    }
-                    let RuntimeRequest::Approval { request_id, context } = request;
-                    let decision = match resolve_permission(
-                        &client_bg,
-                        &cli_api,
-                        &token,
-                        run_id,
-                        &request_id,
-                        ApprovalKind::Permission,
-                        &context,
-                    )
-                    .await
-                    {
-                        Ok(d) => d,
-                        Err(err) => {
-                            warn!(error = %err, "permission resolve failed");
-                            ApprovalDecision::Deny
-                        }
-                    };
-                    let _ = runtime_bg
-                        .send(RuntimeCommand::Approval { request_id, decision })
-                        .await;
-                }
-                RuntimeEvent::ChildExited => {
-                    info!(run_id = %run_id, "runtime child exited");
-                    break;
-                }
-            }
-        }
-    });
+    let (pump, event_error) = spawn_event_pump(
+        runtime.clone(),
+        client.clone(),
+        cli.api_url.clone(),
+        cli.worker_token.clone(),
+        run_id,
+        (*fence).clone(),
+        outbox,
+    );
 
     let cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
     let last_activity = std::sync::Arc::new(tokio::sync::Mutex::new(tokio::time::Instant::now()));
@@ -1330,7 +1252,7 @@ fn event_to_req(event: RuntimeNotification) -> WorkerEventRequest {
     WorkerEventRequest {
         source_event_id: event.source_event_id,
         cursor: event.cursor,
-        event_type: event.event_type,
+        event_type: event.event_type.as_event_type().to_string(),
         payload: event.payload,
         fence: None,
     }

--- a/cloud/crates/runtime-client/src/lib.rs
+++ b/cloud/crates/runtime-client/src/lib.rs
@@ -1,14 +1,17 @@
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use serde_json::Value;
-use tokio::sync::{mpsc, Mutex};
-use zene_cloud_acp_bridge::{AcpBridge, AcpEvent, BridgeMsg, PermissionDecision};
+use tokio::sync::{mpsc, oneshot, Mutex};
+use zene_cloud_acp_bridge::{
+    AcpBridge, AcpEvent, BridgeMsg, MockAgent, MockMsg, PermissionDecision,
+};
 
-pub use zene_cloud_domain::{ApprovalDecision, CloudEventKind};
+pub use zene_cloud_domain::{ApprovalDecision, ApprovalKind, CloudEventKind};
 
 /// ACP `optionId` mapping stays inside this adapter.
 pub fn to_permission_decision(decision: ApprovalDecision) -> PermissionDecision {
@@ -77,7 +80,7 @@ pub enum RuntimeCommand {
 pub struct RuntimeNotification {
     pub source_event_id: String,
     pub cursor: Option<u64>,
-    pub event_type: String,
+    pub event_type: CloudEventKind,
     pub payload: Value,
 }
 
@@ -102,13 +105,14 @@ pub enum RuntimeEvent {
 pub enum RuntimeRequest {
     Approval {
         request_id: String,
+        kind: ApprovalKind,
         context: Value,
     },
 }
 
 /// Product payload stored on Cloud approval rows. ACP option lists and
 /// session metadata stay inside the adapter.
-pub fn approval_payload(params: &Value) -> Value {
+fn approval_payload(params: &Value) -> Value {
     let mut map = serde_json::Map::new();
     map.insert(
         "requestId".into(),
@@ -143,7 +147,7 @@ fn runtime_notification(event: AcpEvent) -> RuntimeNotification {
     RuntimeNotification {
         source_event_id: event.source_event_id,
         cursor: event.cursor,
-        event_type: kind.as_event_type().into(),
+        event_type: kind,
         payload: product_payload(kind, &event.payload),
     }
 }
@@ -330,6 +334,7 @@ fn runtime_request(method: &str, params: &Value) -> Option<RuntimeRequest> {
     if method == "session/request_permission" {
         Some(RuntimeRequest::Approval {
             request_id: permission_request_key(params),
+            kind: ApprovalKind::Permission,
             context: approval_payload(params),
         })
     } else {
@@ -486,6 +491,130 @@ impl RuntimeClient for AcpRuntimeClient {
     }
 }
 
+/// In-process runtime used when no `zene` binary is available.
+///
+/// MockAgent still speaks ACP internally; this adapter exposes the same
+/// `RuntimeClient` product types as [`AcpRuntimeClient`].
+pub struct MockRuntimeClient {
+    agent: MockAgent,
+    msg_tx: Mutex<Option<mpsc::UnboundedSender<MockMsg>>>,
+    events: Arc<Mutex<mpsc::UnboundedReceiver<RuntimeEvent>>>,
+    pending_approvals: Arc<Mutex<HashMap<String, oneshot::Sender<PermissionDecision>>>>,
+    prompt_lock: Mutex<()>,
+    alive: AtomicBool,
+}
+
+impl MockRuntimeClient {
+    pub fn connect(workdir: &Path) -> Self {
+        let agent = MockAgent::new(workdir.to_path_buf());
+        let session_id = agent.session_id().to_string();
+        let (msg_tx, mut msg_rx) = mpsc::unbounded_channel();
+        let (events_tx, events_rx) = mpsc::unbounded_channel();
+        let pending_approvals = Arc::new(Mutex::new(HashMap::new()));
+        let pending = pending_approvals.clone();
+        let _ = events_tx.send(RuntimeEvent::Initialized {
+            session_id: session_id.clone(),
+            event: RuntimeNotification {
+                source_event_id: format!("mock-session-{session_id}"),
+                cursor: None,
+                event_type: CloudEventKind::SessionStarted,
+                payload: serde_json::json!({ "sessionId": session_id }),
+            },
+        });
+        tokio::spawn(async move {
+            while let Some(message) = msg_rx.recv().await {
+                let event = match message {
+                    MockMsg::Event(event) => {
+                        RuntimeEvent::Notification(RuntimeNotification::from_acp(event))
+                    }
+                    MockMsg::Permission {
+                        request_key,
+                        params,
+                        respond,
+                    } => {
+                        pending.lock().await.insert(request_key.clone(), respond);
+                        let event = RuntimeNotification::from_acp(AcpEvent::from_reverse_request(
+                            &Value::String(request_key.clone()),
+                            "session/request_permission",
+                            &params,
+                        ));
+                        let mut context = approval_payload(&params);
+                        if let Some(map) = context.as_object_mut() {
+                            map.insert("requestId".into(), Value::String(request_key.clone()));
+                        }
+                        RuntimeEvent::Request {
+                            request: RuntimeRequest::Approval {
+                                request_id: request_key,
+                                kind: ApprovalKind::Tool,
+                                context,
+                            },
+                            event,
+                        }
+                    }
+                };
+                if events_tx.send(event).is_err() {
+                    break;
+                }
+            }
+            let _ = events_tx.send(RuntimeEvent::ChildExited);
+        });
+        Self {
+            agent,
+            msg_tx: Mutex::new(Some(msg_tx)),
+            events: Arc::new(Mutex::new(events_rx)),
+            pending_approvals,
+            prompt_lock: Mutex::new(()),
+            alive: AtomicBool::new(true),
+        }
+    }
+}
+
+#[async_trait]
+impl RuntimeClient for MockRuntimeClient {
+    async fn session_id(&self) -> Result<String> {
+        Ok(self.agent.session_id().to_string())
+    }
+
+    async fn send(&self, command: RuntimeCommand) -> Result<()> {
+        match command {
+            RuntimeCommand::Prompt { text } => {
+                let _guard = self.prompt_lock.lock().await;
+                let msg_tx = self
+                    .msg_tx
+                    .lock()
+                    .await
+                    .clone()
+                    .ok_or_else(|| anyhow!("mock runtime shut down"))?;
+                self.agent.run_prompt(&text, msg_tx).await
+            }
+            RuntimeCommand::Cancel => Ok(()),
+            RuntimeCommand::Approval { request_id, decision } => {
+                let respond = self
+                    .pending_approvals
+                    .lock()
+                    .await
+                    .remove(&request_id)
+                    .ok_or_else(|| anyhow!("unknown approval request_id {request_id}"))?;
+                let _ = respond.send(to_permission_decision(decision));
+                Ok(())
+            }
+            RuntimeCommand::Shutdown => {
+                self.alive.store(false, Ordering::SeqCst);
+                self.msg_tx.lock().await.take();
+                Ok(())
+            }
+        }
+    }
+
+    async fn next_event(&self) -> Option<RuntimeEvent> {
+        self.events.lock().await.recv().await
+    }
+
+    async fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::SeqCst)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -498,7 +627,11 @@ mod tests {
         );
         assert!(matches!(
             request,
-            Some(RuntimeRequest::Approval { request_id, .. }) if request_id == "call-7"
+            Some(RuntimeRequest::Approval {
+                request_id,
+                kind: ApprovalKind::Permission,
+                ..
+            }) if request_id == "call-7"
         ));
     }
 
@@ -558,7 +691,7 @@ mod tests {
             }
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
-        assert_eq!(event.event_type, "text_delta");
+        assert_eq!(event.event_type.as_event_type(), "text_delta");
         assert!(event.source_event_id.starts_with("acp-"));
         assert_eq!(event.cursor, None);
         assert_eq!(event.payload, serde_json::json!({ "text": "hello" }));
@@ -576,7 +709,7 @@ mod tests {
             }
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
-        assert_eq!(event.event_type, "thought_delta");
+        assert_eq!(event.event_type.as_event_type(), "thought_delta");
         assert_eq!(event.payload, serde_json::json!({ "text": "hmm" }));
     }
 
@@ -596,7 +729,7 @@ mod tests {
             }
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
-        assert_eq!(event.event_type, "tool_call");
+        assert_eq!(event.event_type.as_event_type(), "tool_call");
         assert_eq!(
             event.payload,
             serde_json::json!({
@@ -627,7 +760,7 @@ mod tests {
             }
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
-        assert_eq!(event.event_type, "tool_result");
+        assert_eq!(event.event_type.as_event_type(), "tool_result");
         assert_eq!(event.payload["toolCallId"], "call-1");
         assert_eq!(event.payload["status"], "completed");
         assert_eq!(event.payload["text"], "ok");
@@ -649,7 +782,7 @@ mod tests {
             }
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
-        assert_eq!(event.event_type, "user_message");
+        assert_eq!(event.event_type.as_event_type(), "user_message");
         assert_eq!(event.payload, serde_json::json!({ "text": "hi" }));
     }
 
@@ -665,7 +798,7 @@ mod tests {
             }
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
-        assert_eq!(event.event_type, "state_changed");
+        assert_eq!(event.event_type.as_event_type(), "state_changed");
         assert_eq!(event.payload, serde_json::json!({ "state": "plan" }));
         assert!(event.payload.get("modeId").is_none());
         assert!(event.payload.get("sessionUpdate").is_none());
@@ -693,7 +826,7 @@ mod tests {
             }
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
-        assert_eq!(event.event_type, "usage_update");
+        assert_eq!(event.event_type.as_event_type(), "usage_update");
         assert_eq!(
             event.payload,
             serde_json::json!({
@@ -729,7 +862,7 @@ mod tests {
             }
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
-        assert_eq!(event.event_type, "projection_ready");
+        assert_eq!(event.event_type.as_event_type(), "projection_ready");
         assert_eq!(
             event.payload,
             serde_json::json!({
@@ -755,7 +888,7 @@ mod tests {
             }
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
-        assert_eq!(event.event_type, "plan");
+        assert_eq!(event.event_type.as_event_type(), "plan");
         assert_eq!(
             event.payload,
             serde_json::json!({
@@ -776,7 +909,7 @@ mod tests {
             }
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
-        assert_eq!(event.event_type, "available_commands");
+        assert_eq!(event.event_type.as_event_type(), "available_commands");
         assert_eq!(
             event.payload,
             serde_json::json!({
@@ -796,7 +929,7 @@ mod tests {
             }
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
-        assert_eq!(event.event_type, "acp");
+        assert_eq!(event.event_type.as_event_type(), "acp");
         assert_eq!(event.payload, raw);
     }
 
@@ -811,7 +944,7 @@ mod tests {
                 "result": { "sessionId": "session-1" }
             }),
         });
-        assert_eq!(event.event_type, "session_started");
+        assert_eq!(event.event_type.as_event_type(), "session_started");
         assert_eq!(event.payload, serde_json::json!({ "sessionId": "session-1" }));
     }
 
@@ -827,7 +960,7 @@ mod tests {
                 "result": { "sessionId": "session-1" }
             }),
         });
-        assert_eq!(event.event_type, "session_started");
+        assert_eq!(event.event_type.as_event_type(), "session_started");
         assert_eq!(
             event.payload,
             serde_json::json!({ "sessionId": "session-1", "resumed": true })
@@ -849,7 +982,7 @@ mod tests {
                 }
             }),
         ));
-        assert_eq!(event.event_type, "approval_requested");
+        assert_eq!(event.event_type.as_event_type(), "approval_requested");
         assert_eq!(
             event.payload,
             serde_json::json!({
@@ -880,7 +1013,11 @@ mod tests {
         let request = runtime_request("session/request_permission", &params);
         assert!(matches!(
             request,
-            Some(RuntimeRequest::Approval { request_id, context })
+            Some(RuntimeRequest::Approval {
+                request_id,
+                kind: ApprovalKind::Permission,
+                context
+            })
                 if request_id == "call-7"
                     && context == serde_json::json!({
                         "requestId": "call-7",
@@ -949,5 +1086,61 @@ mod tests {
             Some(ApprovalDecision::Deny)
         );
         assert_eq!(ApprovalDecision::parse("unknown"), None);
+    }
+
+    #[tokio::test]
+    async fn mock_runtime_client_emits_product_events_and_tool_approval() {
+        let dir = std::env::temp_dir().join(format!("zene-mock-runtime-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let client = Arc::new(MockRuntimeClient::connect(&dir));
+        let pump = client.clone();
+        let pump_task = tokio::spawn(async move {
+            let mut saw_text = false;
+            let mut saw_tool_approval = false;
+            while let Some(event) = pump.next_event().await {
+                match event {
+                    RuntimeEvent::Initialized { event, .. } => {
+                        assert_eq!(event.event_type, CloudEventKind::SessionStarted);
+                    }
+                    RuntimeEvent::Notification(event) => {
+                        if event.event_type == CloudEventKind::TextDelta {
+                            saw_text = true;
+                        }
+                    }
+                    RuntimeEvent::Request { request, event } => {
+                        assert_eq!(event.event_type, CloudEventKind::ApprovalRequested);
+                        let RuntimeRequest::Approval {
+                            request_id,
+                            kind,
+                            context,
+                        } = request;
+                        assert_eq!(kind, ApprovalKind::Tool);
+                        assert_eq!(context["toolCallId"], "tool_write_notes");
+                        pump.send(RuntimeCommand::Approval {
+                            request_id,
+                            decision: ApprovalDecision::AllowOnce,
+                        })
+                        .await
+                        .expect("resolve mock approval");
+                        saw_tool_approval = true;
+                    }
+                    RuntimeEvent::ChildExited => break,
+                }
+                if saw_text && saw_tool_approval {
+                    break;
+                }
+            }
+            (saw_text, saw_tool_approval)
+        });
+        client
+            .send(RuntimeCommand::Prompt {
+                text: "write notes".into(),
+            })
+            .await
+            .expect("mock prompt");
+        let (saw_text, saw_tool_approval) = pump_task.await.expect("pump");
+        assert!(saw_text, "expected classified text_delta");
+        assert!(saw_tool_approval, "expected tool approval request");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `1d53100`（PR #77 已合并）。**
+> **进度快照：2026-08-13，基线 `8ff37a6`（PR #78 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是 Console 时间线直接消费产品事件（`CloudEventKind`）；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是 JobRunner mock 路径走 `RuntimeClient` 产品类型；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -954,7 +954,8 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
 5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision` / `ApprovalKind` / `ApprovalRisk`。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
 6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection 等不进时间线。未识别帧仍为 `acp`。
-7. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
+7. **JobRunner 只看见 RuntimeClient 产品类型（Wave 16）**：mock 与真实 ACP 共用 event pump；`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeRequest::Approval` 携带 `ApprovalKind`。ACP `MockMsg` / `optionId` 只留在 adapter。
+8. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
 Conversation event 与 materialized `messages` cache 的双轨可以保留，直到 legacy session 可证明无损迁移。不要为了架构干净上完整 Event Sourcing。
 
@@ -1055,7 +1056,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          Cloud 存库/API 审批决策使用 ApprovalDecision 枚举
          Cloud 产品审批类型不再携带 jsonrpc_id
          Cloud 审批产品面（决策/kind/risk）从 Console 到 RuntimeCommand 收口
-         Console 时间线按 event_type 消费产品字段（含 user_message；本轮）
+         Console 时间线按 event_type 消费产品字段（含 user_message）
+         JobRunner mock 路径走 RuntimeClient 产品类型（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1080,13 +1082,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | Console 已按产品 `event_type` 渲染时间线；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | JobRunner mock/real 共用 RuntimeClient；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 都只看见 `RuntimeClient` 产品类型；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1185,6 +1187,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - Console 按 `event_type` 分发时间线：`text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result` 直接渲染产品字段，legacy `params.update` 仍可回放。plan/usage/projection/session_started/approval_requested 不进时间线。
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
    - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
+   - JobRunner mock 与真实 ACP 共用 event pump；只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；审批请求携带 `ApprovalKind`。ACP `MockMsg` 与 `optionId` 只留在 adapter。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1210,10 +1213,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | Console 已按产品事件渲染时间线；Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | JobRunner 已只看见 RuntimeClient 产品类型；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**事件语义已收到 Console 时间线**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
+推荐组合：**JobRunner 已与 ACP 解耦**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #78 把 Console 时间线接到了产品 `event_type`。本 PR 把 **JobRunner** 从 ACP 解耦：mock 与真实 ACP 共用同一条 event pump。

`RuntimeNotification.event_type` 改为 domain `CloudEventKind`。`RuntimeRequest::Approval` 携带 `ApprovalKind`（ACP 为 permission，mock 为 tool），JobRunner 不再写死 kind。新增 `MockRuntimeClient` 实现 `RuntimeClient`；ACP `MockMsg` / `optionId` 只留在 adapter。Worker 不再调用 `from_acp` / `approval_payload` / `to_permission_decision`。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不改 Console 布局。

`cd cloud && cargo test -p zene-cloud-runtime-client -p zene-cloud-worker --locked` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

