### PR TITLE
feat: RuntimeClient 产品 payload 保持 domain 结构体

### DIFF
--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -21,11 +21,11 @@ use zene_cloud_runtime_client::{
     RuntimeNotification, RuntimeRequest,
 };
 use zene_cloud_domain::{
-    ApprovalDecision, ApprovalKind, ApprovalRequest, ApprovalRisk, ApprovalStatus, ClaimedRun,
-    CloneAuthResponse, CreateApprovalRequest, LlmAuthResponse, RunStatus, WorkerClaimRequest,
-    WorkerCommand, WorkerCommandAckRequest, WorkerCommandKind, WorkerCommandsResponse,
-    WorkerEventRequest, WorkerFence, WorkerPullRequestRequest, WorkerPushRequest,
-    WorkerSessionRequest, WorkerStatusRequest, WorkerTitleRequest,
+    ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRequest, ApprovalRisk,
+    ApprovalStatus, ClaimedRun, CloneAuthResponse, CreateApprovalRequest, LlmAuthResponse,
+    RunStatus, WorkerClaimRequest, WorkerCommand, WorkerCommandAckRequest, WorkerCommandKind,
+    WorkerCommandsResponse, WorkerEventRequest, WorkerFence, WorkerPullRequestRequest,
+    WorkerPushRequest, WorkerSessionRequest, WorkerStatusRequest, WorkerTitleRequest,
 };
 
 #[derive(Debug, Clone, Parser)]
@@ -1110,13 +1110,13 @@ async fn resolve_permission(
     request_key: &str,
     kind: ApprovalKind,
     allowed_decisions: Vec<ApprovalDecision>,
-    payload: &serde_json::Value,
+    payload: &ApprovalEventPayload,
 ) -> Result<ApprovalDecision> {
     let body = CreateApprovalRequest {
         request_key: request_key.to_string(),
         kind,
         risk: ApprovalRisk::Medium,
-        payload: payload.clone(),
+        payload: serde_json::to_value(payload).unwrap_or(serde_json::json!({})),
         allowed_decisions,
         expires_at: None,
     };
@@ -1227,7 +1227,7 @@ fn event_to_req(event: RuntimeNotification) -> WorkerEventRequest {
         source_event_id: event.source_event_id,
         cursor: event.cursor,
         event_type: event.event_type.into(),
-        payload: event.payload,
+        payload: event.payload.to_value(),
         fence: None,
     }
 }

--- a/cloud/crates/runtime-client/src/lib.rs
+++ b/cloud/crates/runtime-client/src/lib.rs
@@ -75,6 +75,48 @@ pub enum RuntimeCommand {
     Shutdown,
 }
 
+/// In-memory product payload produced by the adapter.
+///
+/// Classified kinds keep domain structs until JobRunner serializes at the
+/// HTTP/DB boundary. Unrecognized frames and extraction fallbacks stay
+/// [`RuntimePayload::Json`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum RuntimePayload {
+    Text(TextEventPayload),
+    ToolCall(ToolCallPayload),
+    ToolResult(ToolResultPayload),
+    State(StateChangedPayload),
+    Usage(UsagePayload),
+    Plan(PlanPayload),
+    Commands(AvailableCommandsPayload),
+    SessionStarted(SessionStartedPayload),
+    ApprovalRequested(ApprovalEventPayload),
+    Json(Value),
+}
+
+impl RuntimePayload {
+    pub fn to_value(&self) -> Value {
+        match self {
+            Self::Text(payload) => to_json(payload),
+            Self::ToolCall(payload) => to_json(payload),
+            Self::ToolResult(payload) => to_json(payload),
+            Self::State(payload) => to_json(payload),
+            Self::Usage(payload) => to_json(payload),
+            Self::Plan(payload) => to_json(payload),
+            Self::Commands(payload) => to_json(payload),
+            Self::SessionStarted(payload) => to_json(payload),
+            Self::ApprovalRequested(payload) => to_json(payload),
+            Self::Json(value) => value.clone(),
+        }
+    }
+}
+
+impl PartialEq<Value> for RuntimePayload {
+    fn eq(&self, other: &Value) -> bool {
+        self.to_value() == *other
+    }
+}
+
 /// A runtime notification with the stable fields persisted by the worker.
 ///
 /// `event_type` is the product kind. Classified kinds store a denormalized
@@ -86,7 +128,7 @@ pub struct RuntimeNotification {
     pub source_event_id: String,
     pub cursor: Option<u64>,
     pub event_type: CloudEventKind,
-    pub payload: Value,
+    pub payload: RuntimePayload,
 }
 
 impl RuntimeNotification {
@@ -113,15 +155,15 @@ pub enum RuntimeRequest {
         request_id: String,
         kind: ApprovalKind,
         allowed_decisions: Vec<ApprovalDecision>,
-        context: Value,
+        context: ApprovalEventPayload,
     },
 }
 
 /// Product payload stored on Cloud approval rows. ACP option lists and
 /// session metadata stay inside the adapter.
-fn approval_payload(params: &Value) -> Value {
+fn approval_payload(params: &Value) -> ApprovalEventPayload {
     let tool = params.get("toolCall").unwrap_or(&Value::Null);
-    to_json(ApprovalEventPayload {
+    ApprovalEventPayload {
         request_id: permission_request_key(params),
         tool_call_id: json_str(tool, "toolCallId"),
         title: json_str(tool, "title"),
@@ -129,7 +171,7 @@ fn approval_payload(params: &Value) -> Value {
         kind: json_str(tool, "kind"),
         status: json_str(tool, "status"),
         raw_input: json_opt(tool, "rawInput"),
-    })
+    }
 }
 
 fn allowed_decisions_from_params(params: &Value) -> Vec<ApprovalDecision> {
@@ -179,29 +221,29 @@ fn runtime_notification(event: AcpEvent) -> RuntimeNotification {
     }
 }
 
-fn product_payload(kind: CloudEventKind, raw: &Value) -> Value {
+fn product_payload(kind: CloudEventKind, raw: &Value) -> RuntimePayload {
     match kind {
         CloudEventKind::TextDelta
         | CloudEventKind::ThoughtDelta
         | CloudEventKind::UserMessage => {
             let Some(update) = raw.pointer("/params/update") else {
-                return raw.clone();
+                return RuntimePayload::Json(raw.clone());
             };
-            to_json(TextEventPayload {
+            RuntimePayload::Text(TextEventPayload {
                 text: text_from_update(update),
             })
         }
         CloudEventKind::ToolCall => {
             let Some(update) = raw.pointer("/params/update") else {
-                return raw.clone();
+                return RuntimePayload::Json(raw.clone());
             };
-            to_json(tool_call_payload(update))
+            RuntimePayload::ToolCall(tool_call_payload(update))
         }
         CloudEventKind::ToolResult => {
             let Some(update) = raw.pointer("/params/update") else {
-                return raw.clone();
+                return RuntimePayload::Json(raw.clone());
             };
-            to_json(tool_result_payload(update))
+            RuntimePayload::ToolResult(tool_result_payload(update))
         }
         CloudEventKind::ApprovalRequested => approval_product(raw),
         CloudEventKind::SessionStarted => session_started_product(raw),
@@ -210,7 +252,7 @@ fn product_payload(kind: CloudEventKind, raw: &Value) -> Value {
         CloudEventKind::ProjectionReady => projection_product(raw),
         CloudEventKind::Plan => plan_product(raw),
         CloudEventKind::AvailableCommands => commands_product(raw),
-        _ => raw.clone(),
+        _ => RuntimePayload::Json(raw.clone()),
     }
 }
 
@@ -251,11 +293,11 @@ fn tool_result_payload(update: &Value) -> ToolResultPayload {
     }
 }
 
-fn approval_product(raw: &Value) -> Value {
-    approval_payload(raw.get("params").unwrap_or(raw))
+fn approval_product(raw: &Value) -> RuntimePayload {
+    RuntimePayload::ApprovalRequested(approval_payload(raw.get("params").unwrap_or(raw)))
 }
 
-fn session_started_product(raw: &Value) -> Value {
+fn session_started_product(raw: &Value) -> RuntimePayload {
     let session_id = raw
         .pointer("/result/sessionId")
         .or_else(|| raw.pointer("/params/sessionId"))
@@ -268,23 +310,23 @@ fn session_started_product(raw: &Value) -> Value {
         resumed,
     };
     if payload.session_id.is_none() && payload.resumed.is_none() {
-        return raw.clone();
+        return RuntimePayload::Json(raw.clone());
     }
-    to_json(payload)
+    RuntimePayload::SessionStarted(payload)
 }
 
-fn state_product(raw: &Value) -> Value {
+fn state_product(raw: &Value) -> RuntimePayload {
     let Some(update) = raw.pointer("/params/update") else {
-        return raw.clone();
+        return RuntimePayload::Json(raw.clone());
     };
-    to_json(StateChangedPayload {
+    RuntimePayload::State(StateChangedPayload {
         state: json_opt(update, "modeId"),
     })
 }
 
-fn usage_product(raw: &Value) -> Value {
+fn usage_product(raw: &Value) -> RuntimePayload {
     let Some(update) = raw.pointer("/params/update") else {
-        return raw.clone();
+        return RuntimePayload::Json(raw.clone());
     };
     let mut payload = UsagePayload {
         used: json_opt(update, "used"),
@@ -298,33 +340,33 @@ fn usage_product(raw: &Value) -> Value {
         payload.context_epoch = json_opt(meta, "contextEpoch");
         payload.cached_tokens = json_opt(meta, "cachedTokens");
     }
-    to_json(payload)
+    RuntimePayload::Usage(payload)
 }
 
-fn projection_product(raw: &Value) -> Value {
+fn projection_product(raw: &Value) -> RuntimePayload {
     let Some(update) = raw.pointer("/params/update") else {
-        return raw.clone();
+        return RuntimePayload::Json(raw.clone());
     };
-    match update.get("_meta") {
+    RuntimePayload::Json(match update.get("_meta") {
         Some(meta) if meta.is_object() => meta.clone(),
         _ => serde_json::json!({}),
-    }
+    })
 }
 
-fn plan_product(raw: &Value) -> Value {
+fn plan_product(raw: &Value) -> RuntimePayload {
     let Some(update) = raw.pointer("/params/update") else {
-        return raw.clone();
+        return RuntimePayload::Json(raw.clone());
     };
-    to_json(PlanPayload {
+    RuntimePayload::Plan(PlanPayload {
         entries: json_opt(update, "entries"),
     })
 }
 
-fn commands_product(raw: &Value) -> Value {
+fn commands_product(raw: &Value) -> RuntimePayload {
     let Some(update) = raw.pointer("/params/update") else {
-        return raw.clone();
+        return RuntimePayload::Json(raw.clone());
     };
-    to_json(AvailableCommandsPayload {
+    RuntimePayload::Commands(AvailableCommandsPayload {
         available_commands: json_opt(update, "availableCommands"),
     })
 }
@@ -554,7 +596,10 @@ impl MockRuntimeClient {
                 source_event_id: format!("mock-session-{session_id}"),
                 cursor: None,
                 event_type: CloudEventKind::SessionStarted,
-                payload: serde_json::json!({ "sessionId": session_id }),
+                payload: RuntimePayload::SessionStarted(SessionStartedPayload {
+                    session_id: Some(session_id.clone()),
+                    resumed: None,
+                }),
             },
         });
         tokio::spawn(async move {
@@ -575,9 +620,7 @@ impl MockRuntimeClient {
                             &params,
                         ));
                         let mut context = approval_payload(&params);
-                        if let Some(map) = context.as_object_mut() {
-                            map.insert("requestId".into(), Value::String(request_key.clone()));
-                        }
+                        context.request_id = request_key.clone();
                         RuntimeEvent::Request {
                             request: RuntimeRequest::Approval {
                                 request_id: request_key,
@@ -655,6 +698,10 @@ impl RuntimeClient for MockRuntimeClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn json(event: &RuntimeNotification) -> Value {
+        event.payload.to_value()
+    }
 
     #[test]
     fn permission_request_is_normalized_without_exposing_method_paths() {
@@ -798,13 +845,13 @@ mod tests {
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
         assert_eq!(event.event_type.as_event_type(), "tool_result");
-        assert_eq!(event.payload["toolCallId"], "call-1");
-        assert_eq!(event.payload["status"], "completed");
-        assert_eq!(event.payload["text"], "ok");
-        assert_eq!(event.payload["isError"], false);
-        assert_eq!(event.payload["rawOutput"]["text"], "ok");
-        assert!(event.payload.get("sessionUpdate").is_none());
-        assert!(event.payload.get("method").is_none());
+        assert_eq!(json(&event)["toolCallId"], "call-1");
+        assert_eq!(json(&event)["status"], "completed");
+        assert_eq!(json(&event)["text"], "ok");
+        assert_eq!(json(&event)["isError"], false);
+        assert_eq!(json(&event)["rawOutput"]["text"], "ok");
+        assert!(json(&event).get("sessionUpdate").is_none());
+        assert!(json(&event).get("method").is_none());
     }
 
     #[test]
@@ -837,8 +884,8 @@ mod tests {
         let event = runtime_notification(AcpEvent::from_notification(&raw));
         assert_eq!(event.event_type.as_event_type(), "state_changed");
         assert_eq!(event.payload, serde_json::json!({ "state": "plan" }));
-        assert!(event.payload.get("modeId").is_none());
-        assert!(event.payload.get("sessionUpdate").is_none());
+        assert!(json(&event).get("modeId").is_none());
+        assert!(json(&event).get("sessionUpdate").is_none());
     }
 
     #[test]
@@ -876,8 +923,8 @@ mod tests {
                 "cachedTokens": 40
             })
         );
-        assert!(event.payload.get("_meta").is_none());
-        assert!(event.payload.get("method").is_none());
+        assert!(json(&event).get("_meta").is_none());
+        assert!(json(&event).get("method").is_none());
     }
 
     #[test]
@@ -909,8 +956,8 @@ mod tests {
                 "contextEpoch": 2
             })
         );
-        assert!(event.payload.get("sessionUpdate").is_none());
-        assert!(event.payload.get("method").is_none());
+        assert!(json(&event).get("sessionUpdate").is_none());
+        assert!(json(&event).get("method").is_none());
     }
 
     #[test]
@@ -1031,9 +1078,9 @@ mod tests {
                 "rawInput": { "path": "notes.md" }
             })
         );
-        assert!(event.payload.get("method").is_none());
-        assert!(event.payload.get("jsonrpc").is_none());
-        assert!(event.payload.get("id").is_none());
+        assert!(json(&event).get("method").is_none());
+        assert!(json(&event).get("jsonrpc").is_none());
+        assert!(json(&event).get("id").is_none());
     }
 
     #[test]
@@ -1058,12 +1105,16 @@ mod tests {
             })
                 if request_id == "call-7"
                     && allowed_decisions == vec![ApprovalDecision::AllowOnce]
-                    && context == serde_json::json!({
-                        "requestId": "call-7",
-                        "toolCallId": "call-7",
-                        "title": "Write notes",
-                        "kind": "edit"
-                    })
+                    && context
+                        == ApprovalEventPayload {
+                            request_id: "call-7".into(),
+                            tool_call_id: Some("call-7".into()),
+                            title: Some("Write notes".into()),
+                            tool_name: None,
+                            kind: Some("edit".into()),
+                            status: None,
+                            raw_input: None,
+                        }
         ));
     }
 
@@ -1172,7 +1223,7 @@ mod tests {
                             allowed_decisions,
                             vec![ApprovalDecision::AllowOnce, ApprovalDecision::Deny]
                         );
-                        assert_eq!(context["toolCallId"], "tool_write_notes");
+                        assert_eq!(context.tool_call_id.as_deref(), Some("tool_write_notes"));
                         pump.send(RuntimeCommand::Approval {
                             request_id,
                             decision: ApprovalDecision::AllowOnce,

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `7a3fb56`（PR #85 已合并）。**
+> **进度快照：2026-08-13，基线 `3caed53`（PR #86 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是 worker 内部控制请求与 runtime session；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是 RuntimeClient 产品 payload 保持 domain 结构体直到 HTTP/DB 边界；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -954,7 +954,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
 5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision` / `ApprovalKind` / `ApprovalRisk`。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
 6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段。平台事件 payload 是 domain `PlatformEvent`。写入路径 `event_type` 是 `RunEventKind`。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection 等不进时间线。未识别帧仍为 `acp`。
-7. **JobRunner 只看见 RuntimeClient 产品类型（Wave 16）**：mock 与真实 ACP 共用 event pump、command poller 与 idle hold；`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeRequest::Approval` 携带 `ApprovalKind` 与 `allowed_decisions`（来自 ACP `optionId`）。分类事件 payload 是 domain 结构体。ACP `MockMsg` / `optionId` 只留在 adapter。
+7. **JobRunner 只看见 RuntimeClient 产品类型（Wave 16）**：mock 与真实 ACP 共用 event pump、command poller 与 idle hold；`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeNotification.payload` 是 `RuntimePayload`；`RuntimeRequest::Approval` 携带 `ApprovalKind`、`allowed_decisions` 与 `ApprovalEventPayload`。ACP `MockMsg` / `optionId` 只留在 adapter。
 8. **Worker 内部控制已走 domain 类型（Wave 16）**：claim / heartbeat / commands query / runtime session / push / PR 使用 `WorkerClaimRequest`、`WorkerFence`、`WorkerSessionRequest`、`WorkerPushRequest`、`WorkerPullRequestRequest`。产品 runtime session 仍存在 `acp_session_id` 列。CLI ACP transport session 未动。
 9. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
@@ -1064,8 +1064,9 @@ Wave 16  统一 transport command/event  ← 当前工作
          分类事件 payload 使用 domain 结构体
          平台事件 payload 使用 domain 结构体
          存库 event_type 使用 RunEventKind
-         worker 内部控制请求使用 domain 类型（本轮）
-         ACP session 收成产品 runtime session（本轮）
+         worker 内部控制请求使用 domain 类型
+         ACP session 收成产品 runtime session
+         RuntimeClient 产品 payload 保持 domain 结构体直到 HTTP 边界（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1090,13 +1091,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | worker 控制请求与 runtime session 已收口；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | RuntimeClient 产品 payload 已是 domain 结构体；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体，JobRunner 在 HTTP/DB 边界才序列化；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1195,7 +1196,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - Console 按 `event_type` 分发时间线：`text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result` 直接渲染产品字段，legacy `params.update` 仍可回放。plan/usage/projection/session_started/approval_requested 不进时间线。
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
    - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
-   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；审批请求携带 `ApprovalKind` 与 `allowed_decisions`（ACP `optionId` 在 adapter 内映射）。分类事件 payload 是 domain 结构体；审批表 payload 同样序列化 `ApprovalEventPayload`。平台事件 payload 是 domain `PlatformEvent`。写入路径 `event_type` 是 `RunEventKind`；`RunEvent` 读出仍为字符串。worker 内部控制 HTTP（claim / heartbeat / commands / runtime session / push / PR）使用 domain 请求类型；产品 runtime session 仍写入 `acp_session_id` 列。ACP `MockMsg` 与 `optionId` 只留在 adapter。
+   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeNotification.payload` 是 `RuntimePayload`（分类 kind 持有 domain 结构体，未识别/提取失败为 `Json`）。审批请求 `context` 是 `ApprovalEventPayload`。JobRunner 在写 `WorkerEventRequest` / `CreateApprovalRequest` 时才序列化 JSON。`RunEvent` 读出仍为字符串 payload。worker 内部控制 HTTP 使用 domain 请求类型；产品 runtime session 仍写入 `acp_session_id` 列。ACP `MockMsg` 与 `optionId` 只留在 adapter。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1221,10 +1222,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | worker 控制请求与 runtime session 已收口；Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | RuntimeClient 产品 payload 已是 domain 结构体；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**worker 控制请求与 runtime session 已收口**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
+推荐组合：**RuntimeClient 产品 payload 已保持 domain 结构体直到 HTTP 边界**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1373,4 +1374,17 @@ Wave 16  统一 transport command/event  ← 当前工作
 - domain `RunEventKind` 覆盖 worker/API 写入与 DB `append_event*`：分类 kind + `platform` + `runtime`。
 - `WorkerEventRequest.event_type` 拒绝未知字符串。`RunEvent.event_type` 读出仍为字符串，不迁移已存记录。
 - Console `RunEventType` 与该枚举对齐。不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
+
+### 2026-08-13 — worker 内部控制请求
+
+- claim / heartbeat / commands / runtime session / push / PR 使用 domain 请求类型。
+- attempt session persist 收成产品 runtime session；SQL 仍写 `acp_session_id`。
+- 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
+
+### 2026-08-13 — RuntimeClient 产品 payload
+
+- `RuntimeNotification.payload` 是 `RuntimePayload`：分类 kind 持有 domain 结构体，未识别帧与提取失败仍为原始 JSON。
+- `RuntimeRequest::Approval.context` 是 `ApprovalEventPayload`。JobRunner 在 HTTP/DB 边界才序列化。
+- `CreateApprovalRequest.payload` 与 `RunEvent.payload` 读出仍为 JSON，不迁移已存记录。
+- 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #86 把 worker 内部控制 HTTP 收成 domain 类型之后，RuntimeClient 分类结果仍立刻变成 `serde_json::Value`。本 PR 让 **产品 payload 在内存中保持 domain 结构体**，直到 JobRunner 写入 HTTP/DB。

`RuntimeNotification.payload` 改为 `RuntimePayload`：分类 kind 持有 `TextEventPayload` / `ToolCallPayload` 等；未识别帧与提取失败仍为原始 JSON。`RuntimeRequest::Approval.context` 改为 `ApprovalEventPayload`。JobRunner 在 `WorkerEventRequest` / `CreateApprovalRequest` 边界才 `to_value`。`RunEvent` 读出与审批表 JSON 不迁。CLI ACP transport 未动。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不改 Console 布局。

`cd cloud && cargo test -p zene-cloud-runtime-client -p zene-cloud-worker -p zene-cloud-domain --locked` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

