### PR TITLE
feat: 平台事件 payload 类型化

### DIFF
--- a/cloud/apps/web/components/RunView.tsx
+++ b/cloud/apps/web/components/RunView.tsx
@@ -30,8 +30,9 @@ import {
   modelsForPicker,
   saveSelectedModel,
 } from "@/lib/models";
-import { allowsDeny, allowsOnce, extraDecisions } from "@/lib/approval";
+import { allowsDeny, allowsOnce, approvalCardBody, extraDecisions } from "@/lib/approval";
 import type { Approval, ApprovalDecision, LlmSettingsView, Repo, Run, RunEvent, RunMessage } from "@/lib/types";
+import { platformEventFromPayload } from "@/lib/platformEvent";
 import { timelineProductFromEvent, timelineToolOutput, type TimelineProduct } from "@/lib/runtimeEvent";
 import { CodePanel, useCodePanelWidth } from "./CodePanel";
 import { Markdown } from "./Markdown";
@@ -262,13 +263,13 @@ function applyTimelineProductToDraft(draft: TimelineDraft, product: TimelineProd
 }
 
 function applyPlatformEventToDraft(draft: TimelineDraft, payload: NonNullable<RunEvent["payload"]>) {
-  if (payload.event === "run.created" && typeof (payload as { prompt?: string }).prompt === "string") {
-    draftAppendUser(draft, (payload as { prompt?: string }).prompt || "");
+  const platform = platformEventFromPayload(payload);
+  if (platform?.event === "run.created" && typeof platform.prompt === "string") {
+    draftAppendUser(draft, platform.prompt || "");
   }
-  if (payload.event === "message.created") {
-    const role = (payload as { role?: string }).role;
-    const text = (payload as { text?: string }).text || "";
-    if (bubbleRole(role) === "user" && text) draftAppendUser(draft, text);
+  if (platform?.event === "message.created") {
+    const text = platform.text || "";
+    if (bubbleRole(platform.role) === "user" && text) draftAppendUser(draft, text);
   }
 }
 
@@ -1173,24 +1174,24 @@ export function RunView({
 
   const handleEvent = useCallback(
     (event: RunEvent) => {
-      const payload = event.payload || {};
-      if (payload.event === "run.status" && payload.status) {
+      const platform = platformEventFromPayload(event.payload);
+      if (platform?.event === "run.status" && platform.status) {
         setRun((prev) => {
           if (!prev) return prev;
-          const next = { ...prev, status: payload.status! };
-          if (payload.headSha) next.headSha = payload.headSha;
+          const next = { ...prev, status: platform.status! };
+          if (platform.headSha) next.headSha = platform.headSha;
           return next;
         });
         onRunsChanged();
       }
-      if (payload.event === "run.title" && typeof payload.title === "string" && payload.title) {
-        lastKnownTitle.current = payload.title;
-        setRun((prev) => (prev ? { ...prev, title: payload.title! } : prev));
+      if (platform?.event === "run.title" && platform.title) {
+        lastKnownTitle.current = platform.title;
+        setRun((prev) => (prev ? { ...prev, title: platform.title! } : prev));
         onRunsChanged();
       }
 
-      if (payload.event === "run.created" && typeof (payload as { prompt?: string }).prompt === "string") {
-        const prompt = (payload as { prompt?: string }).prompt || "";
+      if (platform?.event === "run.created" && typeof platform.prompt === "string") {
+        const prompt = platform.prompt || "";
         if (prompt) {
           hasAssistantTail.current = false;
           setItems((prev) => {
@@ -1202,10 +1203,9 @@ export function RunView({
         }
       }
 
-      if (payload.event === "message.created") {
-        const role = (payload as { role?: string }).role;
-        const text = (payload as { text?: string }).text || "";
-        if (bubbleRole(role) === "user" && text) appendUserBubble(text);
+      if (platform?.event === "message.created") {
+        const text = platform.text || "";
+        if (bubbleRole(platform.role) === "user" && text) appendUserBubble(text);
       }
 
       const product = timelineProductFromEvent(event);
@@ -1299,17 +1299,17 @@ export function RunView({
         const draft = buildTimelineFromEvents(allEvents);
         let statusPatch: Partial<Run> | null = null;
         for (const e of allEvents) {
-          const payload = e.payload || {};
-          if (payload.event === "run.status" && payload.status) {
+          const platform = platformEventFromPayload(e.payload);
+          if (platform?.event === "run.status" && platform.status) {
             statusPatch = {
               ...(statusPatch || {}),
-              status: payload.status,
-              ...(payload.headSha ? { headSha: payload.headSha } : {}),
+              status: platform.status,
+              ...(platform.headSha ? { headSha: platform.headSha } : {}),
             };
           }
-          if (payload.event === "run.title" && typeof payload.title === "string" && payload.title) {
-            lastKnownTitle.current = payload.title;
-            statusPatch = { ...(statusPatch || {}), title: payload.title };
+          if (platform?.event === "run.title" && platform.title) {
+            lastKnownTitle.current = platform.title;
+            statusPatch = { ...(statusPatch || {}), title: platform.title };
           }
         }
         if (statusPatch) {
@@ -1900,10 +1900,7 @@ export function RunView({
                 const item = seg.item;
                 if (item.kind === "approval") {
                   const ap = item.approval;
-                  const summary =
-                    typeof ap.payload === "object"
-                      ? JSON.stringify(ap.payload, null, 2)
-                      : String(ap.payload || "");
+                  const summary = approvalCardBody(ap.payload);
                   const allowed = ap.allowedDecisions || ["allow-once", "reject-once"];
                   const extra = extraDecisions(allowed);
                   const decided = Boolean(item.decision);

--- a/cloud/apps/web/lib/approval.ts
+++ b/cloud/apps/web/lib/approval.ts
@@ -1,4 +1,4 @@
-import type { ApprovalDecision } from "@/lib/types";
+import type { Approval, ApprovalDecision, ApprovalEventPayload } from "@/lib/types";
 
 const ALLOW_ONCE: ApprovalDecision[] = ["allow-once", "allow"];
 const DENY_ONCE: ApprovalDecision[] = ["reject-once", "deny"];
@@ -14,4 +14,26 @@ export function allowsDeny(allowed: ApprovalDecision[]): boolean {
 
 export function extraDecisions(allowed: ApprovalDecision[]): ApprovalDecision[] {
   return allowed.filter((decision) => !PRIMARY.includes(decision));
+}
+
+/** Product fields for the existing approval card body. Legacy ACP envelopes stay JSON. */
+export function approvalCardBody(payload: Approval["payload"]): string {
+  if (payload == null) return "";
+  if (typeof payload !== "object") return String(payload);
+  const product = payload as ApprovalEventPayload & { params?: unknown; method?: unknown };
+  if (product.params || product.method) {
+    return stringify(payload);
+  }
+  if (product.rawInput !== undefined) return stringify(product.rawInput);
+  const line = [product.title, product.toolCallId].filter(Boolean).join(" · ");
+  return line || stringify(payload);
+}
+
+function stringify(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }

--- a/cloud/apps/web/lib/platformEvent.ts
+++ b/cloud/apps/web/lib/platformEvent.ts
@@ -1,0 +1,21 @@
+import type { PlatformEvent, RunEvent } from "@/lib/types";
+
+const PLATFORM_EVENTS = new Set<PlatformEvent["event"]>([
+  "run.created",
+  "run.title",
+  "run.archived",
+  "run.status",
+  "message.created",
+  "approval.created",
+  "approval.decided",
+]);
+
+export function platformEventFromPayload(
+  payload: RunEvent["payload"],
+): PlatformEvent | undefined {
+  const event = payload?.event;
+  if (!event || !PLATFORM_EVENTS.has(event as PlatformEvent["event"])) {
+    return undefined;
+  }
+  return payload as PlatformEvent;
+}

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -185,6 +185,21 @@ export interface RunEvent {
   };
 }
 
+export type PlatformEvent =
+  | { event: "run.created"; title?: string; prompt?: string }
+  | { event: "run.title"; title?: string }
+  | { event: "run.archived" }
+  | { event: "run.status"; status?: string; headSha?: string }
+  | { event: "message.created"; role?: string; text?: string }
+  | {
+      event: "approval.created";
+      approvalId?: string;
+      status?: string;
+      decision?: string;
+      kind?: string;
+    }
+  | { event: "approval.decided"; approvalId?: string; decision?: string };
+
 export type ApprovalDecision =
   | "allow-once"
   | "allow-always"

--- a/cloud/crates/db/src/lib.rs
+++ b/cloud/crates/db/src/lib.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 use zene_cloud_domain::{
     ApprovalDecision, ApprovalKind, ApprovalRequest, ApprovalRisk, ApprovalStatus, AuthResponse,
     CloneAuthResponse, CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest, LoginRequest, Organization,
-    QueueActive, QueueHold, QueueStats, RegisterRequest, Repository, Run, RunEvent, RunMessage,
+    PlatformEvent, QueueActive, QueueHold, QueueStats, RegisterRequest, Repository, Run, RunEvent, RunMessage,
     RunStatus, User, WorkerCommand, WorkerFence,
 };
 
@@ -476,10 +476,9 @@ impl Db {
             Some("platform.run.created"),
             None,
             "platform",
-            serde_json::json!({
-                "event": "run.created",
-                "title": run.title,
-                "prompt": run.prompt,
+            platform_payload(PlatformEvent::RunCreated {
+                title: run.title.clone(),
+                prompt: run.prompt.clone(),
             }),
         )
         .await?;
@@ -610,9 +609,8 @@ impl Db {
                 title_event_id.as_deref().or(Some("platform.run.title")), 
                 None,
                 "platform",
-                serde_json::json!({
-                    "event": "run.title",
-                    "title": updated.title,
+                platform_payload(PlatformEvent::RunTitle {
+                    title: updated.title.clone(),
                 }),
             )
             .await?;
@@ -625,7 +623,7 @@ impl Db {
                 Some("platform.run.archived"),
                 None,
                 "platform",
-                serde_json::json!({ "event": "run.archived" }),
+                platform_payload(PlatformEvent::RunArchived),
             )
             .await?;
         }
@@ -837,7 +835,7 @@ impl Db {
              WHERE id = ?",
         )
         .bind(status.as_str())
-        .bind(head_sha)
+        .bind(head_sha.clone())
         .bind(finished.clone())
         .bind(run_id.to_string())
         .execute(&mut *tx)
@@ -860,7 +858,7 @@ impl Db {
             Some(&format!("platform.status.{}", status.as_str())),
             None,
             "platform",
-            serde_json::json!({ "event": "run.status", "status": status.as_str() }),
+            run_status_payload(status, head_sha),
         )
         .await?;
         tx.commit().await?;
@@ -890,7 +888,7 @@ impl Db {
              WHERE id = ?",
         )
         .bind(status.as_str())
-        .bind(head_sha)
+        .bind(head_sha.clone())
         .bind(finished)
         .bind(run_id.to_string())
         .execute(&mut *tx)
@@ -913,7 +911,7 @@ impl Db {
             Some(&format!("platform.status.{}", status.as_str())),
             None,
             "platform",
-            serde_json::json!({ "event": "run.status", "status": status.as_str() }),
+            run_status_payload(status, head_sha),
         )
         .await?;
         let updated = sqlx::query_as::<_, RunRow>(&format!("SELECT {RUN_COLUMNS} FROM runs WHERE id = ?"))
@@ -1268,10 +1266,9 @@ impl Db {
             client_message_id,
             None,
             "platform",
-            serde_json::json!({
-                "event": "message.created",
-                "role": role,
-                "text": content,
+            platform_payload(PlatformEvent::MessageCreated {
+                role: role.to_string(),
+                text: content.to_string(),
             }),
         )
         .await?;
@@ -1308,7 +1305,7 @@ impl Db {
                 Some("platform.status.queued"),
                 None,
                 "platform",
-                serde_json::json!({ "event": "run.status", "status": RunStatus::Queued.as_str() }),
+                run_status_payload(RunStatus::Queued, None),
             )
             .await?;
         }
@@ -1624,12 +1621,11 @@ impl Db {
             0,
             Some(&format!("approval.{}", req.request_key)),
             "platform",
-            serde_json::json!({
-                "event": "approval.created",
-                "approvalId": id,
-                "status": status.as_str(),
-                "decision": decision.map(|d| d.as_str()),
-                "kind": req.kind.as_str(),
+            platform_payload(PlatformEvent::ApprovalCreated {
+                approval_id: id,
+                status,
+                decision,
+                kind: req.kind,
             }),
         )
         .await?;
@@ -1748,10 +1744,9 @@ impl Db {
             0,
             Some(&format!("approval.decided.{}", existing.request_key)),
             "platform",
-            serde_json::json!({
-                "event": "approval.decided",
-                "approvalId": approval_id,
-                "decision": decision.as_str(),
+            platform_payload(PlatformEvent::ApprovalDecided {
+                approval_id,
+                decision,
             }),
         )
         .await?;
@@ -2049,3 +2044,11 @@ pub(crate) fn map_approval_full_row(
 const RUN_COLUMNS: &str = "id, organization_id, repository_id, requested_by, status, status_version,
     title, prompt, base_ref, base_sha, head_branch, head_sha, model, permission_mode, max_turns,
     created_at, started_at, finished_at, archived_at";
+
+fn platform_payload(event: PlatformEvent) -> serde_json::Value {
+    serde_json::to_value(event).unwrap_or_else(|_| serde_json::json!({}))
+}
+
+fn run_status_payload(status: RunStatus, head_sha: Option<String>) -> serde_json::Value {
+    platform_payload(PlatformEvent::RunStatusChanged { status, head_sha })
+}

--- a/cloud/crates/db/tests/smoke.rs
+++ b/cloud/crates/db/tests/smoke.rs
@@ -271,10 +271,11 @@ async fn run_state_mutations_have_matching_events() {
     assert!(updated.archived_at.is_some());
 
     let updated = db
-        .update_run_status(run.id, RunStatus::Completed, None, None)
+        .update_run_status(run.id, RunStatus::Completed, Some("abc123".into()), None)
         .await
         .unwrap();
     assert_eq!(updated.status, RunStatus::Completed);
+    assert_eq!(updated.head_sha.as_deref(), Some("abc123"));
     assert!(updated.finished_at.is_some());
 
     let message = db
@@ -292,7 +293,9 @@ async fn run_state_mutations_have_matching_events() {
         event.payload["event"] == "message.created" && event.payload["text"] == "follow-up"
     }));
     assert!(events.iter().any(|event| {
-        event.payload["event"] == "run.status" && event.payload["status"] == "completed"
+        event.payload["event"] == "run.status"
+            && event.payload["status"] == "completed"
+            && event.payload["headSha"] == "abc123"
     }));
     assert!(events.iter().any(|event| {
         event.payload["event"] == "run.status" && event.payload["status"] == "queued"

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -324,6 +324,40 @@ pub struct ApprovalEventPayload {
     pub raw_input: Option<serde_json::Value>,
 }
 
+/// Product payload stored on `event_type = "platform"` rows.
+/// Wire JSON keeps the `event` discriminator and camelCase fields.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "event", rename_all_fields = "camelCase")]
+pub enum PlatformEvent {
+    #[serde(rename = "run.created")]
+    RunCreated { title: String, prompt: String },
+    #[serde(rename = "run.title")]
+    RunTitle { title: String },
+    #[serde(rename = "run.archived")]
+    RunArchived,
+    #[serde(rename = "run.status")]
+    RunStatusChanged {
+        status: RunStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        head_sha: Option<String>,
+    },
+    #[serde(rename = "message.created")]
+    MessageCreated { role: String, text: String },
+    #[serde(rename = "approval.created")]
+    ApprovalCreated {
+        approval_id: Id,
+        status: ApprovalStatus,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        decision: Option<ApprovalDecision>,
+        kind: ApprovalKind,
+    },
+    #[serde(rename = "approval.decided")]
+    ApprovalDecided {
+        approval_id: Id,
+        decision: ApprovalDecision,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RunEvent {
@@ -489,9 +523,10 @@ pub struct WorkerEventRequest {
 #[cfg(test)]
 mod tests {
     use super::{
-        ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, CloudEventKind,
-        CreateApprovalRequest, TextEventPayload, ToolCallPayload, WorkerCommand,
-        WorkerCommandAckRequest, WorkerCommandKind, WorkerEventRequest, WorkerFence,
+        ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, ApprovalStatus,
+        CloudEventKind, CreateApprovalRequest, PlatformEvent, RunStatus, TextEventPayload,
+        ToolCallPayload, WorkerCommand, WorkerCommandAckRequest, WorkerCommandKind,
+        WorkerEventRequest, WorkerFence,
     };
 
     #[test]
@@ -669,6 +704,37 @@ mod tests {
                 "title": "Write",
                 "kind": "edit",
                 "rawInput": { "path": "notes.md" }
+            })
+        );
+        let encoded = serde_json::to_value(PlatformEvent::RunStatusChanged {
+            status: RunStatus::Completed,
+            head_sha: Some("abc123".into()),
+        })
+        .expect("status");
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "event": "run.status",
+                "status": "completed",
+                "headSha": "abc123"
+            })
+        );
+        let encoded = serde_json::to_value(PlatformEvent::RunArchived).expect("archived");
+        assert_eq!(encoded, serde_json::json!({ "event": "run.archived" }));
+        let encoded = serde_json::to_value(PlatformEvent::ApprovalCreated {
+            approval_id: uuid::Uuid::nil(),
+            status: ApprovalStatus::Pending,
+            decision: None,
+            kind: ApprovalKind::Tool,
+        })
+        .expect("approval created");
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "event": "approval.created",
+                "approvalId": uuid::Uuid::nil(),
+                "status": "pending",
+                "kind": "tool"
             })
         );
     }

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `2a7ff47`（PR #81 已合并）。**
+> **进度快照：2026-08-13，基线 `cca7502`（PR #83 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是审批 `allowed_decisions` 与分类事件 payload 类型化；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是平台事件 payload 类型化；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -953,7 +953,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 3. **模型抽象仍偏 provider**：`ModelExecutor` 吃 `ChatRequest`；Subagent 另有 `ChatBackend`。目标是 Turn 只看见 `PreparedContext` → `ModelRequest`。
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
 5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision` / `ApprovalKind` / `ApprovalRisk`。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
-6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection 等不进时间线。未识别帧仍为 `acp`。
+6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段。平台事件 payload 是 domain `PlatformEvent`。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection 等不进时间线。未识别帧仍为 `acp`。
 7. **JobRunner 只看见 RuntimeClient 产品类型（Wave 16）**：mock 与真实 ACP 共用 event pump、command poller 与 idle hold；`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeRequest::Approval` 携带 `ApprovalKind` 与 `allowed_decisions`（来自 ACP `optionId`）。分类事件 payload 是 domain 结构体。ACP `MockMsg` / `optionId` 只留在 adapter。
 8. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
@@ -1059,8 +1059,9 @@ Wave 16  统一 transport command/event  ← 当前工作
          Console 时间线按 event_type 消费产品字段（含 user_message）
          JobRunner mock 路径走 RuntimeClient 产品类型
          JobRunner mock/real 共用 runtime session（command + hold）
-         RuntimeRequest::Approval.allowed_decisions 来自 ACP options（本轮）
-         分类事件 payload 使用 domain 结构体（本轮）
+         RuntimeRequest::Approval.allowed_decisions 来自 ACP options
+         分类事件 payload 使用 domain 结构体
+         平台事件 payload 使用 domain 结构体（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1085,13 +1086,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | 审批 allowed_decisions 与分类 payload 类型化；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | 平台事件 payload 类型化；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1190,7 +1191,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - Console 按 `event_type` 分发时间线：`text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result` 直接渲染产品字段，legacy `params.update` 仍可回放。plan/usage/projection/session_started/approval_requested 不进时间线。
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
    - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
-   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；审批请求携带 `ApprovalKind` 与 `allowed_decisions`（ACP `optionId` 在 adapter 内映射）。分类事件 payload 是 domain 结构体；审批表 payload 同样序列化 `ApprovalEventPayload`。ACP `MockMsg` 与 `optionId` 只留在 adapter。
+   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；审批请求携带 `ApprovalKind` 与 `allowed_decisions`（ACP `optionId` 在 adapter 内映射）。分类事件 payload 是 domain 结构体；审批表 payload 同样序列化 `ApprovalEventPayload`。平台事件 payload 是 domain `PlatformEvent`。ACP `MockMsg` 与 `optionId` 只留在 adapter。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1216,10 +1217,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | 审批 options 与分类 payload 已类型化；Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | 分类/平台 payload 已类型化；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**审批 options 与分类 payload 已类型化**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
+推荐组合：**分类与平台 payload 已类型化**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1355,4 +1356,11 @@ Wave 16  统一 transport command/event  ← 当前工作
 - `ApprovalKind`（`permission` / `tool`）与 `ApprovalRisk`（`low` / `medium` / `high`）同样是产品枚举。
 - Console 用同一套 wire 字符串类型，审批卡片布局不变。
 - 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
+
+### 2026-08-13 — Cloud 平台事件 payload
+
+- domain `PlatformEvent` 覆盖 DB 写入的 `platform` 行：`run.created` / `run.title` / `run.archived` / `run.status` / `message.created` / `approval.created` / `approval.decided`。
+- `run.status` 在传入 `head_sha` 时写入 `headSha`（Console 已读该字段）。
+- Console 按 `event` 分发平台 payload；审批卡消费 `ApprovalEventPayload` 产品字段，legacy ACP 信封仍 JSON。
+- 不迁移已存记录。不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #83 把分类 runtime payload 收成 domain 结构体，平台行仍在 DB 里手拼 JSON。本 PR 把 **platform 事件 payload** 收成产品类型。

DB 写入 `run.created` / `run.title` / `run.archived` / `run.status` / `message.created` / `approval.created` / `approval.decided` 都序列化 `PlatformEvent`。`run.status` 在传入 `head_sha` 时带上 `headSha`（Console 本来就读这个字段）。Console 按 `event` 分发平台 payload；审批卡消费 `ApprovalEventPayload` 产品字段，旧 ACP 信封仍走 JSON。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不改 Console 布局。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-db --locked` 与 `cd cloud/apps/web && npm run typecheck` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

