### PR TITLE
feat: 审批选项与分类事件 payload 类型化

### DIFF
--- a/cloud/Cargo.lock
+++ b/cloud/Cargo.lock
@@ -3031,6 +3031,7 @@ version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
+ "serde",
  "serde_json",
  "tokio",
  "uuid",

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -94,6 +94,67 @@ export interface AcpSessionUpdate {
   rawOutput?: { text?: string; isError?: boolean };
 }
 
+export interface TextEventPayload {
+  text?: string;
+}
+
+export interface ToolCallPayload {
+  toolCallId?: string;
+  title?: string;
+  toolName?: string;
+  kind?: string;
+  status?: string;
+  rawInput?: unknown;
+}
+
+export interface ToolResultPayload {
+  toolCallId?: string;
+  title?: string;
+  toolName?: string;
+  kind?: string;
+  status?: string;
+  rawOutput?: { text?: string; isError?: boolean };
+  text?: string;
+  isError?: boolean;
+}
+
+export interface SessionStartedPayload {
+  sessionId?: string;
+  resumed?: boolean;
+}
+
+export interface StateChangedPayload {
+  state?: unknown;
+}
+
+export interface UsagePayload {
+  used?: unknown;
+  size?: unknown;
+  promptTokens?: unknown;
+  completionTokens?: unknown;
+  contextPercent?: unknown;
+  contextEpoch?: unknown;
+  cachedTokens?: unknown;
+}
+
+export interface PlanPayload {
+  entries?: unknown;
+}
+
+export interface AvailableCommandsPayload {
+  availableCommands?: unknown;
+}
+
+export interface ApprovalEventPayload {
+  requestId: string;
+  toolCallId?: string;
+  title?: string;
+  toolName?: string;
+  kind?: string;
+  status?: string;
+  rawInput?: unknown;
+}
+
 export interface RunEvent {
   seq: number;
   /** Optional provider/runtime cursor; `seq` remains the server ordering. */
@@ -115,6 +176,9 @@ export interface RunEvent {
     rawInput?: unknown;
     rawOutput?: { text?: string; isError?: boolean };
     isError?: boolean;
+    requestId?: string;
+    sessionId?: string;
+    resumed?: boolean;
     params?: {
       update?: AcpSessionUpdate;
     };

--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -691,6 +691,7 @@ fn spawn_event_pump<R: RuntimeClient + 'static>(
                     let RuntimeRequest::Approval {
                         request_id,
                         kind,
+                        allowed_decisions,
                         context,
                     } = request;
                     let decision = match resolve_permission(
@@ -700,6 +701,7 @@ fn spawn_event_pump<R: RuntimeClient + 'static>(
                         run_id,
                         &request_id,
                         kind,
+                        allowed_decisions,
                         &context,
                     )
                     .await
@@ -1107,6 +1109,7 @@ async fn resolve_permission(
     run_id: Uuid,
     request_key: &str,
     kind: ApprovalKind,
+    allowed_decisions: Vec<ApprovalDecision>,
     payload: &serde_json::Value,
 ) -> Result<ApprovalDecision> {
     let body = CreateApprovalRequest {
@@ -1114,11 +1117,7 @@ async fn resolve_permission(
         kind,
         risk: ApprovalRisk::Medium,
         payload: payload.clone(),
-        allowed_decisions: vec![
-            ApprovalDecision::AllowOnce,
-            ApprovalDecision::AllowSession,
-            ApprovalDecision::Deny,
-        ],
+        allowed_decisions,
         expires_at: None,
     };
     let created: ApprovalRequest = client

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -210,6 +210,120 @@ impl CloudEventKind {
     }
 }
 
+/// Classified product payloads persisted on `RunEvent.payload`.
+/// Wire JSON stays camelCase; ACP envelopes stay inside the adapter.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TextEventPayload {
+    #[serde(default)]
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolCallPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_input: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolResultPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_output: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionStartedPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resumed: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct StateChangedPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UsagePayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub used: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion_tokens: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_percent: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_epoch: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cached_tokens: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entries: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AvailableCommandsPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub available_commands: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ApprovalEventPayload {
+    pub request_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw_input: Option<serde_json::Value>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RunEvent {
@@ -375,8 +489,9 @@ pub struct WorkerEventRequest {
 #[cfg(test)]
 mod tests {
     use super::{
-        ApprovalDecision, ApprovalKind, ApprovalRisk, CloudEventKind, CreateApprovalRequest,
-        WorkerCommand, WorkerCommandAckRequest, WorkerCommandKind, WorkerEventRequest, WorkerFence,
+        ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, CloudEventKind,
+        CreateApprovalRequest, TextEventPayload, ToolCallPayload, WorkerCommand,
+        WorkerCommandAckRequest, WorkerCommandKind, WorkerEventRequest, WorkerFence,
     };
 
     #[test]
@@ -505,6 +620,57 @@ mod tests {
         }
         assert_eq!(CloudEventKind::parse("platform"), None);
         assert_eq!(CloudEventKind::parse("runtime"), None);
+    }
+
+    #[test]
+    fn classified_event_payloads_round_trip_camel_case() {
+        let encoded = serde_json::to_value(TextEventPayload {
+            text: "hello".into(),
+        })
+        .expect("text");
+        assert_eq!(encoded, serde_json::json!({ "text": "hello" }));
+        let encoded = serde_json::to_value(ToolCallPayload {
+            tool_call_id: Some("call-7".into()),
+            title: Some("Write".into()),
+            raw_input: Some(serde_json::json!({ "path": "notes.md" })),
+            ..ToolCallPayload::default()
+        })
+        .expect("tool");
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "toolCallId": "call-7",
+                "title": "Write",
+                "rawInput": { "path": "notes.md" }
+            })
+        );
+        assert_eq!(
+            ApprovalDecision::default_allowed(),
+            vec![
+                ApprovalDecision::AllowOnce,
+                ApprovalDecision::AllowSession,
+                ApprovalDecision::Deny
+            ]
+        );
+        let encoded = serde_json::to_value(ApprovalEventPayload {
+            request_id: "call-7".into(),
+            tool_call_id: Some("call-7".into()),
+            title: Some("Write".into()),
+            kind: Some("edit".into()),
+            raw_input: Some(serde_json::json!({ "path": "notes.md" })),
+            ..ApprovalEventPayload::default()
+        })
+        .expect("approval");
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "requestId": "call-7",
+                "toolCallId": "call-7",
+                "title": "Write",
+                "kind": "edit",
+                "rawInput": { "path": "notes.md" }
+            })
+        );
     }
 }
 
@@ -642,6 +808,10 @@ impl ApprovalDecision {
         })
     }
 
+    pub fn default_allowed() -> Vec<Self> {
+        vec![Self::AllowOnce, Self::AllowSession, Self::Deny]
+    }
+
     pub fn status(self) -> ApprovalStatus {
         match self {
             Self::Deny => ApprovalStatus::Denied,
@@ -722,11 +892,7 @@ fn default_risk() -> ApprovalRisk {
 }
 
 fn default_allowed_decisions() -> Vec<ApprovalDecision> {
-    vec![
-        ApprovalDecision::AllowOnce,
-        ApprovalDecision::AllowSession,
-        ApprovalDecision::Deny,
-    ]
+    ApprovalDecision::default_allowed()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/cloud/crates/runtime-client/Cargo.toml
+++ b/cloud/crates/runtime-client/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 uuid.workspace = true

--- a/cloud/crates/runtime-client/src/lib.rs
+++ b/cloud/crates/runtime-client/src/lib.rs
@@ -5,13 +5,18 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
+use serde::Serialize;
 use serde_json::Value;
 use tokio::sync::{mpsc, oneshot, Mutex};
 use zene_cloud_acp_bridge::{
     AcpBridge, AcpEvent, BridgeMsg, MockAgent, MockMsg, PermissionDecision,
 };
 
-pub use zene_cloud_domain::{ApprovalDecision, ApprovalKind, CloudEventKind};
+pub use zene_cloud_domain::{
+    ApprovalDecision, ApprovalEventPayload, ApprovalKind, AvailableCommandsPayload,
+    CloudEventKind, PlanPayload, SessionStartedPayload, StateChangedPayload, TextEventPayload,
+    ToolCallPayload, ToolResultPayload, UsagePayload,
+};
 
 /// ACP `optionId` mapping stays inside this adapter.
 pub fn to_permission_decision(decision: ApprovalDecision) -> PermissionDecision {
@@ -100,12 +105,14 @@ pub enum RuntimeEvent {
 
 /// Runtime-level meaning of a request requiring user approval. Protocol method
 /// names, JSON-RPC ids, and parameter paths stay inside this adapter.
+/// `allowed_decisions` is the product list mapped from ACP `optionId`s.
 /// `context` is the product payload stored on the approval row.
 #[derive(Debug)]
 pub enum RuntimeRequest {
     Approval {
         request_id: String,
         kind: ApprovalKind,
+        allowed_decisions: Vec<ApprovalDecision>,
         context: Value,
     },
 }
@@ -113,18 +120,38 @@ pub enum RuntimeRequest {
 /// Product payload stored on Cloud approval rows. ACP option lists and
 /// session metadata stay inside the adapter.
 fn approval_payload(params: &Value) -> Value {
-    let mut map = serde_json::Map::new();
-    map.insert(
-        "requestId".into(),
-        Value::String(permission_request_key(params)),
-    );
-    if let Some(tool) = params.get("toolCall") {
-        map.extend(take_fields(
-            tool,
-            &["toolCallId", "title", "toolName", "kind", "status", "rawInput"],
-        ));
+    let tool = params.get("toolCall").unwrap_or(&Value::Null);
+    to_json(ApprovalEventPayload {
+        request_id: permission_request_key(params),
+        tool_call_id: json_str(tool, "toolCallId"),
+        title: json_str(tool, "title"),
+        tool_name: json_str(tool, "toolName"),
+        kind: json_str(tool, "kind"),
+        status: json_str(tool, "status"),
+        raw_input: json_opt(tool, "rawInput"),
+    })
+}
+
+fn allowed_decisions_from_params(params: &Value) -> Vec<ApprovalDecision> {
+    let mut decisions = Vec::new();
+    if let Some(options) = params.get("options").and_then(Value::as_array) {
+        for option in options {
+            let Some(id) = option.get("optionId").and_then(Value::as_str) else {
+                continue;
+            };
+            let Some(decision) = ApprovalDecision::parse(id) else {
+                continue;
+            };
+            if !decisions.contains(&decision) {
+                decisions.push(decision);
+            }
+        }
     }
-    Value::Object(map)
+    if decisions.is_empty() {
+        ApprovalDecision::default_allowed()
+    } else {
+        decisions
+    }
 }
 
 #[async_trait]
@@ -160,40 +187,21 @@ fn product_payload(kind: CloudEventKind, raw: &Value) -> Value {
             let Some(update) = raw.pointer("/params/update") else {
                 return raw.clone();
             };
-            serde_json::json!({ "text": text_from_update(update) })
+            to_json(TextEventPayload {
+                text: text_from_update(update),
+            })
         }
         CloudEventKind::ToolCall => {
             let Some(update) = raw.pointer("/params/update") else {
                 return raw.clone();
             };
-            Value::Object(take_fields(
-                update,
-                &["toolCallId", "title", "toolName", "kind", "status", "rawInput"],
-            ))
+            to_json(tool_call_payload(update))
         }
         CloudEventKind::ToolResult => {
             let Some(update) = raw.pointer("/params/update") else {
                 return raw.clone();
             };
-            let mut map = take_fields(
-                update,
-                &[
-                    "toolCallId",
-                    "title",
-                    "toolName",
-                    "kind",
-                    "status",
-                    "rawOutput",
-                ],
-            );
-            let text = tool_result_text(update);
-            if !text.is_empty() {
-                map.insert("text".into(), Value::String(text));
-            }
-            if let Some(is_error) = update.pointer("/rawOutput/isError") {
-                map.insert("isError".into(), is_error.clone());
-            }
-            Value::Object(map)
+            to_json(tool_result_payload(update))
         }
         CloudEventKind::ApprovalRequested => approval_product(raw),
         CloudEventKind::SessionStarted => session_started_product(raw),
@@ -206,6 +214,43 @@ fn product_payload(kind: CloudEventKind, raw: &Value) -> Value {
     }
 }
 
+fn to_json<T: Serialize>(value: T) -> Value {
+    serde_json::to_value(value).unwrap_or(Value::Object(Default::default()))
+}
+
+fn json_str(update: &Value, key: &str) -> Option<String> {
+    update.get(key).and_then(Value::as_str).map(str::to_string)
+}
+
+fn json_opt(update: &Value, key: &str) -> Option<Value> {
+    update.get(key).filter(|value| !value.is_null()).cloned()
+}
+
+fn tool_call_payload(update: &Value) -> ToolCallPayload {
+    ToolCallPayload {
+        tool_call_id: json_str(update, "toolCallId"),
+        title: json_str(update, "title"),
+        tool_name: json_str(update, "toolName"),
+        kind: json_str(update, "kind"),
+        status: json_str(update, "status"),
+        raw_input: json_opt(update, "rawInput"),
+    }
+}
+
+fn tool_result_payload(update: &Value) -> ToolResultPayload {
+    let text = tool_result_text(update);
+    ToolResultPayload {
+        tool_call_id: json_str(update, "toolCallId"),
+        title: json_str(update, "title"),
+        tool_name: json_str(update, "toolName"),
+        kind: json_str(update, "kind"),
+        status: json_str(update, "status"),
+        raw_output: json_opt(update, "rawOutput"),
+        text: if text.is_empty() { None } else { Some(text) },
+        is_error: update.pointer("/rawOutput/isError").and_then(Value::as_bool),
+    }
+}
+
 fn approval_product(raw: &Value) -> Value {
     approval_payload(raw.get("params").unwrap_or(raw))
 }
@@ -214,48 +259,46 @@ fn session_started_product(raw: &Value) -> Value {
     let session_id = raw
         .pointer("/result/sessionId")
         .or_else(|| raw.pointer("/params/sessionId"))
-        .cloned();
-    let mut map = serde_json::Map::new();
-    if let Some(session_id) = session_id {
-        map.insert("sessionId".into(), session_id);
-    }
-    if raw.get("method").and_then(Value::as_str) == Some("session/resume") {
-        map.insert("resumed".into(), Value::Bool(true));
-    }
-    if map.is_empty() {
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let resumed = (raw.get("method").and_then(Value::as_str) == Some("session/resume"))
+        .then_some(true);
+    let payload = SessionStartedPayload {
+        session_id,
+        resumed,
+    };
+    if payload.session_id.is_none() && payload.resumed.is_none() {
         return raw.clone();
     }
-    Value::Object(map)
+    to_json(payload)
 }
 
 fn state_product(raw: &Value) -> Value {
     let Some(update) = raw.pointer("/params/update") else {
         return raw.clone();
     };
-    match update.get("modeId") {
-        Some(state) if !state.is_null() => serde_json::json!({ "state": state }),
-        _ => serde_json::json!({}),
-    }
+    to_json(StateChangedPayload {
+        state: json_opt(update, "modeId"),
+    })
 }
 
 fn usage_product(raw: &Value) -> Value {
     let Some(update) = raw.pointer("/params/update") else {
         return raw.clone();
     };
-    let mut map = take_fields(update, &["used", "size"]);
+    let mut payload = UsagePayload {
+        used: json_opt(update, "used"),
+        size: json_opt(update, "size"),
+        ..UsagePayload::default()
+    };
     if let Some(meta) = update.get("_meta") {
-        map.extend(take_fields(
-            meta,
-            &[
-                "promptTokens",
-                "completionTokens",
-                "contextPercent",
-                "contextEpoch",
-                "cachedTokens",
-            ],
-        ));
+        payload.prompt_tokens = json_opt(meta, "promptTokens");
+        payload.completion_tokens = json_opt(meta, "completionTokens");
+        payload.context_percent = json_opt(meta, "contextPercent");
+        payload.context_epoch = json_opt(meta, "contextEpoch");
+        payload.cached_tokens = json_opt(meta, "cachedTokens");
     }
-    Value::Object(map)
+    to_json(payload)
 }
 
 fn projection_product(raw: &Value) -> Value {
@@ -272,26 +315,18 @@ fn plan_product(raw: &Value) -> Value {
     let Some(update) = raw.pointer("/params/update") else {
         return raw.clone();
     };
-    Value::Object(take_fields(update, &["entries"]))
+    to_json(PlanPayload {
+        entries: json_opt(update, "entries"),
+    })
 }
 
 fn commands_product(raw: &Value) -> Value {
     let Some(update) = raw.pointer("/params/update") else {
         return raw.clone();
     };
-    Value::Object(take_fields(update, &["availableCommands"]))
-}
-
-fn take_fields(update: &Value, keys: &[&str]) -> serde_json::Map<String, Value> {
-    let mut map = serde_json::Map::new();
-    for key in keys {
-        if let Some(value) = update.get(*key) {
-            if !value.is_null() {
-                map.insert((*key).to_string(), value.clone());
-            }
-        }
-    }
-    map
+    to_json(AvailableCommandsPayload {
+        available_commands: json_opt(update, "availableCommands"),
+    })
 }
 
 fn text_from_update(update: &Value) -> String {
@@ -335,6 +370,7 @@ fn runtime_request(method: &str, params: &Value) -> Option<RuntimeRequest> {
         Some(RuntimeRequest::Approval {
             request_id: permission_request_key(params),
             kind: ApprovalKind::Permission,
+            allowed_decisions: allowed_decisions_from_params(params),
             context: approval_payload(params),
         })
     } else {
@@ -546,6 +582,7 @@ impl MockRuntimeClient {
                             request: RuntimeRequest::Approval {
                                 request_id: request_key,
                                 kind: ApprovalKind::Tool,
+                                allowed_decisions: allowed_decisions_from_params(&params),
                                 context,
                             },
                             event,
@@ -1016,15 +1053,30 @@ mod tests {
             Some(RuntimeRequest::Approval {
                 request_id,
                 kind: ApprovalKind::Permission,
+                allowed_decisions,
                 context
             })
                 if request_id == "call-7"
+                    && allowed_decisions == vec![ApprovalDecision::AllowOnce]
                     && context == serde_json::json!({
                         "requestId": "call-7",
                         "toolCallId": "call-7",
                         "title": "Write notes",
                         "kind": "edit"
                     })
+        ));
+    }
+
+    #[test]
+    fn missing_permission_options_use_default_allowed_decisions() {
+        let request = runtime_request(
+            "session/request_permission",
+            &serde_json::json!({ "toolCall": { "toolCallId": "call-7" } }),
+        );
+        assert!(matches!(
+            request,
+            Some(RuntimeRequest::Approval { allowed_decisions, .. })
+                if allowed_decisions == ApprovalDecision::default_allowed()
         ));
     }
 
@@ -1112,9 +1164,14 @@ mod tests {
                         let RuntimeRequest::Approval {
                             request_id,
                             kind,
+                            allowed_decisions,
                             context,
                         } = request;
                         assert_eq!(kind, ApprovalKind::Tool);
+                        assert_eq!(
+                            allowed_decisions,
+                            vec![ApprovalDecision::AllowOnce, ApprovalDecision::Deny]
+                        );
                         assert_eq!(context["toolCallId"], "tool_write_notes");
                         pump.send(RuntimeCommand::Approval {
                             request_id,

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `06a10a9`（PR #80 已合并）。**
+> **进度快照：2026-08-13，基线 `2a7ff47`（PR #81 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是 JobRunner mock/real 共用同一条 runtime session；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是审批 `allowed_decisions` 与分类事件 payload 类型化；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -954,7 +954,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
 5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision` / `ApprovalKind` / `ApprovalRisk`。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
 6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection 等不进时间线。未识别帧仍为 `acp`。
-7. **JobRunner 只看见 RuntimeClient 产品类型（Wave 16）**：mock 与真实 ACP 共用 event pump、command poller 与 idle hold；`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeRequest::Approval` 携带 `ApprovalKind`。ACP `MockMsg` / `optionId` 只留在 adapter。
+7. **JobRunner 只看见 RuntimeClient 产品类型（Wave 16）**：mock 与真实 ACP 共用 event pump、command poller 与 idle hold；`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeRequest::Approval` 携带 `ApprovalKind` 与 `allowed_decisions`（来自 ACP `optionId`）。分类事件 payload 是 domain 结构体。ACP `MockMsg` / `optionId` 只留在 adapter。
 8. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
 Conversation event 与 materialized `messages` cache 的双轨可以保留，直到 legacy session 可证明无损迁移。不要为了架构干净上完整 Event Sourcing。
@@ -1058,7 +1058,9 @@ Wave 16  统一 transport command/event  ← 当前工作
          Cloud 审批产品面（决策/kind/risk）从 Console 到 RuntimeCommand 收口
          Console 时间线按 event_type 消费产品字段（含 user_message）
          JobRunner mock 路径走 RuntimeClient 产品类型
-         JobRunner mock/real 共用 runtime session（command + hold；本轮）
+         JobRunner mock/real 共用 runtime session（command + hold）
+         RuntimeRequest::Approval.allowed_decisions 来自 ACP options（本轮）
+         分类事件 payload 使用 domain 结构体（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1083,13 +1085,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | JobRunner mock/real 共用 runtime session；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | 审批 allowed_decisions 与分类 payload 类型化；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1188,7 +1190,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - Console 按 `event_type` 分发时间线：`text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result` 直接渲染产品字段，legacy `params.update` 仍可回放。plan/usage/projection/session_started/approval_requested 不进时间线。
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
    - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
-   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；审批请求携带 `ApprovalKind`。ACP `MockMsg` 与 `optionId` 只留在 adapter。
+   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；审批请求携带 `ApprovalKind` 与 `allowed_decisions`（ACP `optionId` 在 adapter 内映射）。分类事件 payload 是 domain 结构体；审批表 payload 同样序列化 `ApprovalEventPayload`。ACP `MockMsg` 与 `optionId` 只留在 adapter。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1214,10 +1216,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | JobRunner 已共用 runtime session；Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | 审批 options 与分类 payload 已类型化；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**JobRunner 已共用 runtime session**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
+推荐组合：**审批 options 与分类 payload 已类型化**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #81 让 JobRunner 共用 runtime session，但审批按钮仍写死三选项，分类事件仍用手拼 JSON。本 PR 把 **ACP `options` 与分类 payload** 收成产品类型。

`RuntimeRequest::Approval` 携带 `allowed_decisions`（adapter 把 ACP `optionId` 映射为 `ApprovalDecision`；缺省/无法解析则用默认三选项）。JobRunner 把该列表写入审批行，Console 按钮与 runtime 实际给出的选项一致。mock 只有 allow-once / reject-once。分类事件与审批表 payload 序列化 domain 结构体（camelCase），不把 `optionId` 写入存库。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不改 Console 布局。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-runtime-client -p zene-cloud-worker --locked` 与 `cd cloud/apps/web && npm run typecheck` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

