### PR TITLE
feat: 审批写入 payload 使用 ApprovalEventPayload

### DIFF
--- a/cloud/apps/web/lib/approval.ts
+++ b/cloud/apps/web/lib/approval.ts
@@ -1,4 +1,4 @@
-import type { Approval, ApprovalDecision, ApprovalEventPayload } from "@/lib/types";
+import type { Approval, ApprovalDecision } from "@/lib/types";
 
 const ALLOW_ONCE: ApprovalDecision[] = ["allow-once", "allow"];
 const DENY_ONCE: ApprovalDecision[] = ["reject-once", "deny"];
@@ -20,7 +20,7 @@ export function extraDecisions(allowed: ApprovalDecision[]): ApprovalDecision[] 
 export function approvalCardBody(payload: Approval["payload"]): string {
   if (payload == null) return "";
   if (typeof payload !== "object") return String(payload);
-  const product = payload as ApprovalEventPayload & { params?: unknown; method?: unknown };
+  const product = payload;
   if (product.params || product.method) {
     return stringify(payload);
   }

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -222,7 +222,8 @@ export interface Approval {
   kind?: ApprovalKind;
   risk?: ApprovalRisk;
   status?: ApprovalStatus;
-  payload?: unknown;
+  /** Product fields on new rows; legacy ACP envelopes may still include `params` / `method`. */
+  payload?: ApprovalEventPayload & { params?: unknown; method?: unknown };
   allowedDecisions?: ApprovalDecision[];
 }
 

--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -1116,7 +1116,7 @@ async fn resolve_permission(
         request_key: request_key.to_string(),
         kind,
         risk: ApprovalRisk::Medium,
-        payload: serde_json::to_value(payload).unwrap_or(serde_json::json!({})),
+        payload: payload.clone(),
         allowed_decisions,
         expires_at: None,
     };

--- a/cloud/crates/db/src/lib.rs
+++ b/cloud/crates/db/src/lib.rs
@@ -1577,7 +1577,7 @@ impl Db {
             None
         };
         let allowed = serde_json::to_string(&req.allowed_decisions)?;
-        let payload = req.payload.to_string();
+        let payload = serde_json::to_string(&req.payload)?;
 
         let inserted = sqlx::query(
             "INSERT INTO approval_requests

--- a/cloud/crates/db/tests/smoke.rs
+++ b/cloud/crates/db/tests/smoke.rs
@@ -2,9 +2,9 @@ use sqlx::sqlite::SqlitePoolOptions;
 use uuid::Uuid;
 use zene_cloud_db::Db;
 use zene_cloud_domain::{
-    ApprovalDecision, ApprovalKind, ApprovalRisk, ApprovalStatus, CreateApprovalRequest,
-    CreateRepositoryRequest, CreateRunRequest,
-    RegisterRequest, RunEventKind, RunStatus, WorkerCommandKind, WorkerFence,
+    ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, ApprovalStatus,
+    CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest, RegisterRequest,
+    RunEventKind, RunStatus, WorkerCommandKind, WorkerFence,
 };
 
 #[tokio::test]
@@ -349,7 +349,15 @@ fn approval_request(request_key: &str) -> CreateApprovalRequest {
         request_key: request_key.into(),
         kind: ApprovalKind::Permission,
         risk: ApprovalRisk::Medium,
-        payload: serde_json::json!({"path": "notes.txt"}),
+        payload: ApprovalEventPayload {
+            request_id: request_key.into(),
+            tool_call_id: None,
+            title: None,
+            tool_name: None,
+            kind: None,
+            status: None,
+            raw_input: Some(serde_json::json!({"path": "notes.txt"})),
+        },
         allowed_decisions: vec![ApprovalDecision::AllowOnce, ApprovalDecision::Deny],
         expires_at: None,
     }

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -751,13 +751,28 @@ mod tests {
             "requestKey": "permission-1",
             "jsonrpcId": "rpc-1",
             "kind": "permission",
-            "payload": { "path": "notes.txt" }
+            "payload": {
+                "requestId": "permission-1",
+                "rawInput": { "path": "notes.txt" }
+            }
         }))
         .expect("legacy jsonrpcId should be ignored");
         let encoded = serde_json::to_value(&parsed).expect("serialize");
         assert!(encoded.get("jsonrpcId").is_none());
         assert_eq!(encoded["requestKey"], "permission-1");
         assert_eq!(encoded["kind"], "permission");
+        assert_eq!(encoded["payload"]["requestId"], "permission-1");
+        assert_eq!(encoded["payload"]["rawInput"]["path"], "notes.txt");
+    }
+
+    #[test]
+    fn create_approval_request_rejects_non_product_payload() {
+        let parsed = serde_json::from_value::<CreateApprovalRequest>(serde_json::json!({
+            "requestKey": "permission-1",
+            "kind": "permission",
+            "payload": { "path": "notes.txt" }
+        }));
+        assert!(parsed.is_err());
     }
 
     #[test]
@@ -1089,7 +1104,8 @@ pub struct CreateApprovalRequest {
     pub kind: ApprovalKind,
     #[serde(default = "default_risk")]
     pub risk: ApprovalRisk,
-    pub payload: serde_json::Value,
+    /// Product payload written by the worker. Wire JSON stays camelCase.
+    pub payload: ApprovalEventPayload,
     #[serde(default = "default_allowed_decisions")]
     pub allowed_decisions: Vec<ApprovalDecision>,
     #[serde(default)]
@@ -1148,6 +1164,8 @@ pub struct ApprovalRequest {
     pub request_key: String,
     pub kind: ApprovalKind,
     pub risk: ApprovalRisk,
+    /// Stored JSON. New rows are `ApprovalEventPayload`; historical ACP
+    /// envelopes still load as raw values.
     pub payload: serde_json::Value,
     pub status: ApprovalStatus,
     pub allowed_decisions: Vec<ApprovalDecision>,

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `3caed53`（PR #86 已合并）。**
+> **进度快照：2026-08-13，基线 `beb5564`（PR #87 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是 RuntimeClient 产品 payload 保持 domain 结构体直到 HTTP/DB 边界；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是审批写入 payload 使用 `ApprovalEventPayload`；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -954,7 +954,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
 5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision` / `ApprovalKind` / `ApprovalRisk`。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
 6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段。平台事件 payload 是 domain `PlatformEvent`。写入路径 `event_type` 是 `RunEventKind`。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection 等不进时间线。未识别帧仍为 `acp`。
-7. **JobRunner 只看见 RuntimeClient 产品类型（Wave 16）**：mock 与真实 ACP 共用 event pump、command poller 与 idle hold；`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeNotification.payload` 是 `RuntimePayload`；`RuntimeRequest::Approval` 携带 `ApprovalKind`、`allowed_decisions` 与 `ApprovalEventPayload`。ACP `MockMsg` / `optionId` 只留在 adapter。
+7. **JobRunner 只看见 RuntimeClient 产品类型（Wave 16）**：mock 与真实 ACP 共用 event pump、command poller 与 idle hold；`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeNotification.payload` 是 `RuntimePayload`；`RuntimeRequest::Approval` 携带 `ApprovalKind`、`allowed_decisions` 与 `ApprovalEventPayload`。`CreateApprovalRequest.payload` 同样是 `ApprovalEventPayload`。ACP `MockMsg` / `optionId` 只留在 adapter。
 8. **Worker 内部控制已走 domain 类型（Wave 16）**：claim / heartbeat / commands query / runtime session / push / PR 使用 `WorkerClaimRequest`、`WorkerFence`、`WorkerSessionRequest`、`WorkerPushRequest`、`WorkerPullRequestRequest`。产品 runtime session 仍存在 `acp_session_id` 列。CLI ACP transport session 未动。
 9. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
 
@@ -1066,7 +1066,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          存库 event_type 使用 RunEventKind
          worker 内部控制请求使用 domain 类型
          ACP session 收成产品 runtime session
-         RuntimeClient 产品 payload 保持 domain 结构体直到 HTTP 边界（本轮）
+         RuntimeClient 产品 payload 保持 domain 结构体直到 HTTP 边界
+         审批写入 payload 使用 ApprovalEventPayload（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1091,13 +1092,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | RuntimeClient 产品 payload 已是 domain 结构体；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | 审批写入 payload 已是 ApprovalEventPayload；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体，JobRunner 在 HTTP/DB 边界才序列化；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体；`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`，`ApprovalRequest.payload` 读出仍为 JSON；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1196,7 +1197,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - Console 按 `event_type` 分发时间线：`text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result` 直接渲染产品字段，legacy `params.update` 仍可回放。plan/usage/projection/session_started/approval_requested 不进时间线。
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
    - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
-   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeNotification.payload` 是 `RuntimePayload`（分类 kind 持有 domain 结构体，未识别/提取失败为 `Json`）。审批请求 `context` 是 `ApprovalEventPayload`。JobRunner 在写 `WorkerEventRequest` / `CreateApprovalRequest` 时才序列化 JSON。`RunEvent` 读出仍为字符串 payload。worker 内部控制 HTTP 使用 domain 请求类型；产品 runtime session 仍写入 `acp_session_id` 列。ACP `MockMsg` 与 `optionId` 只留在 adapter。
+   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeNotification.payload` 是 `RuntimePayload`（分类 kind 持有 domain 结构体，未识别/提取失败为 `Json`）。审批请求 `context` 是 `ApprovalEventPayload`。`CreateApprovalRequest.payload` 同样是 `ApprovalEventPayload`；JobRunner 不再先转成 `Value`。`ApprovalRequest.payload` 与 `RunEvent.payload` 读出仍为 JSON。worker 内部控制 HTTP 使用 domain 请求类型；产品 runtime session 仍写入 `acp_session_id` 列。ACP `MockMsg` 与 `optionId` 只留在 adapter。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1222,10 +1223,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | RuntimeClient 产品 payload 已是 domain 结构体；Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | 审批写入 payload 已是 ApprovalEventPayload；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**RuntimeClient 产品 payload 已保持 domain 结构体直到 HTTP 边界**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
+推荐组合：**审批写入 payload 已是 ApprovalEventPayload**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1384,7 +1385,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 ### 2026-08-13 — RuntimeClient 产品 payload
 
 - `RuntimeNotification.payload` 是 `RuntimePayload`：分类 kind 持有 domain 结构体，未识别帧与提取失败仍为原始 JSON。
-- `RuntimeRequest::Approval.context` 是 `ApprovalEventPayload`。JobRunner 在 HTTP/DB 边界才序列化。
+- `RuntimeRequest::Approval.context` 是 `ApprovalEventPayload`。JobRunner 写审批 HTTP 时当时仍序列化为 JSON。
 - `CreateApprovalRequest.payload` 与 `RunEvent.payload` 读出仍为 JSON，不迁移已存记录。
+- 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
+
+### 2026-08-13 — 审批写入 payload
+
+- `CreateApprovalRequest.payload` 是 `ApprovalEventPayload`；worker 不再先转成 `Value`。
+- `ApprovalRequest.payload` 读出仍为 JSON，不迁移已存 ACP 信封。Console 审批卡按产品字段渲染，legacy `params` / `method` 仍 JSON。
 - 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #87 让 RuntimeClient 审批 context 保持 `ApprovalEventPayload`，但 JobRunner 写入时仍先转成 `Value`。本 PR 把 **审批写入路径** 收成同一产品结构体。

`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`；worker 直接提交该结构体，DB 按它序列化。`ApprovalRequest.payload` 读出仍为 JSON，不迁移已存 ACP 信封。Console 审批卡按产品字段渲染，legacy `params` / `method` 仍走 JSON。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不改 Console 布局。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-db -p zene-cloud-worker -p zene-cloud-api --locked` 与 `cd cloud/apps/web && npm run typecheck` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

