### PR TITLE
feat: JobRunner mock/real 共用同一条 runtime session

### DIFF
--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -724,6 +724,198 @@ fn spawn_event_pump<R: RuntimeClient + 'static>(
     (pump, event_error)
 }
 
+fn spawn_command_poller<R: RuntimeClient + 'static>(
+    runtime: Arc<R>,
+    client: reqwest::Client,
+    api_url: String,
+    token: String,
+    run_id: Uuid,
+    fence: WorkerFence,
+    cancelled: Arc<AtomicBool>,
+    last_activity: Arc<tokio::sync::Mutex<tokio::time::Instant>>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match fetch_commands(&client, &api_url, &token, run_id, &fence).await {
+                Ok(commands) => {
+                    for cmd in commands {
+                        if cmd.kind == WorkerCommandKind::Cancel {
+                            cancelled.store(true, Ordering::SeqCst);
+                            let _ = runtime.send(RuntimeCommand::Cancel).await;
+                            return;
+                        }
+                        if cmd.kind == WorkerCommandKind::Prompt {
+                            if let Some(text) = cmd.text {
+                                {
+                                    let mut ts = last_activity.lock().await;
+                                    *ts = tokio::time::Instant::now();
+                                }
+                                let _ = set_status_raw(
+                                    &client,
+                                    &api_url,
+                                    &token,
+                                    run_id,
+                                    &fence,
+                                    RunStatus::Running,
+                                )
+                                .await;
+                                match runtime.send(RuntimeCommand::Prompt { text }).await {
+                                    Ok(()) => {
+                                        if let Some(message_id) = cmd.message_id {
+                                            if let Err(err) = ack_command(
+                                                &client,
+                                                &api_url,
+                                                &token,
+                                                run_id,
+                                                &fence,
+                                                message_id,
+                                            )
+                                            .await
+                                            {
+                                                warn!(error = %err, "follow-up command acknowledgement failed");
+                                            }
+                                        }
+                                    }
+                                    Err(err) => {
+                                        warn!(error = %err, "follow-up prompt failed; command will be retried");
+                                    }
+                                }
+                                {
+                                    let mut ts = last_activity.lock().await;
+                                    *ts = tokio::time::Instant::now();
+                                }
+                                if !cancelled.load(Ordering::SeqCst) {
+                                    let _ = set_status_raw(
+                                        &client,
+                                        &api_url,
+                                        &token,
+                                        run_id,
+                                        &fence,
+                                        RunStatus::WaitingForUser,
+                                    )
+                                    .await;
+                                }
+                            }
+                        }
+                    }
+                }
+                Err(err) => warn!(error = %err, "commands poll failed"),
+            }
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    })
+}
+
+async fn run_runtime_session<R: RuntimeClient + 'static>(
+    runtime: Arc<R>,
+    client: &reqwest::Client,
+    cli: &Cli,
+    claimed: &ClaimedRun,
+    fence: &WorkerFence,
+    outbox: EventOutbox,
+    shutdown: Arc<AtomicBool>,
+    idle: Duration,
+    llm_env: Option<&HashMap<String, String>>,
+    persist_session: bool,
+) -> Result<RunOutcome> {
+    let run_id = claimed.run.id;
+    if persist_session {
+        let session_id = runtime.session_id().await?;
+        persist_acp_session(client, cli, run_id, fence, &session_id).await?;
+    }
+    let (pump, event_error) = spawn_event_pump(
+        runtime.clone(),
+        client.clone(),
+        cli.api_url.clone(),
+        cli.worker_token.clone(),
+        run_id,
+        (*fence).clone(),
+        outbox,
+    );
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let last_activity = Arc::new(tokio::sync::Mutex::new(tokio::time::Instant::now()));
+    let cmd_task = spawn_command_poller(
+        runtime.clone(),
+        client.clone(),
+        cli.api_url.clone(),
+        cli.worker_token.clone(),
+        run_id,
+        (*fence).clone(),
+        cancelled.clone(),
+        last_activity.clone(),
+    );
+
+    runtime
+        .send(RuntimeCommand::Prompt {
+            text: claimed.run.prompt.clone(),
+        })
+        .await
+        .context("runtime prompt")?;
+    {
+        let mut ts = last_activity.lock().await;
+        *ts = tokio::time::Instant::now();
+    }
+    if !cancelled.load(Ordering::SeqCst) {
+        set_status(client, cli, run_id, fence, RunStatus::WaitingForUser, None, None).await?;
+        if let Some(llm_env) = llm_env {
+            if let Err(err) = maybe_refresh_run_title(
+                client,
+                cli,
+                run_id,
+                fence,
+                &claimed.run.prompt,
+                llm_env,
+            )
+            .await
+            {
+                warn!(run_id = %run_id, error = %err, "run title refresh failed");
+            }
+        }
+    }
+
+    let hold_exit = loop {
+        if cancelled.load(Ordering::SeqCst) {
+            break HoldExit::Cancelled;
+        }
+        if shutdown.load(Ordering::SeqCst) {
+            info!(run_id = %run_id, "ending hold due to shutdown signal");
+            break HoldExit::Shutdown;
+        }
+        if event_error.lock().await.is_some() {
+            warn!(run_id = %run_id, "ending hold after event delivery failure");
+            break HoldExit::RuntimeInterrupted;
+        }
+        if !runtime.is_alive().await {
+            info!(run_id = %run_id, "runtime child exited");
+            break HoldExit::RuntimeInterrupted;
+        }
+        let elapsed = last_activity.lock().await.elapsed();
+        if elapsed >= idle {
+            info!(run_id = %run_id, idle_secs = idle.as_secs(), "runtime idle timeout");
+            break HoldExit::IdleTimeout;
+        }
+        tokio::time::sleep(Duration::from_millis(400)).await;
+    };
+
+    cmd_task.abort();
+    let _ = runtime.send(RuntimeCommand::Shutdown).await;
+    let _ = pump.await;
+
+    if let Some(err) = event_error.lock().await.clone() {
+        bail!("event delivery failed: {err}");
+    }
+    if cancelled.load(Ordering::SeqCst) {
+        set_status(client, cli, run_id, fence, RunStatus::Cancelled, None, None).await?;
+        return Ok(RunOutcome::Cancelled);
+    }
+    if shutdown.load(Ordering::SeqCst) {
+        return Ok(RunOutcome::Shutdown);
+    }
+    Ok(outcome_for_hold(true, hold_exit))
+}
+
+const MOCK_HOLD_IDLE: Duration = Duration::from_secs(3);
+
 async fn run_with_mock(
     client: &reqwest::Client,
     cli: &Cli,
@@ -733,92 +925,25 @@ async fn run_with_mock(
     outbox_root: &Path,
     shutdown: Arc<AtomicBool>,
 ) -> Result<RunOutcome> {
-    let run_id = claimed.run.id;
-    let outbox = EventOutbox::open(outbox_root, run_id).await?;
+    let outbox = EventOutbox::open(outbox_root, claimed.run.id).await?;
     outbox
-        .flush(client, &cli.api_url, &cli.worker_token, run_id, fence)
+        .flush(client, &cli.api_url, &cli.worker_token, claimed.run.id, fence)
         .await
         .context("flush recovered event outbox")?;
     let runtime = Arc::new(MockRuntimeClient::connect(workspace));
-    let (event_task, event_error) = spawn_event_pump(
-        runtime.clone(),
-        client.clone(),
-        cli.api_url.clone(),
-        cli.worker_token.clone(),
-        run_id,
-        (*fence).clone(),
+    run_runtime_session(
+        runtime,
+        client,
+        cli,
+        claimed,
+        fence,
         outbox,
-    );
-
-    let cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-    let cancel_flag = cancelled.clone();
-    let runtime_cancel = runtime.clone();
-    let client_cmd = client.clone();
-    let cli_cmd = cli.api_url.clone();
-    let token_cmd = cli.worker_token.clone();
-    let command_fence = (*fence).clone();
-    let cmd_task = tokio::spawn(async move {
-        loop {
-            if let Ok(commands) = fetch_commands(&client_cmd, &cli_cmd, &token_cmd, run_id, &command_fence).await {
-                for cmd in commands {
-                    if cmd.kind == WorkerCommandKind::Cancel {
-                        cancel_flag.store(true, std::sync::atomic::Ordering::SeqCst);
-                        let _ = runtime_cancel.send(RuntimeCommand::Cancel).await;
-                        return;
-                    }
-                    if cmd.kind == WorkerCommandKind::Prompt {
-                        if let (Some(text), Some(message_id)) = (cmd.text, cmd.message_id) {
-                            match runtime_cancel.send(RuntimeCommand::Prompt { text }).await {
-                                Ok(()) => {
-                                    if let Err(err) = ack_command(
-                                        &client_cmd, &cli_cmd, &token_cmd, run_id,
-                                        &command_fence, message_id,
-                                    ).await {
-                                        warn!(error = %err, "mock follow-up acknowledgement failed");
-                                    }
-                                }
-                                Err(err) => warn!(error = %err, "mock follow-up prompt failed; command will be retried"),
-                            }
-                        }
-                    }
-                }
-            }
-            tokio::time::sleep(Duration::from_secs(2)).await;
-        }
-    });
-
-    runtime
-        .send(RuntimeCommand::Prompt {
-            text: claimed.run.prompt.clone(),
-        })
-        .await
-        .context("mock prompt")?;
-
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
-    while tokio::time::Instant::now() < deadline {
-        if cancelled.load(std::sync::atomic::Ordering::SeqCst)
-            || shutdown.load(Ordering::SeqCst)
-        {
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(500)).await;
-    }
-
-    let _ = runtime.send(RuntimeCommand::Shutdown).await;
-    cmd_task.abort();
-    let _ = event_task.await;
-
-    if let Some(err) = event_error.lock().await.clone() {
-        bail!("event delivery failed: {err}");
-    }
-    if cancelled.load(std::sync::atomic::Ordering::SeqCst) {
-        set_status(client, cli, run_id, &fence, RunStatus::Cancelled, None, None).await?;
-        return Ok(RunOutcome::Cancelled);
-    }
-    if shutdown.load(Ordering::SeqCst) {
-        return Ok(RunOutcome::Shutdown);
-    }
-    Ok(RunOutcome::Completed)
+        shutdown,
+        MOCK_HOLD_IDLE,
+        None,
+        false,
+    )
+    .await
 }
 
 async fn fetch_llm_auth(
@@ -959,171 +1084,21 @@ async fn run_with_real_acp(
         .await
         .context("connect runtime client")?,
     );
-    let session_id = runtime.session_id().await?;
-    persist_acp_session(client, cli, run_id, fence, &session_id).await?;
-    let (pump, event_error) = spawn_event_pump(
-        runtime.clone(),
-        client.clone(),
-        cli.api_url.clone(),
-        cli.worker_token.clone(),
-        run_id,
-        (*fence).clone(),
+    run_runtime_session(
+        runtime,
+        client,
+        cli,
+        claimed,
+        fence,
         outbox,
-    );
-
-    let cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-    let last_activity = std::sync::Arc::new(tokio::sync::Mutex::new(tokio::time::Instant::now()));
-    let cancel_flag = cancelled.clone();
-    let runtime_cancel = runtime.clone();
-    let activity_cmd = last_activity.clone();
-    let client_cmd = client.clone();
-    let cli_cmd = cli.api_url.clone();
-    let token_cmd = cli.worker_token.clone();
-    let command_fence = (*fence).clone();
-    let cmd_task = tokio::spawn(async move {
-        loop {
-            match fetch_commands(&client_cmd, &cli_cmd, &token_cmd, run_id, &command_fence).await {
-                Ok(commands) => {
-                    for cmd in commands {
-                        if cmd.kind == WorkerCommandKind::Cancel {
-                            cancel_flag.store(true, std::sync::atomic::Ordering::SeqCst);
-                            let _ = runtime_cancel.send(RuntimeCommand::Cancel).await;
-                            return;
-                        }
-                        if cmd.kind == WorkerCommandKind::Prompt {
-                            if let Some(text) = cmd.text {
-                                {
-                                    let mut ts = activity_cmd.lock().await;
-                                    *ts = tokio::time::Instant::now();
-                                }
-                                let _ = set_status_raw(
-                                    &client_cmd,
-                                    &cli_cmd,
-                                    &token_cmd,
-                                    run_id,
-                                    &command_fence,
-                                    RunStatus::Running,
-                                )
-                                .await;
-                                match runtime_cancel.send(RuntimeCommand::Prompt { text }).await {
-                                    Ok(()) => {
-                                        if let Some(message_id) = cmd.message_id {
-                                            if let Err(err) = ack_command(
-                                                &client_cmd,
-                                                &cli_cmd,
-                                                &token_cmd,
-                                                run_id,
-                                                &command_fence,
-                                                message_id,
-                                            )
-                                            .await
-                                            {
-                                                warn!(error = %err, "follow-up command acknowledgement failed");
-                                            }
-                                        }
-                                    }
-                                    Err(err) => {
-                                        warn!(error = %err, "follow-up prompt failed; command will be retried");
-                                    }
-                                }
-                                {
-                                    let mut ts = activity_cmd.lock().await;
-                                    *ts = tokio::time::Instant::now();
-                                }
-                                if !cancel_flag.load(std::sync::atomic::Ordering::SeqCst) {
-                                    let _ = set_status_raw(
-                                        &client_cmd,
-                                        &cli_cmd,
-                                        &token_cmd,
-                                        run_id,
-                                        &command_fence,
-                                        RunStatus::WaitingForUser,
-                                    )
-                                    .await;
-                                }
-                            }
-                        }
-                    }
-                }
-                Err(err) => warn!(error = %err, "commands poll failed"),
-            }
-            tokio::time::sleep(Duration::from_secs(2)).await;
-        }
-    });
-
-    runtime
-        .send(RuntimeCommand::Prompt {
-            text: claimed.run.prompt.clone(),
-        })
-        .await
-        .context("session/prompt")?;
-    {
-        let mut ts = last_activity.lock().await;
-        *ts = tokio::time::Instant::now();
-    }
-    // Turn finished — free the UI for follow-ups while ACP session stays warm.
-    if !cancelled.load(std::sync::atomic::Ordering::SeqCst) {
-        set_status(client, cli, run_id, &fence, RunStatus::WaitingForUser, None, None).await?;
-        if let Err(err) =
-            maybe_refresh_run_title(
-                client,
-                cli,
-                run_id,
-                &fence,
-                &claimed.run.prompt,
-                &llm_env,
-            )
-            .await
-        {
-            warn!(run_id = %run_id, error = %err, "run title refresh failed");
-        }
-    }
-
-    // Keep the session alive for follow-ups until idle timeout, cancel, SIGTERM, or child exit.
-    let idle = Duration::from_secs(cli.acp_idle_secs.max(1));
-    let hold_exit = loop {
-        if cancelled.load(Ordering::SeqCst) {
-            break HoldExit::Cancelled;
-        }
-        if shutdown.load(Ordering::SeqCst) {
-            info!(run_id = %run_id, "ending hold due to shutdown signal");
-            break HoldExit::Shutdown;
-        }
-        if event_error.lock().await.is_some() {
-            warn!(run_id = %run_id, "ending hold after event delivery failure");
-            break HoldExit::RuntimeInterrupted;
-        }
-        if !runtime.is_alive().await {
-            info!(run_id = %run_id, "runtime child exited");
-            break HoldExit::RuntimeInterrupted;
-        }
-        let elapsed = {
-            let ts = last_activity.lock().await;
-            ts.elapsed()
-        };
-        if elapsed >= idle {
-            info!(run_id = %run_id, idle_secs = cli.acp_idle_secs, "acp idle timeout");
-            break HoldExit::IdleTimeout;
-        }
-        tokio::time::sleep(Duration::from_millis(400)).await;
-    };
-
-    cmd_task.abort();
-    let _ = runtime.send(RuntimeCommand::Shutdown).await;
-    let _ = pump.await;
-
-    if let Some(err) = event_error.lock().await.clone() {
-        bail!("event delivery failed: {err}");
-    }
-    if cancelled.load(std::sync::atomic::Ordering::SeqCst) {
-        set_status(client, cli, run_id, &fence, RunStatus::Cancelled, None, None).await?;
-        return Ok(RunOutcome::Cancelled);
-    }
-    if shutdown.load(Ordering::SeqCst) {
-        return Ok(RunOutcome::Shutdown);
-    }
-    Ok(outcome_for_hold(true, hold_exit))
+        shutdown,
+        Duration::from_secs(cli.acp_idle_secs.max(1)),
+        Some(&llm_env),
+        true,
+    )
+    .await
 }
+
 
 async fn resolve_permission(
     client: &reqwest::Client,

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `8ff37a6`（PR #78 已合并）。**
+> **进度快照：2026-08-13，基线 `06a10a9`（PR #80 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是 JobRunner mock 路径走 `RuntimeClient` 产品类型；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是 JobRunner mock/real 共用同一条 runtime session；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -954,7 +954,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
 5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision` / `ApprovalKind` / `ApprovalRisk`。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
 6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection 等不进时间线。未识别帧仍为 `acp`。
-7. **JobRunner 只看见 RuntimeClient 产品类型（Wave 16）**：mock 与真实 ACP 共用 event pump；`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeRequest::Approval` 携带 `ApprovalKind`。ACP `MockMsg` / `optionId` 只留在 adapter。
+7. **JobRunner 只看见 RuntimeClient 产品类型（Wave 16）**：mock 与真实 ACP 共用 event pump、command poller 与 idle hold；`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeRequest::Approval` 携带 `ApprovalKind`。ACP `MockMsg` / `optionId` 只留在 adapter。
 8. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
 Conversation event 与 materialized `messages` cache 的双轨可以保留，直到 legacy session 可证明无损迁移。不要为了架构干净上完整 Event Sourcing。
@@ -1057,7 +1057,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          Cloud 产品审批类型不再携带 jsonrpc_id
          Cloud 审批产品面（决策/kind/risk）从 Console 到 RuntimeCommand 收口
          Console 时间线按 event_type 消费产品字段（含 user_message）
-         JobRunner mock 路径走 RuntimeClient 产品类型（本轮）
+         JobRunner mock 路径走 RuntimeClient 产品类型
+         JobRunner mock/real 共用 runtime session（command + hold；本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1082,13 +1083,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | JobRunner mock/real 共用 RuntimeClient；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | JobRunner mock/real 共用 runtime session；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 都只看见 `RuntimeClient` 产品类型；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1187,7 +1188,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - Console 按 `event_type` 分发时间线：`text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result` 直接渲染产品字段，legacy `params.update` 仍可回放。plan/usage/projection/session_started/approval_requested 不进时间线。
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
    - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
-   - JobRunner mock 与真实 ACP 共用 event pump；只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；审批请求携带 `ApprovalKind`。ACP `MockMsg` 与 `optionId` 只留在 adapter。
+   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；审批请求携带 `ApprovalKind`。ACP `MockMsg` 与 `optionId` 只留在 adapter。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1213,10 +1214,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | JobRunner 已只看见 RuntimeClient 产品类型；Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | JobRunner 已共用 runtime session；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**JobRunner 已与 ACP 解耦**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
+推荐组合：**JobRunner 已共用 runtime session**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #80 让 mock 走了 `RuntimeClient`，但 command poller 与 idle hold 仍各写一套。本 PR 把 **JobRunner runtime session** 收成一条路径。

mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller、idle hold。Follow-up 会刷新 `last_activity`，mock 的 3s idle 会随跟进延长。ACP session 持久化与 title refresh 仍只在真实路径。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不改 Console 布局。

`cd cloud && cargo test -p zene-cloud-worker --locked` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

