### PR TITLE
feat: worker 内部控制请求使用 domain 类型

### DIFF
--- a/cloud/apps/api/src/routes.rs
+++ b/cloud/apps/api/src/routes.rs
@@ -16,8 +16,8 @@ use zene_cloud_domain::{
     LlmAuthResponse, LlmSettingsView, LoginRequest, PostMessageRequest, QueueStats, RegisterRequest,
     RunStatus, UpdateGithubProviderConfigRequest, UpdateLlmSettingsRequest, UpdateRunRequest,
     WorkerCommandAckRequest, WorkerCommandsResponse, WorkerEventRequest, WorkerFence,
-    WorkerFenceRequest, WorkerAcpSessionRequest,
-    WorkerPullRequestRequest, WorkerPushRequest, WorkerStatusRequest, WorkerTitleRequest,
+    WorkerSessionRequest, WorkerClaimRequest, WorkerPullRequestRequest, WorkerPushRequest,
+    WorkerStatusRequest, WorkerTitleRequest,
 };
 
 use crate::auth::{AuthUser, WorkerAuth};
@@ -86,7 +86,8 @@ pub fn router(state: AppState) -> Router {
         .route("/internal/v1/runs/claim", post(claim_run))
         .route("/internal/v1/queue/stats", get(queue_stats))
         .route("/internal/v1/runs/{run_id}/heartbeat", post(heartbeat))
-        .route("/internal/v1/runs/{run_id}/acp-session", post(worker_acp_session))
+        .route("/internal/v1/runs/{run_id}/runtime-session", post(worker_runtime_session))
+        .route("/internal/v1/runs/{run_id}/acp-session", post(worker_runtime_session))
         .route("/internal/v1/runs/{run_id}/events", post(worker_event))
         .route("/internal/v1/runs/{run_id}/status", post(worker_status))
         .route("/internal/v1/runs/{run_id}/title", post(worker_title))
@@ -1120,17 +1121,10 @@ async fn user_push(
     Ok(Json(result))
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ClaimRequest {
-    worker_id: String,
-    workspace_root: String,
-}
-
 async fn claim_run(
     State(state): State<AppState>,
     _worker: WorkerAuth,
-    Json(req): Json<ClaimRequest>,
+    Json(req): Json<WorkerClaimRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     let claimed = state
         .db
@@ -1158,29 +1152,24 @@ async fn heartbeat(
     State(state): State<AppState>,
     _worker: WorkerAuth,
     Path(run_id): Path<Uuid>,
-    Json(req): Json<WorkerFenceRequest>,
+    Json(req): Json<WorkerFence>,
 ) -> Result<impl IntoResponse, AppError> {
-    let fence = WorkerFence {
-        attempt_id: req.attempt_id,
-        generation: req.generation,
-        worker_id: req.worker_id,
-    };
-    state.db.heartbeat_fenced(run_id, &fence).await?;
+    state.db.heartbeat_fenced(run_id, &req).await?;
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 
-async fn worker_acp_session(
+async fn worker_runtime_session(
     State(state): State<AppState>,
     _worker: WorkerAuth,
     Path(run_id): Path<Uuid>,
-    Json(req): Json<WorkerAcpSessionRequest>,
+    Json(req): Json<WorkerSessionRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     let fence = req
         .fence
         .ok_or_else(|| AppError::bad_request("worker fence is required"))?;
     state
         .db
-        .set_acp_session_id_fenced(run_id, &fence, &req.session_id)
+        .set_runtime_session_id_fenced(run_id, &fence, &req.session_id)
         .await?;
     Ok(Json(serde_json::json!({ "ok": true })))
 }
@@ -1284,15 +1273,10 @@ async fn worker_commands(
     State(state): State<AppState>,
     _worker: WorkerAuth,
     Path(run_id): Path<Uuid>,
-    Query(req): Query<WorkerFenceRequest>,
+    Query(req): Query<WorkerFence>,
 ) -> Result<impl IntoResponse, AppError> {
-    let fence = WorkerFence {
-        attempt_id: req.attempt_id,
-        generation: req.generation,
-        worker_id: req.worker_id,
-    };
     Ok(Json(WorkerCommandsResponse {
-        commands: state.db.poll_worker_commands_fenced(run_id, &fence).await?,
+        commands: state.db.poll_worker_commands_fenced(run_id, &req).await?,
     }))
 }
 
@@ -1581,7 +1565,7 @@ mod reconnect_replay_tests {
             claim_run(
                 State(state.clone()),
                 WorkerAuth,
-                Json(ClaimRequest {
+                Json(WorkerClaimRequest {
                     worker_id: "worker-1".into(),
                     workspace_root: workspace_root.to_string_lossy().into(),
                 }),
@@ -1636,7 +1620,7 @@ mod reconnect_replay_tests {
             claim_run(
                 State(state.clone()),
                 WorkerAuth,
-                Json(ClaimRequest {
+                Json(WorkerClaimRequest {
                     worker_id: "worker-2".into(),
                     workspace_root: workspace_root.to_string_lossy().into(),
                 }),

--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -22,9 +22,10 @@ use zene_cloud_runtime_client::{
 };
 use zene_cloud_domain::{
     ApprovalDecision, ApprovalKind, ApprovalRequest, ApprovalRisk, ApprovalStatus, ClaimedRun,
-    CloneAuthResponse, CreateApprovalRequest, LlmAuthResponse, RunStatus, WorkerCommand,
-    WorkerCommandAckRequest, WorkerCommandKind, WorkerCommandsResponse, WorkerEventRequest,
-    WorkerFence, WorkerStatusRequest, WorkerTitleRequest, WorkerAcpSessionRequest,
+    CloneAuthResponse, CreateApprovalRequest, LlmAuthResponse, RunStatus, WorkerClaimRequest,
+    WorkerCommand, WorkerCommandAckRequest, WorkerCommandKind, WorkerCommandsResponse,
+    WorkerEventRequest, WorkerFence, WorkerPullRequestRequest, WorkerPushRequest,
+    WorkerSessionRequest, WorkerStatusRequest, WorkerTitleRequest,
 };
 
 #[derive(Debug, Clone, Parser)]
@@ -284,10 +285,10 @@ async fn claim_run(
     let response = client
         .post(format!("{}/internal/v1/runs/claim", cli.api_url))
         .bearer_auth(&cli.worker_token)
-        .json(&serde_json::json!({
-            "workerId": worker_id,
-            "workspaceRoot": cli.workspace_root.display().to_string()
-        }))
+        .json(&WorkerClaimRequest {
+            worker_id: worker_id.to_string(),
+            workspace_root: cli.workspace_root.display().to_string(),
+        })
         .send()
         .await?
         .error_for_status()?;
@@ -321,7 +322,6 @@ async fn execute_run(
         client.clone(),
         cli.api_url.clone(),
         cli.worker_token.clone(),
-        worker_id.to_string(),
         run_id,
         fence.clone(),
     );
@@ -823,7 +823,7 @@ async fn run_runtime_session<R: RuntimeClient + 'static>(
     let run_id = claimed.run.id;
     if persist_session {
         let session_id = runtime.session_id().await?;
-        persist_acp_session(client, cli, run_id, fence, &session_id).await?;
+        persist_runtime_session(client, cli, run_id, fence, &session_id).await?;
     }
     let (pump, event_error) = spawn_event_pump(
         runtime.clone(),
@@ -1156,25 +1156,25 @@ async fn resolve_permission(
     bail!("approval {approval_id} timed out")
 }
 
-async fn persist_acp_session(
+async fn persist_runtime_session(
     client: &reqwest::Client,
     cli: &Cli,
     run_id: Uuid,
     fence: &WorkerFence,
     session_id: &str,
 ) -> Result<()> {
-    let request = WorkerAcpSessionRequest {
+    let request = WorkerSessionRequest {
         session_id: session_id.to_string(),
         fence: Some(fence.clone()),
     };
     client
-        .post(format!("{}/internal/v1/runs/{run_id}/acp-session", cli.api_url))
+        .post(format!("{}/internal/v1/runs/{run_id}/runtime-session", cli.api_url))
         .bearer_auth(&cli.worker_token)
         .json(&request)
         .send()
         .await?
         .error_for_status()
-        .context("persist ACP session")?;
+        .context("persist runtime session")?;
     Ok(())
 }
 
@@ -1236,7 +1236,6 @@ fn heartbeat_loop(
     client: reqwest::Client,
     api_url: String,
     token: String,
-    worker_id: String,
     run_id: Uuid,
     fence: WorkerFence,
 ) -> tokio::task::JoinHandle<()> {
@@ -1245,12 +1244,7 @@ fn heartbeat_loop(
             let _ = client
                 .post(format!("{api_url}/internal/v1/runs/{run_id}/heartbeat"))
                 .bearer_auth(&token)
-                .json(&serde_json::json!({
-                    "workerId": worker_id,
-                    "attemptId": fence.attempt_id,
-                    "generation": fence.generation,
-                    "workspaceRoot": "."
-                }))
+                .json(&fence)
                 .send()
                 .await;
             tokio::time::sleep(Duration::from_secs(20)).await;
@@ -1516,11 +1510,11 @@ async fn post_push(client: &reqwest::Client, cli: &Cli, run_id: Uuid) -> Result<
             cli.api_url
         ))
         .bearer_auth(&cli.worker_token)
-        .json(&serde_json::json!({
-            "force": false,
+        .json(&WorkerPushRequest {
+            force: false,
             // Stable across retries of this run; the broker persists the key.
-            "idempotencyKey": format!("worker-push-{run_id}"),
-        }))
+            idempotency_key: Some(format!("worker-push-{run_id}")),
+        })
         .send()
         .await?
         .error_for_status()?;
@@ -1539,11 +1533,12 @@ async fn post_pull_request(
             cli.api_url
         ))
         .bearer_auth(&cli.worker_token)
-        .json(&serde_json::json!({
-            "title": title,
-            "body": "Created by Zene Cloud worker",
-            "draft": true
-        }))
+        .json(&WorkerPullRequestRequest {
+            title: Some(title.to_string()),
+            body: Some("Created by Zene Cloud worker".into()),
+            draft: true,
+            idempotency_key: None,
+        })
         .send()
         .await?
         .error_for_status()?;
@@ -1874,7 +1869,7 @@ mod title_tests {
         use zene_cloud_db::Db;
         use zene_cloud_domain::{
             CreateRepositoryRequest, CreateRunRequest, RegisterRequest, RunEvent, RunStatus,
-            UpdateLlmSettingsRequest,
+            UpdateLlmSettingsRequest, WorkerClaimRequest,
         };
         use zene_cloud_github::{GithubClient, GithubConfig};
 
@@ -1967,10 +1962,10 @@ mod title_tests {
         let claim: zene_cloud_domain::ClaimedRun = client
             .post(format!("{api_url}/internal/v1/runs/claim"))
             .bearer_auth(worker_token)
-            .json(&serde_json::json!({
-                "workerId": "worker-1",
-                "workspaceRoot": workspace_root,
-            }))
+            .json(&WorkerClaimRequest {
+                worker_id: "worker-1".into(),
+                workspace_root: workspace_root.to_string_lossy().into(),
+            })
             .send()
             .await
             .unwrap()
@@ -2001,10 +1996,10 @@ mod title_tests {
         let replacement: zene_cloud_domain::ClaimedRun = client
             .post(format!("{api_url}/internal/v1/runs/claim"))
             .bearer_auth(worker_token)
-            .json(&serde_json::json!({
-                "workerId": "worker-2",
-                "workspaceRoot": workspace_root,
-            }))
+            .json(&WorkerClaimRequest {
+                worker_id: "worker-2".into(),
+                workspace_root: workspace_root.to_string_lossy().into(),
+            })
             .send()
             .await
             .unwrap()

--- a/cloud/crates/db/src/lib.rs
+++ b/cloud/crates/db/src/lib.rs
@@ -788,7 +788,7 @@ impl Db {
         Ok(Some((run, attempt_id, generation, resume_session_id, workspace_dir)))
     }
 
-    pub async fn set_acp_session_id_fenced(
+    pub async fn set_runtime_session_id_fenced(
         &self,
         run_id: Uuid,
         fence: &WorkerFence,
@@ -807,7 +807,7 @@ impl Db {
         .execute(&self.pool)
         .await?;
         if result.rows_affected() != 1 {
-            bail!("stale_attempt: worker fence rejected ACP session update")
+            bail!("stale_attempt: worker fence rejected runtime session update")
         }
         Ok(())
     }
@@ -1163,7 +1163,7 @@ impl Db {
         match row {
             Some((generation, Some(worker_id), None))
                 if generation == fence.generation && worker_id == fence.worker_id => Ok(()),
-            _ => bail!("stale_attempt: worker fence rejected ACP session update"),
+            _ => bail!("stale_attempt: worker fence rejected runtime session update"),
         }
     }
 

--- a/cloud/crates/db/tests/smoke.rs
+++ b/cloud/crates/db/tests/smoke.rs
@@ -73,7 +73,7 @@ async fn register_create_run_and_claim() {
         worker_id: "worker-1".into(),
     };
     db.heartbeat_fenced(run.id, &fence).await.unwrap();
-    db.set_acp_session_id_fenced(run.id, &fence, "acp-session-1")
+    db.set_runtime_session_id_fenced(run.id, &fence, "runtime-session-1")
         .await
         .unwrap();
     let event = db
@@ -125,7 +125,7 @@ async fn register_create_run_and_claim() {
         serde_json::json!({}),
     ).await.unwrap_err().to_string().contains("stale_attempt"));
     assert!(db
-        .set_acp_session_id_fenced(run.id, &stale, "stale-session")
+        .set_runtime_session_id_fenced(run.id, &stale, "stale-session")
         .await
         .unwrap_err()
         .to_string()
@@ -153,7 +153,7 @@ async fn register_create_run_and_claim() {
         .await
         .unwrap()
         .expect("failed run should be re-claimable after queueing");
-    assert_eq!(reclaimed.3.as_deref(), Some("acp-session-1"));
+    assert_eq!(reclaimed.3.as_deref(), Some("runtime-session-1"));
     let replacement_fence = WorkerFence {
         attempt_id: reclaimed.1,
         generation: reclaimed.2,

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -542,10 +542,17 @@ pub struct ClaimedRun {
     pub run: Run,
     pub attempt_id: Id,
     pub generation: i64,
-    /// Existing ACP session to resume after a worker replacement, if available.
+    /// Existing runtime session to resume after a worker replacement, if available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resume_session_id: Option<String>,
     pub workspace_dir: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkerClaimRequest {
+    pub worker_id: String,
+    pub workspace_root: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -600,7 +607,8 @@ mod tests {
         ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, ApprovalStatus,
         CloudEventKind, CreateApprovalRequest, PlatformEvent, RunEventKind, RunStatus,
         TextEventPayload, ToolCallPayload, WorkerCommand, WorkerCommandAckRequest,
-        WorkerCommandKind, WorkerEventRequest, WorkerFence,
+        WorkerCommandKind, WorkerEventRequest, WorkerFence, WorkerClaimRequest,
+        WorkerPushRequest, WorkerSessionRequest,
     };
 
     #[test]
@@ -616,6 +624,54 @@ mod tests {
         let encoded = serde_json::to_value(request).expect("ack should serialize");
         assert_eq!(encoded["messageId"], uuid::Uuid::nil().to_string());
         assert_eq!(encoded["generation"], 2);
+    }
+
+    #[test]
+    fn worker_claim_and_session_requests_round_trip_camel_case() {
+        let encoded = serde_json::to_value(WorkerClaimRequest {
+            worker_id: "worker-1".into(),
+            workspace_root: "/tmp/ws".into(),
+        })
+        .expect("claim");
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "workerId": "worker-1",
+                "workspaceRoot": "/tmp/ws"
+            })
+        );
+        let encoded = serde_json::to_value(WorkerSessionRequest {
+            session_id: "session-1".into(),
+            fence: Some(WorkerFence {
+                attempt_id: uuid::Uuid::nil(),
+                generation: 1,
+                worker_id: "worker-1".into(),
+            }),
+        })
+        .expect("session");
+        assert_eq!(encoded["sessionId"], "session-1");
+        assert_eq!(encoded["generation"], 1);
+        let parsed: WorkerFence = serde_json::from_value(serde_json::json!({
+            "workerId": "worker-1",
+            "attemptId": uuid::Uuid::nil(),
+            "generation": 1,
+            "workspaceRoot": "."
+        }))
+        .expect("legacy heartbeat extra field should be ignored");
+        assert_eq!(parsed.worker_id, "worker-1");
+        assert_eq!(parsed.generation, 1);
+        let encoded = serde_json::to_value(WorkerPushRequest {
+            force: false,
+            idempotency_key: Some("worker-push-1".into()),
+        })
+        .expect("push");
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "force": false,
+                "idempotencyKey": "worker-push-1"
+            })
+        );
     }
 
     #[test]
@@ -847,15 +903,7 @@ pub struct WorkerStatusRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct WorkerFenceRequest {
-    pub attempt_id: Id,
-    pub generation: i64,
-    pub worker_id: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct WorkerAcpSessionRequest {
+pub struct WorkerSessionRequest {
     pub session_id: String,
     #[serde(flatten)]
     pub fence: Option<WorkerFence>,

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `f49366e`（PR #84 已合并）。**
+> **进度快照：2026-08-13，基线 `7a3fb56`（PR #85 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是存库 `event_type` 类型化；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是 worker 内部控制请求与 runtime session；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -955,7 +955,8 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision` / `ApprovalKind` / `ApprovalRisk`。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
 6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段。平台事件 payload 是 domain `PlatformEvent`。写入路径 `event_type` 是 `RunEventKind`。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection 等不进时间线。未识别帧仍为 `acp`。
 7. **JobRunner 只看见 RuntimeClient 产品类型（Wave 16）**：mock 与真实 ACP 共用 event pump、command poller 与 idle hold；`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeRequest::Approval` 携带 `ApprovalKind` 与 `allowed_decisions`（来自 ACP `optionId`）。分类事件 payload 是 domain 结构体。ACP `MockMsg` / `optionId` 只留在 adapter。
-8. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
+8. **Worker 内部控制已走 domain 类型（Wave 16）**：claim / heartbeat / commands query / runtime session / push / PR 使用 `WorkerClaimRequest`、`WorkerFence`、`WorkerSessionRequest`、`WorkerPushRequest`、`WorkerPullRequestRequest`。产品 runtime session 仍存在 `acp_session_id` 列。CLI ACP transport session 未动。
+9. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
 Conversation event 与 materialized `messages` cache 的双轨可以保留，直到 legacy session 可证明无损迁移。不要为了架构干净上完整 Event Sourcing。
 
@@ -1062,7 +1063,9 @@ Wave 16  统一 transport command/event  ← 当前工作
          RuntimeRequest::Approval.allowed_decisions 来自 ACP options
          分类事件 payload 使用 domain 结构体
          平台事件 payload 使用 domain 结构体
-         存库 event_type 使用 RunEventKind（本轮）
+         存库 event_type 使用 RunEventKind
+         worker 内部控制请求使用 domain 类型（本轮）
+         ACP session 收成产品 runtime session（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1087,13 +1090,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | 存库 event_type 类型化；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | worker 控制请求与 runtime session 已收口；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1192,7 +1195,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - Console 按 `event_type` 分发时间线：`text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result` 直接渲染产品字段，legacy `params.update` 仍可回放。plan/usage/projection/session_started/approval_requested 不进时间线。
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
    - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
-   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；审批请求携带 `ApprovalKind` 与 `allowed_decisions`（ACP `optionId` 在 adapter 内映射）。分类事件 payload 是 domain 结构体；审批表 payload 同样序列化 `ApprovalEventPayload`。平台事件 payload 是 domain `PlatformEvent`。写入路径 `event_type` 是 `RunEventKind`；`RunEvent` 读出仍为字符串。ACP `MockMsg` 与 `optionId` 只留在 adapter。
+   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；审批请求携带 `ApprovalKind` 与 `allowed_decisions`（ACP `optionId` 在 adapter 内映射）。分类事件 payload 是 domain 结构体；审批表 payload 同样序列化 `ApprovalEventPayload`。平台事件 payload 是 domain `PlatformEvent`。写入路径 `event_type` 是 `RunEventKind`；`RunEvent` 读出仍为字符串。worker 内部控制 HTTP（claim / heartbeat / commands / runtime session / push / PR）使用 domain 请求类型；产品 runtime session 仍写入 `acp_session_id` 列。ACP `MockMsg` 与 `optionId` 只留在 adapter。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1218,10 +1221,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | 分类/平台 payload 与存库 event_type 已类型化；Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | worker 控制请求与 runtime session 已收口；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**分类/平台 payload 与存库 event_type 已类型化**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
+推荐组合：**worker 控制请求与 runtime session 已收口**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #85 把存库 `event_type` 收成 `RunEventKind` 之后，worker 内部控制 HTTP 仍在手拼 JSON，ACP session 仍是 transport 名。本 PR 把 **worker 控制请求** 收成 domain 类型，并把 attempt 上的 session 收成产品 runtime session。

claim 用 `WorkerClaimRequest`；heartbeat / commands query 直接用 `WorkerFence`（不再多发被忽略的 `workspaceRoot`）；session persist 用 `WorkerSessionRequest` 打 `/runtime-session`（旧 `/acp-session` 仍指向同一 handler）；push / PR 用已有 `WorkerPushRequest` / `WorkerPullRequestRequest`。DB 方法改名为 `set_runtime_session_id_fenced`，SQL 仍写 `acp_session_id` 列。CLI ACP transport session 未动。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不改 Console 布局。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-db -p zene-cloud-worker -p zene-cloud-api --locked` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

