### PR TITLE
feat: 存库 event_type 使用 RunEventKind

### DIFF
--- a/cloud/apps/api/src/routes.rs
+++ b/cloud/apps/api/src/routes.rs
@@ -1202,7 +1202,7 @@ async fn worker_event(
                 &fence,
                 Some(&req.source_event_id),
                 req.cursor,
-                &req.event_type,
+                req.event_type,
                 req.payload,
             )
             .await?,
@@ -1441,7 +1441,7 @@ mod reconnect_replay_tests {
     use zene_cloud_db::Db;
     use zene_cloud_domain::{
         AuthResponse, ClaimedRun, CreateRepositoryRequest, CreateRunRequest, RegisterRequest,
-        Repository, Run, RunEvent, RunStatus, UpdateLlmSettingsRequest, WorkerEventRequest,
+        Repository, Run, RunEvent, RunEventKind, RunStatus, UpdateLlmSettingsRequest, WorkerEventRequest,
         WorkerFence, WorkerTitleRequest,
     };
     use zene_cloud_github::{GithubClient, GithubConfig};
@@ -1487,7 +1487,7 @@ mod reconnect_replay_tests {
                 Json(WorkerEventRequest {
                     source_event_id: source_event_id.into(),
                     cursor: Some(cursor),
-                    event_type: "runtime".into(),
+                    event_type: RunEventKind::Runtime,
                     payload: json!({ "marker": marker }),
                     fence: Some(fence),
                 }),

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -64,7 +64,7 @@ export interface RunMessage {
   createdAt: string;
 }
 
-/** Classified product kinds written by RuntimeClient. `platform` / legacy `runtime` stay outside this union. */
+/** Classified product kinds written by RuntimeClient. */
 export type CloudEventKind =
   | "text_delta"
   | "thought_delta"
@@ -80,6 +80,7 @@ export type CloudEventKind =
   | "approval_requested"
   | "acp";
 
+/** Stored `event_type` written by Cloud. Matches domain `RunEventKind`. */
 export type RunEventType = CloudEventKind | "platform" | "runtime";
 
 export interface AcpSessionUpdate {

--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -1226,7 +1226,7 @@ fn event_to_req(event: RuntimeNotification) -> WorkerEventRequest {
     WorkerEventRequest {
         source_event_id: event.source_event_id,
         cursor: event.cursor,
-        event_type: event.event_type.as_event_type().to_string(),
+        event_type: event.event_type.into(),
         payload: event.payload,
         fence: None,
     }
@@ -1637,7 +1637,7 @@ mod title_tests {
     use serde_json::json;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use uuid::Uuid;
-    use zene_cloud_domain::{WorkerEventRequest, WorkerFence};
+    use zene_cloud_domain::{RunEventKind, WorkerEventRequest, WorkerFence};
 
     #[test]
     fn completions_url_appends_path() {
@@ -1710,7 +1710,7 @@ mod title_tests {
         WorkerEventRequest {
             source_event_id: source_event_id.into(),
             cursor: Some(7),
-            event_type: "acp".into(),
+            event_type: RunEventKind::Acp,
             payload: json!({"ok": true}),
             fence: None,
         }
@@ -1985,7 +1985,7 @@ mod title_tests {
         let first_event = WorkerEventRequest {
             source_event_id: "real-provider-event-1".into(),
             cursor: Some(21),
-            event_type: "runtime".into(),
+            event_type: RunEventKind::Runtime,
             payload: json!({"marker": "first"}),
             fence: None,
         };
@@ -2029,7 +2029,7 @@ mod title_tests {
         let second_event = WorkerEventRequest {
             source_event_id: "real-provider-event-2".into(),
             cursor: Some(22),
-            event_type: "runtime".into(),
+            event_type: RunEventKind::Runtime,
             payload: json!({"marker": "second"}),
             fence: None,
         };

--- a/cloud/crates/db/src/lib.rs
+++ b/cloud/crates/db/src/lib.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 use zene_cloud_domain::{
     ApprovalDecision, ApprovalKind, ApprovalRequest, ApprovalRisk, ApprovalStatus, AuthResponse,
     CloneAuthResponse, CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest, LoginRequest, Organization,
-    PlatformEvent, QueueActive, QueueHold, QueueStats, RegisterRequest, Repository, Run, RunEvent, RunMessage,
+    PlatformEvent, QueueActive, QueueHold, QueueStats, RegisterRequest, Repository, Run, RunEvent, RunEventKind, RunMessage,
     RunStatus, User, WorkerCommand, WorkerFence,
 };
 
@@ -475,7 +475,7 @@ impl Db {
             0,
             Some("platform.run.created"),
             None,
-            "platform",
+            RunEventKind::Platform,
             platform_payload(PlatformEvent::RunCreated {
                 title: run.title.clone(),
                 prompt: run.prompt.clone(),
@@ -608,7 +608,7 @@ impl Db {
                 fence.map_or(0, |fence| fence.generation),
                 title_event_id.as_deref().or(Some("platform.run.title")), 
                 None,
-                "platform",
+                RunEventKind::Platform,
                 platform_payload(PlatformEvent::RunTitle {
                     title: updated.title.clone(),
                 }),
@@ -622,7 +622,7 @@ impl Db {
                 0,
                 Some("platform.run.archived"),
                 None,
-                "platform",
+                RunEventKind::Platform,
                 platform_payload(PlatformEvent::RunArchived),
             )
             .await?;
@@ -857,7 +857,7 @@ impl Db {
             fence.generation,
             Some(&format!("platform.status.{}", status.as_str())),
             None,
-            "platform",
+            RunEventKind::Platform,
             run_status_payload(status, head_sha),
         )
         .await?;
@@ -910,7 +910,7 @@ impl Db {
             0,
             Some(&format!("platform.status.{}", status.as_str())),
             None,
-            "platform",
+            RunEventKind::Platform,
             run_status_payload(status, head_sha),
         )
         .await?;
@@ -1039,7 +1039,7 @@ impl Db {
         run_id: Uuid,
         fence: &WorkerFence,
         source_event_id: Option<&str>,
-        event_type: &str,
+        event_type: RunEventKind,
         payload: serde_json::Value,
     ) -> Result<RunEvent> {
         let mut tx = self.pool.begin().await?;
@@ -1056,7 +1056,7 @@ impl Db {
         run_id: Uuid,
         attempt_generation: i64,
         source_event_id: Option<&str>,
-        event_type: &str,
+        event_type: RunEventKind,
         payload: serde_json::Value,
     ) -> Result<RunEvent> {
         let mut tx = self.pool.begin().await?;
@@ -1073,7 +1073,7 @@ impl Db {
         fence: &WorkerFence,
         source_event_id: Option<&str>,
         cursor: Option<u64>,
-        event_type: &str,
+        event_type: RunEventKind,
         payload: serde_json::Value,
     ) -> Result<RunEvent> {
         let mut tx = self.pool.begin().await?;
@@ -1092,7 +1092,7 @@ impl Db {
         attempt_generation: i64,
         source_event_id: Option<&str>,
         cursor: Option<u64>,
-        event_type: &str,
+        event_type: RunEventKind,
         payload: serde_json::Value,
     ) -> Result<RunEvent> {
         let next: (i64,) =
@@ -1132,7 +1132,7 @@ impl Db {
         .bind(attempt_generation)
         .bind(source_event_id)
         .bind(cursor.map(|value| value as i64))
-        .bind(event_type)
+        .bind(event_type.as_event_type())
         .bind(payload.to_string())
         .bind(now.to_rfc3339())
         .execute(&mut **tx)
@@ -1141,7 +1141,7 @@ impl Db {
             run_id,
             seq: next.0,
             cursor,
-            event_type: event_type.into(),
+            event_type: event_type.as_event_type().to_string(),
             payload,
             created_at: now,
         })
@@ -1265,7 +1265,7 @@ impl Db {
             0,
             client_message_id,
             None,
-            "platform",
+            RunEventKind::Platform,
             platform_payload(PlatformEvent::MessageCreated {
                 role: role.to_string(),
                 text: content.to_string(),
@@ -1304,7 +1304,7 @@ impl Db {
                 0,
                 Some("platform.status.queued"),
                 None,
-                "platform",
+                RunEventKind::Platform,
                 run_status_payload(RunStatus::Queued, None),
             )
             .await?;
@@ -1620,7 +1620,7 @@ impl Db {
             run_id,
             0,
             Some(&format!("approval.{}", req.request_key)),
-            "platform",
+            RunEventKind::Platform,
             platform_payload(PlatformEvent::ApprovalCreated {
                 approval_id: id,
                 status,
@@ -1743,7 +1743,7 @@ impl Db {
             existing.run_id,
             0,
             Some(&format!("approval.decided.{}", existing.request_key)),
-            "platform",
+            RunEventKind::Platform,
             platform_payload(PlatformEvent::ApprovalDecided {
                 approval_id,
                 decision,

--- a/cloud/crates/db/tests/smoke.rs
+++ b/cloud/crates/db/tests/smoke.rs
@@ -4,7 +4,7 @@ use zene_cloud_db::Db;
 use zene_cloud_domain::{
     ApprovalDecision, ApprovalKind, ApprovalRisk, ApprovalStatus, CreateApprovalRequest,
     CreateRepositoryRequest, CreateRunRequest,
-    RegisterRequest, RunStatus, WorkerCommandKind, WorkerFence,
+    RegisterRequest, RunEventKind, RunStatus, WorkerCommandKind, WorkerFence,
 };
 
 #[tokio::test]
@@ -82,7 +82,7 @@ async fn register_create_run_and_claim() {
             &fence,
             Some("fenced-event-1"),
             Some(17),
-            "runtime",
+            RunEventKind::Runtime,
             serde_json::json!({"ok": true}),
         )
         .await
@@ -93,7 +93,7 @@ async fn register_create_run_and_claim() {
             run.id,
             &fence,
             Some("platform-event-1"),
-            "platform",
+            RunEventKind::Platform,
             serde_json::json!({"platform": true}),
         )
         .await
@@ -105,7 +105,7 @@ async fn register_create_run_and_claim() {
             &fence,
             Some("fenced-event-1"),
             Some(99),
-            "runtime-retry",
+            RunEventKind::Runtime,
             serde_json::json!({"retry": true}),
         )
         .await
@@ -121,7 +121,7 @@ async fn register_create_run_and_claim() {
         run.id,
         &stale,
         Some("stale-event"),
-        "runtime",
+        RunEventKind::Runtime,
         serde_json::json!({}),
     ).await.unwrap_err().to_string().contains("stale_attempt"));
     assert!(db
@@ -165,7 +165,7 @@ async fn register_create_run_and_claim() {
             &replacement_fence,
             Some("fenced-event-1"),
             Some(99),
-            "runtime-replayed",
+            RunEventKind::Runtime,
             serde_json::json!({"replayed": true}),
         )
         .await
@@ -199,7 +199,7 @@ async fn register_create_run_and_claim() {
             run.id,
             &replacement_fence,
             Some("post-cursor-platform-event"),
-            "platform",
+            RunEventKind::Platform,
             serde_json::json!({"after_cursor": true}),
         )
         .await

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -151,8 +151,9 @@ pub struct UpdateRunRequest {
 }
 
 /// Product `event_type` written by RuntimeClient for classified frames.
-/// Unrecognized ACP frames are `acp`. Platform / legacy `runtime` rows stay
-/// plain strings on `RunEvent`.
+/// Unrecognized ACP frames are `acp`. Platform / legacy `runtime` rows use
+/// [`RunEventKind`]; `RunEvent.event_type` stays a string so unknown historical
+/// values still load.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CloudEventKind {
@@ -207,6 +208,79 @@ impl CloudEventKind {
             "acp" => Self::Acp,
             _ => return None,
         })
+    }
+}
+
+/// Stored `event_type` written by Cloud (runtime client, platform DB rows, and
+/// worker/API). Wire JSON stays snake_case strings. `RunEvent.event_type` remains
+/// a string on read so unknown historical values still load.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunEventKind {
+    TextDelta,
+    ThoughtDelta,
+    UserMessage,
+    ToolCall,
+    ToolResult,
+    StateChanged,
+    UsageUpdate,
+    ProjectionReady,
+    Plan,
+    AvailableCommands,
+    SessionStarted,
+    ApprovalRequested,
+    Acp,
+    Platform,
+    Runtime,
+}
+
+impl From<CloudEventKind> for RunEventKind {
+    fn from(kind: CloudEventKind) -> Self {
+        match kind {
+            CloudEventKind::TextDelta => Self::TextDelta,
+            CloudEventKind::ThoughtDelta => Self::ThoughtDelta,
+            CloudEventKind::UserMessage => Self::UserMessage,
+            CloudEventKind::ToolCall => Self::ToolCall,
+            CloudEventKind::ToolResult => Self::ToolResult,
+            CloudEventKind::StateChanged => Self::StateChanged,
+            CloudEventKind::UsageUpdate => Self::UsageUpdate,
+            CloudEventKind::ProjectionReady => Self::ProjectionReady,
+            CloudEventKind::Plan => Self::Plan,
+            CloudEventKind::AvailableCommands => Self::AvailableCommands,
+            CloudEventKind::SessionStarted => Self::SessionStarted,
+            CloudEventKind::ApprovalRequested => Self::ApprovalRequested,
+            CloudEventKind::Acp => Self::Acp,
+        }
+    }
+}
+
+impl RunEventKind {
+    pub fn as_event_type(self) -> &'static str {
+        match self {
+            Self::Platform => "platform",
+            Self::Runtime => "runtime",
+            Self::TextDelta => CloudEventKind::TextDelta.as_event_type(),
+            Self::ThoughtDelta => CloudEventKind::ThoughtDelta.as_event_type(),
+            Self::UserMessage => CloudEventKind::UserMessage.as_event_type(),
+            Self::ToolCall => CloudEventKind::ToolCall.as_event_type(),
+            Self::ToolResult => CloudEventKind::ToolResult.as_event_type(),
+            Self::StateChanged => CloudEventKind::StateChanged.as_event_type(),
+            Self::UsageUpdate => CloudEventKind::UsageUpdate.as_event_type(),
+            Self::ProjectionReady => CloudEventKind::ProjectionReady.as_event_type(),
+            Self::Plan => CloudEventKind::Plan.as_event_type(),
+            Self::AvailableCommands => CloudEventKind::AvailableCommands.as_event_type(),
+            Self::SessionStarted => CloudEventKind::SessionStarted.as_event_type(),
+            Self::ApprovalRequested => CloudEventKind::ApprovalRequested.as_event_type(),
+            Self::Acp => CloudEventKind::Acp.as_event_type(),
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "platform" => Some(Self::Platform),
+            "runtime" => Some(Self::Runtime),
+            other => CloudEventKind::parse(other).map(Self::from),
+        }
     }
 }
 
@@ -514,7 +588,7 @@ pub struct WorkerEventRequest {
     pub source_event_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cursor: Option<u64>,
-    pub event_type: String,
+    pub event_type: RunEventKind,
     pub payload: serde_json::Value,
     #[serde(flatten)]
     pub fence: Option<WorkerFence>,
@@ -524,9 +598,9 @@ pub struct WorkerEventRequest {
 mod tests {
     use super::{
         ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, ApprovalStatus,
-        CloudEventKind, CreateApprovalRequest, PlatformEvent, RunStatus, TextEventPayload,
-        ToolCallPayload, WorkerCommand, WorkerCommandAckRequest, WorkerCommandKind,
-        WorkerEventRequest, WorkerFence,
+        CloudEventKind, CreateApprovalRequest, PlatformEvent, RunEventKind, RunStatus,
+        TextEventPayload, ToolCallPayload, WorkerCommand, WorkerCommandAckRequest,
+        WorkerCommandKind, WorkerEventRequest, WorkerFence,
     };
 
     #[test]
@@ -553,9 +627,21 @@ mod tests {
         }))
         .expect("legacy event request should deserialize");
         assert_eq!(request.cursor, None);
+        assert_eq!(request.event_type, RunEventKind::Acp);
 
         let encoded = serde_json::to_value(request).expect("event request should serialize");
         assert!(encoded.get("cursor").is_none());
+        assert_eq!(encoded["eventType"], "acp");
+    }
+
+    #[test]
+    fn worker_event_request_rejects_unknown_event_type() {
+        let parsed = serde_json::from_value::<WorkerEventRequest>(serde_json::json!({
+            "sourceEventId": "legacy-event",
+            "eventType": "not-a-kind",
+            "payload": { "ok": true }
+        }));
+        assert!(parsed.is_err());
     }
 
     #[test]
@@ -655,6 +741,15 @@ mod tests {
         }
         assert_eq!(CloudEventKind::parse("platform"), None);
         assert_eq!(CloudEventKind::parse("runtime"), None);
+        assert_eq!(RunEventKind::parse("platform"), Some(RunEventKind::Platform));
+        assert_eq!(RunEventKind::parse("runtime"), Some(RunEventKind::Runtime));
+        assert_eq!(RunEventKind::parse("text_delta"), Some(RunEventKind::TextDelta));
+        assert_eq!(
+            RunEventKind::from(CloudEventKind::ToolCall).as_event_type(),
+            "tool_call"
+        );
+        assert_eq!(serde_json::to_value(RunEventKind::Platform).expect("platform"), serde_json::json!("platform"));
+        assert_eq!(RunEventKind::parse("not-a-kind"), None);
     }
 
     #[test]

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `cca7502`（PR #83 已合并）。**
+> **进度快照：2026-08-13，基线 `f49366e`（PR #84 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是平台事件 payload 类型化；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是存库 `event_type` 类型化；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -953,7 +953,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 3. **模型抽象仍偏 provider**：`ModelExecutor` 吃 `ChatRequest`；Subagent 另有 `ChatBackend`。目标是 Turn 只看见 `PreparedContext` → `ModelRequest`。
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
 5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision` / `ApprovalKind` / `ApprovalRisk`。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
-6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段。平台事件 payload 是 domain `PlatformEvent`。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection 等不进时间线。未识别帧仍为 `acp`。
+6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段。平台事件 payload 是 domain `PlatformEvent`。写入路径 `event_type` 是 `RunEventKind`。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection 等不进时间线。未识别帧仍为 `acp`。
 7. **JobRunner 只看见 RuntimeClient 产品类型（Wave 16）**：mock 与真实 ACP 共用 event pump、command poller 与 idle hold；`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeRequest::Approval` 携带 `ApprovalKind` 与 `allowed_decisions`（来自 ACP `optionId`）。分类事件 payload 是 domain 结构体。ACP `MockMsg` / `optionId` 只留在 adapter。
 8. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
@@ -1061,7 +1061,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          JobRunner mock/real 共用 runtime session（command + hold）
          RuntimeRequest::Approval.allowed_decisions 来自 ACP options
          分类事件 payload 使用 domain 结构体
-         平台事件 payload 使用 domain 结构体（本轮）
+         平台事件 payload 使用 domain 结构体
+         存库 event_type 使用 RunEventKind（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1086,13 +1087,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | 平台事件 payload 类型化；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | 存库 event_type 类型化；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1191,7 +1192,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - Console 按 `event_type` 分发时间线：`text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result` 直接渲染产品字段，legacy `params.update` 仍可回放。plan/usage/projection/session_started/approval_requested 不进时间线。
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
    - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
-   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；审批请求携带 `ApprovalKind` 与 `allowed_decisions`（ACP `optionId` 在 adapter 内映射）。分类事件 payload 是 domain 结构体；审批表 payload 同样序列化 `ApprovalEventPayload`。平台事件 payload 是 domain `PlatformEvent`。ACP `MockMsg` 与 `optionId` 只留在 adapter。
+   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；审批请求携带 `ApprovalKind` 与 `allowed_decisions`（ACP `optionId` 在 adapter 内映射）。分类事件 payload 是 domain 结构体；审批表 payload 同样序列化 `ApprovalEventPayload`。平台事件 payload 是 domain `PlatformEvent`。写入路径 `event_type` 是 `RunEventKind`；`RunEvent` 读出仍为字符串。ACP `MockMsg` 与 `optionId` 只留在 adapter。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1217,10 +1218,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | 分类/平台 payload 已类型化；Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | 分类/平台 payload 与存库 event_type 已类型化；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**分类与平台 payload 已类型化**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
+推荐组合：**分类/平台 payload 与存库 event_type 已类型化**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1363,4 +1364,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 - `run.status` 在传入 `head_sha` 时写入 `headSha`（Console 已读该字段）。
 - Console 按 `event` 分发平台 payload；审批卡消费 `ApprovalEventPayload` 产品字段，legacy ACP 信封仍 JSON。
 - 不迁移已存记录。不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
+
+### 2026-08-13 — Cloud 存库 event_type
+
+- domain `RunEventKind` 覆盖 worker/API 写入与 DB `append_event*`：分类 kind + `platform` + `runtime`。
+- `WorkerEventRequest.event_type` 拒绝未知字符串。`RunEvent.event_type` 读出仍为字符串，不迁移已存记录。
+- Console `RunEventType` 与该枚举对齐。不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #84 把平台 payload 收成 domain 结构体，但写入路径的 `event_type` 仍是自由字符串。本 PR 把 **存库 event_type** 收成产品枚举。

`RunEventKind` 覆盖分类 kind 以及 `platform` / `runtime`。DB `append_event*`、`WorkerEventRequest` 与 JobRunner `event_to_req` 都写这个枚举；未知 worker `eventType` 会被拒绝。`RunEvent.event_type` 读出仍为字符串，不迁移已存记录。Console `RunEventType` 与该枚举对齐。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不改 Console 布局。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-db -p zene-cloud-worker -p zene-cloud-api --locked` 与 `cd cloud/apps/web && npm run typecheck` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

