### PR TITLE
feat: tree-sitter 符号索引与按需 RepoMap 工具

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,6 +2805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3239,6 +3245,75 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.24.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5387dffa7ffc7d2dae12b50c6f7aab8ff79d6210147c6613561fc3d474c6f75"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.23.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]
@@ -4085,6 +4160,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "zene-index"
+version = "0.1.11"
+dependencies = [
+ "anyhow",
+ "ignore",
+ "serde",
+ "serde_json",
+ "streaming-iterator",
+ "tempfile",
+ "tree-sitter",
+ "tree-sitter-go",
+ "tree-sitter-javascript",
+ "tree-sitter-python",
+ "tree-sitter-rust",
+ "tree-sitter-typescript",
+]
+
+[[package]]
 name = "zene-inference-gateway"
 version = "0.1.11"
 dependencies = [
@@ -4234,6 +4327,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "zene-config",
+ "zene-index",
  "zene-llm",
  "zene-permission",
  "zene-sandbox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/tool-runtime",
     "crates/turn",
     "crates/workspace",
+    "crates/index",
 ]
 resolver = "2"
 
@@ -65,6 +66,7 @@ zene-permission = { version = "0.1.11", path = "crates/permission" }
 zene-tool-runtime = { path = "crates/tool-runtime" }
 zene-turn = { path = "crates/turn" }
 zene-workspace = { path = "crates/workspace" }
+zene-index = { path = "crates/index" }
 unigateway-sdk = { version = "2.14", default-features = false, features = ["core"] }
 llm_providers = "0.12.0"
 tiktoken-rs = "0.12"

--- a/apps/cli/src/acp/updates.rs
+++ b/apps/cli/src/acp/updates.rs
@@ -6,7 +6,7 @@ use zene_llm::{Message, Role};
 /// Map a built-in / MCP tool name to an ACP tool kind.
 pub fn tool_kind(name: &str) -> &'static str {
     match name {
-        "Read" | "Grep" | "Glob" => "read",
+        "Read" | "Grep" | "Glob" | "RepoMap" => "read",
         "Write" | "Edit" => "edit",
         "Bash" | "Task" | "TaskOutput" => "execute",
         "FetchUrl" | "WebSearch" => "fetch",
@@ -44,6 +44,10 @@ pub fn tool_title(name: &str, arguments: &str) -> String {
                 40
             )
         ),
+        "RepoMap" => match field("query").filter(|q| !q.is_empty()) {
+            Some(query) => format!("Mapped repo for {}", truncate(query, 40)),
+            None => "Mapped repository structure".to_string(),
+        },
         "WebSearch" => format!(
             "Searched the web for \"{}\"",
             truncate(field("query").unwrap_or("…"), 40)
@@ -545,6 +549,7 @@ mod tests {
     #[test]
     fn maps_tool_kinds() {
         assert_eq!(tool_kind("Read"), "read");
+        assert_eq!(tool_kind("RepoMap"), "read");
         assert_eq!(tool_kind("Edit"), "edit");
         assert_eq!(tool_kind("Bash"), "execute");
         assert_eq!(tool_kind("TodoWrite"), "think");
@@ -580,10 +585,12 @@ mod tests {
             tool_title("Bash", r#"{"command":"ls -la && find . -name '*.rs'"}"#),
             "Listed files"
         );
+        assert_eq!(tool_title("Grep", r#"{"pattern":"tool_title"}"#), "Searched code for tool_title");
         assert_eq!(
-            tool_title("Grep", r#"{"pattern":"tool_title"}"#),
-            "Searched code for tool_title"
+            tool_title("RepoMap", r#"{"query":"ContextEngine"}"#),
+            "Mapped repo for ContextEngine"
         );
+        assert_eq!(tool_title("RepoMap", "{}"), "Mapped repository structure");
         assert_eq!(tool_title("TodoWrite", r#"{"todos":[]}"#), "Updated todos");
         assert!(!tool_title("Bash", r#"{"command":"ls -la /tmp/foo"}"#).contains('/'));
     }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -58,7 +58,7 @@ pub enum AgentProfile {
     /// All built-in tools (default).
     #[default]
     Full,
-    /// Read-only exploration: Read/Grep/Glob + collaboration + plan tools.
+    /// Read-only exploration: Read/Grep/Glob/RepoMap + collaboration + plan tools.
     Explore,
     /// Read/write coding: Write/Edit/Bash + collaboration + Task subagent + plan tools.
     Coder,

--- a/crates/core/src/plan_mode.rs
+++ b/crates/core/src/plan_mode.rs
@@ -8,10 +8,10 @@ use serde::Deserialize;
 use zene_config::sessions_dir;
 use zene_tools::{PlanModeState, ToolResult};
 
-pub const PLAN_MODE_REMINDER_BODY: &str = "You are in Plan mode. Only read-only tools (Read, Grep, Glob, Skill, WebSearch, FetchUrl) and ExitPlanMode are available. Do not use Write, Edit, Bash, or Task until you call ExitPlanMode with your plan and the user approves it.";
+pub const PLAN_MODE_REMINDER_BODY: &str = "You are in Plan mode. Only read-only tools (Read, Grep, Glob, RepoMap, Skill, WebSearch, FetchUrl) and ExitPlanMode are available. Do not use Write, Edit, Bash, or Task until you call ExitPlanMode with your plan and the user approves it.";
 
 #[allow(dead_code)] // tagged form kept for tests; projection uses PLAN_MODE_REMINDER_BODY
-pub const PLAN_MODE_REMINDER: &str = "<system_reminder>\nYou are in Plan mode. Only read-only tools (Read, Grep, Glob, Skill, WebSearch, FetchUrl) and ExitPlanMode are available. Do not use Write, Edit, Bash, or Task until you call ExitPlanMode with your plan and the user approves it.\n</system_reminder>";
+pub const PLAN_MODE_REMINDER: &str = "<system_reminder>\nYou are in Plan mode. Only read-only tools (Read, Grep, Glob, RepoMap, Skill, WebSearch, FetchUrl) and ExitPlanMode are available. Do not use Write, Edit, Bash, or Task until you call ExitPlanMode with your plan and the user approves it.\n</system_reminder>";
 
 pub type PlanApprovalPrompter =
     Arc<dyn Fn(&Path, &str) -> io::Result<bool> + Send + Sync>;
@@ -96,7 +96,7 @@ pub fn handle_enter_plan_mode(
         }
     };
     state.enter();
-    let mut msg = "Entered plan mode. Use Read/Grep/Glob/Skill/WebSearch to explore, then ExitPlanMode with your plan.".to_string();
+    let mut msg = "Entered plan mode. Use Read/Grep/Glob/RepoMap/Skill/WebSearch to explore, then ExitPlanMode with your plan.".to_string();
     if let Some(reason) = args.reason.filter(|r| !r.trim().is_empty()) {
         msg.push_str(&format!("\nReason: {reason}"));
     }
@@ -177,6 +177,7 @@ pub fn tool_visible_in_definitions(name: &str, plan_active: bool) -> bool {
             "Read"
                 | "Grep"
                 | "Glob"
+                | "RepoMap"
                 | "Skill"
                 | "AskUserQuestion"
                 | "TodoWrite"
@@ -265,6 +266,7 @@ mod tests {
         assert!(tool_visible_in_definitions("WebSearch", true));
         assert!(!tool_visible_in_definitions("Write", true));
         assert!(tool_visible_in_definitions("Read", true));
+        assert!(tool_visible_in_definitions("RepoMap", true));
         assert!(!tool_visible_in_definitions("ExitPlanMode", false));
         assert!(tool_visible_in_definitions("ExitPlanMode", true));
     }

--- a/crates/core/src/tool_scheduler.rs
+++ b/crates/core/src/tool_scheduler.rs
@@ -55,6 +55,14 @@ pub fn classify_tool_accesses(name: &str, arguments: &str) -> ToolAccesses {
             path: None,
             recursive: true,
         }],
+        "RepoMap" => {
+            let path = args.and_then(|v| str_field(&v, "path"));
+            vec![ToolResourceAccess::File {
+                operation: FileOperation::Search,
+                path,
+                recursive: true,
+            }]
+        }
         "Skill" => vec![ToolResourceAccess::File {
             operation: FileOperation::Read,
             path: None,

--- a/crates/core/tests/plan_mode.rs
+++ b/crates/core/tests/plan_mode.rs
@@ -9,6 +9,7 @@ fn plan_mode_blocks_write() {
     assert!(!state.is_tool_allowed("Bash"));
     assert!(!state.is_tool_allowed("Task"));
     assert!(state.is_tool_allowed("Read"));
+    assert!(state.is_tool_allowed("RepoMap"));
 }
 
 #[test]

--- a/crates/index/Cargo.toml
+++ b/crates/index/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "zene-index"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Workspace symbol index and on-demand repo map for Zene agents"
+publish = false
+
+[dependencies]
+anyhow.workspace = true
+ignore = "0.4"
+serde.workspace = true
+serde_json.workspace = true
+tree-sitter = "0.24"
+tree-sitter-go = "0.23"
+tree-sitter-javascript = "0.23"
+tree-sitter-python = "0.23"
+tree-sitter-rust = "0.23"
+tree-sitter-typescript = "0.23"
+streaming-iterator = "0.1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/index/src/language.rs
+++ b/crates/index/src/language.rs
@@ -1,0 +1,59 @@
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceLanguage {
+    Rust,
+    Python,
+    TypeScript,
+    Tsx,
+    JavaScript,
+    Go,
+}
+
+impl SourceLanguage {
+    pub fn from_path(path: &Path) -> Option<Self> {
+        let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+        match ext.as_str() {
+            "rs" => Some(Self::Rust),
+            "py" => Some(Self::Python),
+            "ts" => Some(Self::TypeScript),
+            "tsx" => Some(Self::Tsx),
+            "js" | "mjs" | "cjs" | "jsx" => Some(Self::JavaScript),
+            "go" => Some(Self::Go),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Rust => "rust",
+            Self::Python => "python",
+            Self::TypeScript => "typescript",
+            Self::Tsx => "tsx",
+            Self::JavaScript => "javascript",
+            Self::Go => "go",
+        }
+    }
+}
+
+pub fn skip_dir(name: &str) -> bool {
+    matches!(
+        name,
+        ".git"
+            | ".hg"
+            | ".svn"
+            | ".zene"
+            | "node_modules"
+            | "target"
+            | "dist"
+            | "build"
+            | "vendor"
+            | "__pycache__"
+            | ".next"
+            | "coverage"
+            | "out"
+            | ".venv"
+            | "venv"
+            | "Pods"
+    )
+}

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -1,0 +1,98 @@
+//! Workspace symbol index and on-demand repo map.
+//!
+//! This crate is Select, not ContextEngine: it never injects into the prompt
+//! prefix. Callers expose it as a tool so hits land in the conversation Body.
+
+mod language;
+mod parse;
+mod rank;
+mod render;
+mod store;
+
+pub use render::DEFAULT_TOKEN_BUDGET;
+pub use store::{refresh as refresh_index, RefreshStats, Symbol, SymbolIndex};
+
+use std::path::Path;
+
+use anyhow::Result;
+
+/// Refresh the sidecar index under `{workdir}/.zene/index/` and render a
+/// budgeted repo map. `query` personalizes ranking; `path_prefix` limits
+/// which files are shown (the index itself still covers the workspace).
+pub fn build_repo_map(
+    workdir: &Path,
+    query: Option<&str>,
+    token_budget: u32,
+    path_prefix: Option<&str>,
+) -> Result<String> {
+    let (index, stats) = store::refresh(workdir)?;
+    let budget = if token_budget == 0 {
+        render::DEFAULT_TOKEN_BUDGET
+    } else {
+        token_budget
+    };
+    Ok(render::render_map(
+        &index,
+        &stats,
+        query,
+        budget,
+        path_prefix,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn indexes_rust_and_writes_sidecar() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("lib.rs"),
+            "pub struct Engine {}\npub fn prepare_step() {}\nfn helper() { prepare_step(); }\n",
+        )
+        .unwrap();
+
+        let map = build_repo_map(dir.path(), None, 800, None).unwrap();
+        assert!(map.contains("lib.rs"));
+        assert!(map.contains("prepare_step"));
+        assert!(map.contains("Engine"));
+        assert!(dir.path().join(".zene/index/v1.json").is_file());
+        assert!(map.contains("signatures only"));
+    }
+
+    #[test]
+    fn incremental_refresh_reuses_unchanged_files() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("a.rs"), "pub fn alpha() {}\n").unwrap();
+        fs::write(dir.path().join("b.rs"), "pub fn beta() {}\n").unwrap();
+
+        let (_, first) = refresh_index(dir.path()).unwrap();
+        assert_eq!(first.parsed, 2);
+        assert_eq!(first.cached, 0);
+
+        fs::write(dir.path().join("b.rs"), "pub fn beta() {}\npub fn gamma() {}\n").unwrap();
+        let (index, second) = refresh_index(dir.path()).unwrap();
+        assert_eq!(second.parsed, 1);
+        assert_eq!(second.cached, 1);
+        assert!(index.files["b.rs"].defs.iter().any(|s| s.name == "gamma"));
+    }
+
+    #[test]
+    fn query_personalizes_ranking() {
+        let dir = tempfile::TempDir::new().unwrap();
+        fs::write(dir.path().join("auth.rs"), "pub fn process_refund() {}\n").unwrap();
+        fs::write(dir.path().join("util.rs"), "pub fn helper() {}\n").unwrap();
+
+        let map = build_repo_map(dir.path(), Some("process_refund"), 800, None).unwrap();
+        let auth = map.find("auth.rs").expect("auth.rs in map");
+        let util = map.find("util.rs");
+        assert!(
+            util.is_none_or(|u| auth < u),
+            "matching file should rank first:\n{map}"
+        );
+        assert!(map.contains("Personalized to: process_refund"));
+    }
+}
+

--- a/crates/index/src/parse.rs
+++ b/crates/index/src/parse.rs
@@ -1,0 +1,203 @@
+use anyhow::{Context, Result};
+use streaming_iterator::StreamingIterator;
+use tree_sitter::{Parser, Query, QueryCursor};
+
+use crate::language::SourceLanguage;
+use crate::store::Symbol;
+
+pub fn parse_file(language: SourceLanguage, source: &str) -> Result<(Vec<Symbol>, Vec<String>)> {
+    let lang = ts_language(language);
+    let mut parser = Parser::new();
+    parser
+        .set_language(&lang)
+        .with_context(|| format!("set tree-sitter language {}", language.as_str()))?;
+    let tree = parser
+        .parse(source, None)
+        .with_context(|| format!("parse {} source", language.as_str()))?;
+    let query = Query::new(&lang, query_src(language))
+        .with_context(|| format!("compile {} query", language.as_str()))?;
+
+    let mut defs = Vec::new();
+    let mut refs = Vec::new();
+    let mut cursor = QueryCursor::new();
+    let source_bytes = source.as_bytes();
+    let mut matches = cursor.matches(&query, tree.root_node(), source_bytes);
+
+    while let Some(m) = matches.next() {
+        let mut name: Option<String> = None;
+        let mut def_node = None;
+        let mut is_ref = false;
+        for capture in m.captures {
+            let capture_name = query.capture_names()[capture.index as usize];
+            let node = capture.node;
+            let text = node.utf8_text(source_bytes).unwrap_or("").trim();
+            if text.is_empty() {
+                continue;
+            }
+            match capture_name {
+                "name" => {
+                    name = Some(text.to_string());
+                    if def_node.is_none() {
+                        def_node = Some(node);
+                    }
+                }
+                "def" => def_node = Some(node),
+                "ref" => {
+                    is_ref = true;
+                    refs.push(text.to_string());
+                }
+                _ => {}
+            }
+        }
+        if is_ref {
+            continue;
+        }
+        let Some(name) = name else { continue };
+        let Some(node) = def_node else { continue };
+        let line = node.start_position().row as u32 + 1;
+        let signature = first_line(source, node.start_byte());
+        let kind = classify_kind(language, &signature);
+        defs.push(Symbol {
+            kind,
+            name,
+            line,
+            signature,
+        });
+    }
+
+    defs.sort_by(|a, b| a.line.cmp(&b.line).then(a.name.cmp(&b.name)));
+    defs.dedup_by(|a, b| a.name == b.name && a.line == b.line);
+
+    refs.sort();
+    refs.dedup();
+    refs.retain(|name| name.len() >= 2);
+
+    Ok((defs, refs))
+}
+
+fn ts_language(language: SourceLanguage) -> tree_sitter::Language {
+    match language {
+        SourceLanguage::Rust => tree_sitter_rust::LANGUAGE.into(),
+        SourceLanguage::Python => tree_sitter_python::LANGUAGE.into(),
+        SourceLanguage::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+        SourceLanguage::Tsx => tree_sitter_typescript::LANGUAGE_TSX.into(),
+        SourceLanguage::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
+        SourceLanguage::Go => tree_sitter_go::LANGUAGE.into(),
+    }
+}
+
+fn query_src(language: SourceLanguage) -> &'static str {
+    match language {
+        SourceLanguage::Rust => RUST_QUERY,
+        SourceLanguage::Python => PYTHON_QUERY,
+        SourceLanguage::TypeScript | SourceLanguage::Tsx => TYPESCRIPT_QUERY,
+        SourceLanguage::JavaScript => JAVASCRIPT_QUERY,
+        SourceLanguage::Go => GO_QUERY,
+    }
+}
+
+fn classify_kind(language: SourceLanguage, signature: &str) -> String {
+    let s = signature.trim_start();
+    match language {
+        SourceLanguage::Rust => {
+            if s.contains("fn ") {
+                "function".into()
+            } else if s.contains("struct ") {
+                "struct".into()
+            } else if s.contains("enum ") {
+                "enum".into()
+            } else if s.contains("trait ") {
+                "trait".into()
+            } else if s.contains("mod ") {
+                "module".into()
+            } else if s.contains("impl ") {
+                "impl".into()
+            } else {
+                "type".into()
+            }
+        }
+        SourceLanguage::Python => {
+            if s.starts_with("class ") {
+                "class".into()
+            } else {
+                "function".into()
+            }
+        }
+        SourceLanguage::Go => {
+            if s.contains("type ") {
+                "type".into()
+            } else if s.contains("func (") {
+                "method".into()
+            } else {
+                "function".into()
+            }
+        }
+        _ => {
+            if s.contains("class ") || s.contains("interface ") {
+                "type".into()
+            } else if s.contains("function ") || s.contains("=>") {
+                "function".into()
+            } else {
+                "symbol".into()
+            }
+        }
+    }
+}
+
+fn first_line(source: &str, start_byte: usize) -> String {
+    let rest = source.get(start_byte..).unwrap_or("");
+    let line = rest.lines().next().unwrap_or(rest).trim();
+    let mut out = String::new();
+    for ch in line.chars() {
+        if out.len() + ch.len_utf8() > 120 {
+            break;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+const RUST_QUERY: &str = r#"
+(function_item name: (identifier) @name) @def
+(struct_item name: (type_identifier) @name) @def
+(enum_item name: (type_identifier) @name) @def
+(trait_item name: (type_identifier) @name) @def
+(mod_item name: (identifier) @name) @def
+(type_item name: (type_identifier) @name) @def
+(const_item name: (identifier) @name) @def
+(impl_item type: (type_identifier) @name) @def
+(macro_definition name: (identifier) @name) @def
+(call_expression function: (identifier) @ref)
+(macro_invocation macro: (identifier) @ref)
+(call_expression function: (field_expression field: (field_identifier) @ref))
+"#;
+
+const PYTHON_QUERY: &str = r#"
+(function_definition name: (identifier) @name) @def
+(class_definition name: (identifier) @name) @def
+(call function: (identifier) @ref)
+"#;
+
+const JAVASCRIPT_QUERY: &str = r#"
+(function_declaration name: (identifier) @name) @def
+(class_declaration name: (identifier) @name) @def
+(method_definition name: (property_identifier) @name) @def
+(lexical_declaration (variable_declarator name: (identifier) @name) @def)
+(call_expression function: (identifier) @ref)
+"#;
+
+const TYPESCRIPT_QUERY: &str = r#"
+(function_declaration name: (identifier) @name) @def
+(class_declaration name: (type_identifier) @name) @def
+(method_definition name: (property_identifier) @name) @def
+(interface_declaration name: (type_identifier) @name) @def
+(type_alias_declaration name: (type_identifier) @name) @def
+(call_expression function: (identifier) @ref)
+"#;
+
+const GO_QUERY: &str = r#"
+(function_declaration name: (identifier) @name) @def
+(method_declaration name: (field_identifier) @name) @def
+(type_declaration (type_spec name: (type_identifier) @name) @def)
+(call_expression function: (identifier) @ref)
+"#;

--- a/crates/index/src/rank.rs
+++ b/crates/index/src/rank.rs
@@ -1,0 +1,128 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::store::SymbolIndex;
+
+const DAMPING: f64 = 0.85;
+const ITERATIONS: usize = 20;
+const MAX_EDGES_PER_NAME: usize = 8;
+
+pub fn score_files(index: &SymbolIndex, query: Option<&str>) -> HashMap<String, f64> {
+    let files: Vec<&String> = index.files.keys().collect();
+    if files.is_empty() {
+        return HashMap::new();
+    }
+
+    let mut defs: HashMap<&str, Vec<&String>> = HashMap::new();
+    for (path, file) in &index.files {
+        for symbol in &file.defs {
+            defs.entry(symbol.name.as_str())
+                .or_default()
+                .push(path);
+        }
+    }
+
+    let mut edges: HashMap<String, Vec<String>> = HashMap::new();
+    for path in index.files.keys() {
+        edges.entry(path.clone()).or_default();
+    }
+    for (src, file) in &index.files {
+        let mut seen = HashSet::new();
+        for name in &file.refs {
+            let Some(targets) = defs.get(name.as_str()) else {
+                continue;
+            };
+            for dst in targets.iter().take(MAX_EDGES_PER_NAME) {
+                if *dst == src {
+                    continue;
+                }
+                if seen.insert((*dst).clone()) {
+                    edges.entry(src.clone()).or_default().push((*dst).clone());
+                }
+            }
+        }
+    }
+
+    let personal = personalization(index, query);
+    pagerank(&files, &edges, &personal)
+}
+
+fn personalization(index: &SymbolIndex, query: Option<&str>) -> HashMap<String, f64> {
+    let mut weights: HashMap<String, f64> = HashMap::new();
+    let terms: Vec<String> = query
+        .unwrap_or("")
+        .split_whitespace()
+        .filter(|t| t.len() >= 2)
+        .map(|t| t.to_ascii_lowercase())
+        .collect();
+
+    for (path, file) in &index.files {
+        let mut w = 1.0;
+        if !terms.is_empty() {
+            let path_l = path.to_ascii_lowercase();
+            w = 0.15;
+            for term in &terms {
+                if path_l.contains(term) {
+                    w += 3.0;
+                }
+                for symbol in &file.defs {
+                    if symbol.name.eq_ignore_ascii_case(term) {
+                        w += 8.0;
+                    } else if symbol.name.to_ascii_lowercase().contains(term) {
+                        w += 2.0;
+                    }
+                }
+            }
+        }
+        weights.insert(path.clone(), w);
+    }
+
+    let sum: f64 = weights.values().sum();
+    if sum <= 0.0 {
+        let n = index.files.len() as f64;
+        return index
+            .files
+            .keys()
+            .map(|p| (p.clone(), 1.0 / n))
+            .collect();
+    }
+    for v in weights.values_mut() {
+        *v /= sum;
+    }
+    weights
+}
+
+fn pagerank(
+    files: &[&String],
+    edges: &HashMap<String, Vec<String>>,
+    personal: &HashMap<String, f64>,
+) -> HashMap<String, f64> {
+    let n = files.len() as f64;
+    let mut scores: HashMap<String, f64> = files
+        .iter()
+        .map(|p| (*p).clone())
+        .zip(std::iter::repeat(1.0 / n))
+        .collect();
+
+    for _ in 0..ITERATIONS {
+        let mut next: HashMap<String, f64> = files
+            .iter()
+            .map(|p| {
+                (
+                    (*p).clone(),
+                    (1.0 - DAMPING) * personal.get(*p).copied().unwrap_or(0.0),
+                )
+            })
+            .collect();
+        for (src, dsts) in edges {
+            if dsts.is_empty() {
+                continue;
+            }
+            let share = scores.get(src).copied().unwrap_or(0.0) * DAMPING / dsts.len() as f64;
+            for dst in dsts {
+                *next.entry(dst.clone()).or_insert(0.0) += share;
+            }
+        }
+        scores = next;
+    }
+    scores
+}

--- a/crates/index/src/render.rs
+++ b/crates/index/src/render.rs
@@ -1,0 +1,75 @@
+use crate::rank::score_files;
+use crate::store::{RefreshStats, SymbolIndex};
+
+pub const DEFAULT_TOKEN_BUDGET: u32 = 2500;
+const MAX_DEFS_PER_FILE: usize = 40;
+
+pub fn render_map(
+    index: &SymbolIndex,
+    stats: &RefreshStats,
+    query: Option<&str>,
+    token_budget: u32,
+    path_prefix: Option<&str>,
+) -> String {
+    let prefix = path_prefix
+        .map(normalize_prefix)
+        .filter(|p| !p.is_empty());
+    let scores = score_files(index, query);
+    let mut ranked: Vec<(&String, f64)> = scores
+        .iter()
+        .filter(|(path, _)| prefix.as_ref().is_none_or(|p| path_in_prefix(path, p)))
+        .map(|(path, score)| (path, *score))
+        .collect();
+    ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    let budget_chars = (token_budget.max(64) as usize).saturating_mul(4);
+    let mut body = String::new();
+    let mut shown_files = 0usize;
+    let mut shown_defs = 0usize;
+
+    for (path, _) in &ranked {
+        let Some(file) = index.files.get(*path) else {
+            continue;
+        };
+        if file.defs.is_empty() {
+            continue;
+        }
+        let mut block = format!("{path}\n");
+        for symbol in file.defs.iter().take(MAX_DEFS_PER_FILE) {
+            block.push_str(&format!("  {} {}\n", symbol.kind, symbol.name));
+        }
+        if body.len() + block.len() > budget_chars && !body.is_empty() {
+            break;
+        }
+        body.push_str(&block);
+        shown_files += 1;
+        shown_defs += file.defs.len().min(MAX_DEFS_PER_FILE);
+    }
+
+    let mut out = String::new();
+    out.push_str("Repository map (signatures only; use Read for implementations).\n");
+    if let Some(q) = query.map(str::trim).filter(|s| !s.is_empty()) {
+        out.push_str(&format!("Personalized to: {q}\n"));
+    }
+    out.push_str(&format!(
+        "Indexed {} files ({} parsed, {} cached, {} removed). Showing {shown_files} files / {shown_defs} symbols.\n\n",
+        index.files.len(),
+        stats.parsed,
+        stats.cached,
+        stats.removed
+    ));
+    if body.is_empty() {
+        out.push_str("No indexable definitions found.\n");
+    } else {
+        out.push_str(&body);
+    }
+    out
+}
+
+fn normalize_prefix(path: &str) -> String {
+    path.replace('\\', "/").trim_matches('/').to_string()
+}
+
+fn path_in_prefix(path: &str, prefix: &str) -> bool {
+    path == prefix || path.starts_with(&format!("{prefix}/"))
+}

--- a/crates/index/src/store.rs
+++ b/crates/index/src/store.rs
@@ -1,0 +1,181 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use ignore::WalkBuilder;
+use serde::{Deserialize, Serialize};
+
+use crate::language::{skip_dir, SourceLanguage};
+use crate::parse::parse_file;
+
+const INDEX_VERSION: u32 = 1;
+const MAX_FILES: usize = 4000;
+const MAX_FILE_BYTES: u64 = 512 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Symbol {
+    pub kind: String,
+    pub name: String,
+    pub line: u32,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileSymbols {
+    pub hash: String,
+    pub language: String,
+    pub defs: Vec<Symbol>,
+    pub refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SymbolIndex {
+    pub version: u32,
+    pub files: BTreeMap<String, FileSymbols>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct RefreshStats {
+    pub parsed: usize,
+    pub cached: usize,
+    pub removed: usize,
+}
+
+pub fn refresh(workdir: &Path) -> Result<(SymbolIndex, RefreshStats)> {
+    let path = index_path(workdir);
+    let mut index = load_index(&path).unwrap_or_else(|_| SymbolIndex {
+        version: INDEX_VERSION,
+        files: BTreeMap::new(),
+    });
+    if index.version != INDEX_VERSION {
+        index = SymbolIndex {
+            version: INDEX_VERSION,
+            files: BTreeMap::new(),
+        };
+    }
+
+    let source_files = collect_source_files(workdir)?;
+    let mut live = BTreeMap::new();
+    let mut stats = RefreshStats::default();
+
+    for abs in source_files {
+        let rel = relative_path(workdir, &abs);
+        let meta = match fs::metadata(&abs) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.len() > MAX_FILE_BYTES {
+            continue;
+        }
+        let bytes = match fs::read(&abs) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        if bytes.contains(&0) {
+            continue;
+        }
+        let Ok(source) = std::str::from_utf8(&bytes) else {
+            continue;
+        };
+        let hash = content_hash(&bytes);
+        if let Some(existing) = index.files.get(&rel) {
+            if existing.hash == hash {
+                live.insert(rel, existing.clone());
+                stats.cached += 1;
+                continue;
+            }
+        }
+        let Some(language) = SourceLanguage::from_path(&abs) else {
+            continue;
+        };
+        match parse_file(language, source) {
+            Ok((defs, refs)) => {
+                live.insert(
+                    rel,
+                    FileSymbols {
+                        hash,
+                        language: language.as_str().to_string(),
+                        defs,
+                        refs,
+                    },
+                );
+                stats.parsed += 1;
+            }
+            Err(_) => continue,
+        }
+    }
+
+    stats.removed = index
+        .files
+        .keys()
+        .filter(|k| !live.contains_key(*k))
+        .count();
+    index.files = live;
+    save_index(&path, &index)?;
+    Ok((index, stats))
+}
+
+fn index_path(workdir: &Path) -> PathBuf {
+    workdir.join(".zene").join("index").join("v1.json")
+}
+
+fn load_index(path: &Path) -> Result<SymbolIndex> {
+    let text = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&text)?)
+}
+
+fn save_index(path: &Path, index: &SymbolIndex) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_string(index)?;
+    fs::write(&tmp, json).with_context(|| format!("write {}", tmp.display()))?;
+    fs::rename(&tmp, path).with_context(|| format!("rename {}", path.display()))?;
+    Ok(())
+}
+
+fn collect_source_files(workdir: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    let walker = WalkBuilder::new(workdir)
+        .hidden(false)
+        .git_ignore(true)
+        .git_exclude(true)
+        .filter_entry(|entry| {
+            let name = entry.file_name().to_string_lossy();
+            !(entry.file_type().is_some_and(|t| t.is_dir()) && skip_dir(&name))
+        })
+        .build();
+
+    for entry in walker.flatten() {
+        if !entry.file_type().is_some_and(|t| t.is_file()) {
+            continue;
+        }
+        let path = entry.path();
+        if SourceLanguage::from_path(path).is_none() {
+            continue;
+        }
+        files.push(path.to_path_buf());
+        if files.len() >= MAX_FILES {
+            break;
+        }
+    }
+    Ok(files)
+}
+
+fn relative_path(workdir: &Path, path: &Path) -> String {
+    path.strip_prefix(workdir)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn content_hash(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf29ce484222325u64;
+    for b in bytes {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -19,6 +19,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 zene-config = { workspace = true }
+zene-index = { workspace = true }
 zene-llm = { workspace = true }
 zene-permission = { workspace = true }
 zene-sandbox = { workspace = true }

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -7,6 +7,7 @@ use crate::grep::GrepTool;
 use crate::plan::{EnterPlanModeTool, ExitPlanModeTool};
 use crate::read::ReadTool;
 use crate::registry::ToolRegistry;
+use crate::repomap::RepoMapTool;
 use crate::skill::SkillTool;
 use crate::subagent::SubagentProfile;
 use crate::task::TaskTool;
@@ -38,6 +39,7 @@ pub fn tools_for_profile(profile: SubagentProfile) -> ToolRegistry {
             Box::new(ReadTool),
             Box::new(GrepTool),
             Box::new(GlobTool),
+            Box::new(RepoMapTool),
         ]),
         SubagentProfile::Coder => ToolRegistry::new(vec![
             Box::new(ReadTool),
@@ -46,6 +48,7 @@ pub fn tools_for_profile(profile: SubagentProfile) -> ToolRegistry {
             Box::new(BashTool),
             Box::new(GrepTool),
             Box::new(GlobTool),
+            Box::new(RepoMapTool),
         ]),
     }
 }
@@ -58,6 +61,7 @@ fn all_builtin_tool_boxes(web_search: WebSearchConfig) -> Vec<Box<dyn crate::reg
         Box::new(BashTool),
         Box::new(GrepTool),
         Box::new(GlobTool),
+        Box::new(RepoMapTool),
         Box::new(SkillTool),
         Box::new(TaskTool),
         Box::new(TaskOutputTool),
@@ -76,6 +80,7 @@ fn explore_agent_tool_boxes(web_search: WebSearchConfig) -> Vec<Box<dyn crate::r
         Box::new(ReadTool),
         Box::new(GrepTool),
         Box::new(GlobTool),
+        Box::new(RepoMapTool),
         Box::new(SkillTool),
         Box::new(AskUserQuestionTool),
         Box::new(TodoWriteTool),
@@ -95,6 +100,7 @@ fn coder_agent_tool_boxes(web_search: WebSearchConfig) -> Vec<Box<dyn crate::reg
         Box::new(BashTool),
         Box::new(GrepTool),
         Box::new(GlobTool),
+        Box::new(RepoMapTool),
         Box::new(SkillTool),
         Box::new(TaskTool),
         Box::new(TaskOutputTool),
@@ -118,6 +124,7 @@ mod tests {
         let tools = agent_tools(AgentProfile::Explore, WebSearchConfig::default());
         let names: Vec<String> = tools.definitions().into_iter().map(|d| d.name).collect();
         assert!(names.iter().any(|n| n == "Read"));
+        assert!(names.iter().any(|n| n == "RepoMap"));
         assert!(!names.iter().any(|n| n == "Write"));
         assert!(!names.iter().any(|n| n == "Edit"));
         assert!(!names.iter().any(|n| n == "Bash"));
@@ -128,6 +135,7 @@ mod tests {
     fn coder_profile_includes_write_and_task() {
         let tools = agent_tools(AgentProfile::Coder, WebSearchConfig::default());
         let names: Vec<String> = tools.definitions().into_iter().map(|d| d.name).collect();
+        assert!(names.iter().any(|n| n == "RepoMap"));
         assert!(names.iter().any(|n| n == "Write"));
         assert!(names.iter().any(|n| n == "Edit"));
         assert!(names.iter().any(|n| n == "Task"));

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -12,6 +12,7 @@ mod plan;
 mod plan_mode;
 mod read;
 mod registry;
+mod repomap;
 mod skill;
 mod subagent;
 mod task;

--- a/crates/tools/src/plan.rs
+++ b/crates/tools/src/plan.rs
@@ -17,7 +17,7 @@ impl Tool for EnterPlanModeTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "EnterPlanMode".to_string(),
-            description: "Enter plan mode: only read-only tools (Read, Grep, Glob, Skill) are available until the user approves your plan via ExitPlanMode.".to_string(),
+            description: "Enter plan mode: only read-only tools (Read, Grep, Glob, RepoMap, Skill) are available until the user approves your plan via ExitPlanMode.".to_string(),
             parameters: json!({
                 "type": "object",
                 "properties": {

--- a/crates/tools/src/plan_mode.rs
+++ b/crates/tools/src/plan_mode.rs
@@ -31,6 +31,7 @@ impl PlanModeState {
             "Read"
                 | "Grep"
                 | "Glob"
+                | "RepoMap"
                 | "Skill"
                 | "AskUserQuestion"
                 | "TodoWrite"
@@ -43,7 +44,7 @@ impl PlanModeState {
 
     pub fn blocked_message(tool_name: &str) -> String {
         format!(
-            "Tool `{tool_name}` is blocked in plan mode. Only Read, Grep, Glob, and Skill are allowed until you call ExitPlanMode and the user approves your plan."
+            "Tool `{tool_name}` is blocked in plan mode. Only Read, Grep, Glob, RepoMap, and Skill are allowed until you call ExitPlanMode and the user approves your plan."
         )
     }
 }

--- a/crates/tools/src/repomap.rs
+++ b/crates/tools/src/repomap.rs
@@ -1,0 +1,74 @@
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde::Deserialize;
+use serde_json::json;
+use zene_index::DEFAULT_TOKEN_BUDGET;
+use zene_llm::ToolDefinition;
+
+use crate::registry::{Tool, ToolContext, ToolResult};
+
+pub struct RepoMapTool;
+
+#[derive(Debug, Deserialize)]
+struct RepoMapArgs {
+    #[serde(default)]
+    query: Option<String>,
+    #[serde(default)]
+    token_budget: Option<u32>,
+    #[serde(default)]
+    path: Option<String>,
+}
+
+#[async_trait]
+impl Tool for RepoMapTool {
+    fn name(&self) -> &str {
+        "RepoMap"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: "RepoMap".to_string(),
+            description: "Return a compact repository structure map (important signatures and definition names, not implementations). Use this to see what exists and where, then Read/Grep for the actual code. Optional query personalizes ranking to the current task. Output is a tool result in the conversation body, not a prompt prefix.".to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Optional task or symbol names to rank related files higher"
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "Optional subdirectory to show (index still covers the workspace)"
+                    },
+                    "token_budget": {
+                        "type": "integer",
+                        "description": "Approximate token budget for the map (default 2500)"
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn execute(&self, arguments: &str, ctx: &ToolContext) -> Result<ToolResult> {
+        let args: RepoMapArgs = serde_json::from_str(arguments).context("parse RepoMap args")?;
+        let workdir = ctx.sandbox.workdir().to_path_buf();
+        let query = args.query.filter(|q| !q.trim().is_empty());
+        let path = args.path.filter(|p| !p.trim().is_empty());
+        let budget = args.token_budget.unwrap_or(DEFAULT_TOKEN_BUDGET);
+        let map = tokio::task::spawn_blocking(move || {
+            zene_index::build_repo_map(
+                &workdir,
+                query.as_deref(),
+                budget,
+                path.as_deref(),
+            )
+        })
+        .await
+        .context("RepoMap worker")?
+        .context("build repo map")?;
+        Ok(ToolResult {
+            content: map,
+            is_error: false,
+        })
+    }
+}

--- a/crates/tools/tests/repomap.rs
+++ b/crates/tools/tests/repomap.rs
@@ -1,0 +1,42 @@
+use std::sync::Arc;
+
+use tempfile::tempdir;
+use zene_sandbox::LocalSandbox;
+use zene_config::WebSearchConfig;
+use zene_tools::{builtin_tools, ToolContext};
+
+fn ctx(workdir: &std::path::Path) -> ToolContext {
+    ToolContext {
+        sandbox: Arc::new(LocalSandbox::new(workdir)),
+        cancel: None,
+        subagent: None,
+        permission: None,
+        plan_mode: None,
+        todos: None,
+        ask_user: None,
+        background: None,
+    }
+}
+
+#[tokio::test]
+async fn repo_map_returns_structure_not_source() {
+    let dir = tempdir().unwrap();
+    tokio::fs::write(
+        dir.path().join("engine.rs"),
+        "pub struct ContextEngine {}\nimpl ContextEngine {\n    pub fn prepare_step() {}\n}\n",
+    )
+    .await
+    .unwrap();
+
+    let ctx = ctx(dir.path());
+    let result = builtin_tools(WebSearchConfig::default())
+        .execute("RepoMap", r#"{"query":"ContextEngine"}"#, &ctx)
+        .await
+        .expect("RepoMap should run");
+
+    assert!(!result.is_error);
+    assert!(result.content.contains("engine.rs"));
+    assert!(result.content.contains("ContextEngine"));
+    assert!(result.content.contains("signatures only"));
+    assert!(!result.content.contains("pub fn prepare_step() {}"));
+}

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -192,9 +192,9 @@ Configure main-agent tool subsets via `agent_profile` in `~/.zene/config.toml` o
 | Profile | Built-in tools |
 |---------|----------------|
 | `full` (default) | All built-in tools |
-| `explore` | Read/Grep/Glob + Skill + AskUser/Todo/FetchUrl/WebSearch + plan mode |
-| `coder` | Read/Write/Edit/Bash/Grep/Glob + Skill + Task + collaboration + plan mode |
+| `explore` | Read/Grep/Glob/RepoMap + Skill + AskUser/Todo/FetchUrl/WebSearch + plan mode |
+| `coder` | Read/Write/Edit/Bash/Grep/Glob/RepoMap + Skill + Task + collaboration + plan mode |
 
 MCP tools are always merged regardless of profile.
 
-Code index / Repo Map is **Select**, not ContextEngine: hits must land as tool results in the Body (or a session-frozen prefix). Do not inject a resizing documents block. See [context-engine.md](./context-engine.md) §5.
+Code index / Repo Map is **Select**, not ContextEngine: hits must land as tool results in the Body (or a session-frozen prefix). Do not inject a resizing documents block. See [context-engine.md](./context-engine.md) §5. Implemented as `zene-index` (`{workdir}/.zene/index/v1.json`) plus the `RepoMap` tool.

--- a/docs/agent-components.md
+++ b/docs/agent-components.md
@@ -22,8 +22,8 @@
 zene-context          zene-tools + mcp       zene-session
 estimate/compact      Tool trait/registry    持久化 transcript
 assemble/epoch        内置 + MCP 工具         checkpoint/fork
-                      Select：Grep/Read；
-                      未来符号图 / RepoMap
+                      Select：Grep/Read/RepoMap；
+                      符号图在 zene-index
      │                      │
      └──────────┬───────────┘
                 ▼
@@ -41,8 +41,9 @@ assemble/epoch        内置 + MCP 工具         checkpoint/fork
 | `zene-llm` | 协议与 Provider | config（后续可删） |
 | `zene-sandbox` | 执行隔离 | 无 Zene crate |
 | `zene-context` | 语义上下文引擎 | llm |
+| `zene-index` | 工作区符号图 / Repo Map（Select） | 无 Zene crate |
 | `zene-session` | 会话持久化 | llm |
-| `zene-tools` | 工具插件 | llm, sandbox, session |
+| `zene-tools` | 工具插件 | llm, sandbox, session, index |
 | `zene-mcp` | MCP 适配 | tools |
 | `zene-core` | Zene 产品 runtime | 以上全部 |
 

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -591,7 +591,7 @@ pub struct RuntimeScope {
 | Scope | 工具 | 持久化 | AskUser | Plan mode |
 | --- | --- | --- | --- | --- |
 | Full Agent | 全部配置工具 | durable | enabled | enabled |
-| Explore | Read/Grep/Glob | ephemeral | disabled | disabled |
+| Explore | Read/Grep/Glob/RepoMap | ephemeral | disabled | disabled |
 | Coder | Read/Edit/Write/Bash | ephemeral 或 child session | inherited | disabled |
 
 现有 `SubagentRunner` 可以保留为兼容 API，但内部改为：

--- a/docs/context-engine.md
+++ b/docs/context-engine.md
@@ -6,7 +6,7 @@ Zene 的语义上下文引擎（`crates/context`）。它从 Session 事实算�
 
 **不在本文范围**：新的 compress 算法、改成 Pi JSONL、把 permission / MCP / Turn 塞进 ContextEngine、为 agent 循环建设全仓 embedding。
 
-**进度（2026-08-13）**：crate 边界、`observe → commit → project`、event-backed projection、前缀三区、Plan/overflow 去改写、prefix-adjacent 注入拖尾已在实现里。代码索引（Select）的职责与最小闭环已写入本文，实现未开始。剩余是 legacy fallback 清理，以及 Console 对 `prefixCache` 的展示。
+**进度（2026-08-13）**：crate 边界、`observe → commit → project`、event-backed projection、前缀三区、Plan/overflow 去改写、prefix-adjacent 注入拖尾已在实现里。代码索引（Select）最小闭环已落地：`zene-index` sidecar + 按需 `RepoMap` 工具。剩余是 legacy fallback 清理，以及 Console 对 `prefixCache` 的展示。
 
 ---
 
@@ -22,7 +22,7 @@ ContextEngine       estimate → compact → memory → assemble → epoch → �
 ```
 zene-session     持久化：events、兼容 messages cache、checkpoints、todos
 zene-context     语义上下文：estimate、compact、memory、prefire、epoch、assemble、layout
-zene-tools       Grep/Read/Glob；未来符号查询 / RepoMap（Select，不进 context）
+zene-tools       Grep/Read/Glob/RepoMap；符号查询走 `zene-index`
 zene-llm         ChatRequest + ContextMetadata、TokenUsage.cached_tokens
 zene-core        composition root
 ```
@@ -198,12 +198,12 @@ Repo Map 是给模型看的 **仓库结构地图**，不是源码全文，也不
 
 现状：JIT 工具已经够用——`Read` / `Grep` / `Glob`（见 [ENGINE.md](./ENGINE.md) 的 agent profile）。缺的是结构化导航，不是第二套上下文引擎。
 
-**下一步（agent 工作区，尚未实现）**
+**下一步（agent 工作区，已落地）**
 
 1. tree-sitter 按语法边界抽符号（函数、类、方法、模块），不要按固定行数切块。
-2. 符号图 sidecar：路径、符号、签名、一行定义；文件 content hash 变了才重解析。
-3. `RepoMap` 工具：按 token 预算返回结构地图，输出当工具结果。
-4. Grep 可先打符号表再落文件；Read 仍是唯一把实现拉进窗口的入口。
+2. 符号图 sidecar：`{workdir}/.zene/index/v1.json`；路径、符号、签名、一行定义；文件 content hash 变了才重解析。
+3. `RepoMap` 工具：按 token 预算返回结构地图，输出当工具结果（对话 Body），不写进冻结 Prefix。
+4. Grep / Read 仍负责真正打开实现；Explore / Plan mode / 子 agent 均可调用 `RepoMap`。
 
 **明确不做的下一跳**
 
@@ -265,7 +265,7 @@ TurnEngine 只依赖 `ContextAssembler::prepare` / `handle_overflow`；三段式
 - 仅清理可无损迁移的 legacy session fallback
 - Console 按产品需求展示 `prefixCache`（非第一版必做彩图）
 - Agent-specific runtime wiring 的进一步 crate 化（控制面，见 runtime 文档）
-- §5 最小闭环尚未实现：tree-sitter 符号图（hash 增量）、按需 `RepoMap` 工具；不要为此改 ContextEngine 布局
+- §5 最小闭环已落地：`zene-index`（tree-sitter 符号图 + hash 增量）与 `RepoMap` 工具；不要为此改 ContextEngine 布局
 - 向量检索 / 跨仓 embedding 属于 Console Code Intelligence，不在本文实现范围
 
 ---
@@ -292,6 +292,7 @@ TurnEngine 只依赖 `ContextAssembler::prepare` / `handle_overflow`；三段式
 - 最小闭环：tree-sitter 符号索引 + 按需 Repo Map + 现有 Grep/Read；符号图按文件 hash 增量更新。
 - 向量检索归 Console / 跨仓搜索，不是把 agent 做强的下一跳。
 - Repo Map 按需当工具结果进 Body；个性化地图不得写入冻结 Prefix。
+- 已落地：`zene-index` sidecar（`.zene/index/v1.json`）+ `RepoMap` 工具；不做向量检索。
 
 ### 2026-08-13 — 前缀稳定 + 文档合并
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
按 `docs/context-engine.md` §5 落地 Select 最小闭环：索引不进 ContextEngine，也不做向量检索。

新增 `zene-index`：tree-sitter 抽取 Rust / Python / TS / JS / Go 的定义与引用，sidecar 写在 `{workdir}/.zene/index/v1.json`，按文件 content hash 增量更新。

新增只读工具 `RepoMap`：按 token 预算输出结构地图（签名和符号名，不含实现），结果作为工具输出进对话 Body。可选 `query` 做个性化 PageRank。Explore / Coder / Plan mode / 子 agent 均可调用。

Grep/Read 仍负责打开真正代码。ContextEngine 三区布局未改。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-26fba7b9-7080-4260-a190-8c2f10863683?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-26fba7b9-7080-4260-a190-8c2f10863683&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

