### PR TITLE
feat: projection_ready payload 使用 ProjectionPayload

### DIFF
--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -142,6 +142,13 @@ export interface PlanPayload {
   entries?: unknown;
 }
 
+export interface ProjectionPayload {
+  sourceMessageCount?: unknown;
+  projectedMessageCount?: unknown;
+  delivery?: string;
+  contextEpoch?: unknown;
+}
+
 export interface AvailableCommandsPayload {
   availableCommands?: unknown;
 }

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -380,6 +380,23 @@ pub struct AvailableCommandsPayload {
     pub available_commands: Option<serde_json::Value>,
 }
 
+/// Product payload stored on `projection_ready` rows.
+/// Extra `_meta` keys are preserved so the write path does not drop fields.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectionPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_message_count: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub projected_message_count: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_epoch: Option<serde_json::Value>,
+    #[serde(default, flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ApprovalEventPayload {
@@ -605,8 +622,8 @@ pub struct WorkerEventRequest {
 mod tests {
     use super::{
         ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, ApprovalStatus,
-        CloudEventKind, CreateApprovalRequest, PlatformEvent, RunEventKind, RunStatus,
-        TextEventPayload, ToolCallPayload, WorkerCommand, WorkerCommandAckRequest,
+        CloudEventKind, CreateApprovalRequest, PlatformEvent, ProjectionPayload, RunEventKind,
+        RunStatus, TextEventPayload, ToolCallPayload, WorkerCommand, WorkerCommandAckRequest,
         WorkerCommandKind, WorkerEventRequest, WorkerFence, WorkerClaimRequest,
         WorkerPushRequest, WorkerSessionRequest,
     };
@@ -830,6 +847,27 @@ mod tests {
         })
         .expect("text");
         assert_eq!(encoded, serde_json::json!({ "text": "hello" }));
+        let encoded = serde_json::to_value(ProjectionPayload {
+            source_message_count: Some(serde_json::json!(4)),
+            projected_message_count: Some(serde_json::json!(3)),
+            delivery: Some("strict".into()),
+            context_epoch: Some(serde_json::json!(2)),
+            extra: serde_json::Map::from_iter([(
+                "cacheDriftDetected".into(),
+                serde_json::json!(false),
+            )]),
+        })
+        .expect("projection");
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "sourceMessageCount": 4,
+                "projectedMessageCount": 3,
+                "delivery": "strict",
+                "contextEpoch": 2,
+                "cacheDriftDetected": false
+            })
+        );
         let encoded = serde_json::to_value(ToolCallPayload {
             tool_call_id: Some("call-7".into()),
             title: Some("Write".into()),

--- a/cloud/crates/runtime-client/src/lib.rs
+++ b/cloud/crates/runtime-client/src/lib.rs
@@ -14,8 +14,8 @@ use zene_cloud_acp_bridge::{
 
 pub use zene_cloud_domain::{
     ApprovalDecision, ApprovalEventPayload, ApprovalKind, AvailableCommandsPayload,
-    CloudEventKind, PlanPayload, SessionStartedPayload, StateChangedPayload, TextEventPayload,
-    ToolCallPayload, ToolResultPayload, UsagePayload,
+    CloudEventKind, PlanPayload, ProjectionPayload, SessionStartedPayload, StateChangedPayload,
+    TextEventPayload, ToolCallPayload, ToolResultPayload, UsagePayload,
 };
 
 /// ACP `optionId` mapping stays inside this adapter.
@@ -91,6 +91,7 @@ pub enum RuntimePayload {
     Commands(AvailableCommandsPayload),
     SessionStarted(SessionStartedPayload),
     ApprovalRequested(ApprovalEventPayload),
+    Projection(ProjectionPayload),
     Json(Value),
 }
 
@@ -106,6 +107,7 @@ impl RuntimePayload {
             Self::Commands(payload) => to_json(payload),
             Self::SessionStarted(payload) => to_json(payload),
             Self::ApprovalRequested(payload) => to_json(payload),
+            Self::Projection(payload) => to_json(payload),
             Self::Json(value) => value.clone(),
         }
     }
@@ -347,10 +349,14 @@ fn projection_product(raw: &Value) -> RuntimePayload {
     let Some(update) = raw.pointer("/params/update") else {
         return RuntimePayload::Json(raw.clone());
     };
-    RuntimePayload::Json(match update.get("_meta") {
+    let meta = match update.get("_meta") {
         Some(meta) if meta.is_object() => meta.clone(),
         _ => serde_json::json!({}),
-    })
+    };
+    match serde_json::from_value::<ProjectionPayload>(meta.clone()) {
+        Ok(payload) => RuntimePayload::Projection(payload),
+        Err(_) => RuntimePayload::Json(meta),
+    }
 }
 
 fn plan_product(raw: &Value) -> RuntimePayload {

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `beb5564`（PR #87 已合并）。**
+> **进度快照：2026-08-13，基线 `6c51aed`（PR #88 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是审批写入 payload 使用 `ApprovalEventPayload`；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是 `projection_ready` payload 使用 `ProjectionPayload`；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -1067,7 +1067,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          worker 内部控制请求使用 domain 类型
          ACP session 收成产品 runtime session
          RuntimeClient 产品 payload 保持 domain 结构体直到 HTTP 边界
-         审批写入 payload 使用 ApprovalEventPayload（本轮）
+         审批写入 payload 使用 ApprovalEventPayload
+         projection_ready payload 使用 ProjectionPayload（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1092,13 +1093,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | 审批写入 payload 已是 ApprovalEventPayload；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | projection_ready payload 已是 ProjectionPayload；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体；`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`，`ApprovalRequest.payload` 读出仍为 JSON；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体；`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`，`ApprovalRequest.payload` 读出仍为 JSON；`projection_ready` 写入 `ProjectionPayload`；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1197,7 +1198,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - Console 按 `event_type` 分发时间线：`text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result` 直接渲染产品字段，legacy `params.update` 仍可回放。plan/usage/projection/session_started/approval_requested 不进时间线。
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
    - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
-   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeNotification.payload` 是 `RuntimePayload`（分类 kind 持有 domain 结构体，未识别/提取失败为 `Json`）。审批请求 `context` 是 `ApprovalEventPayload`。`CreateApprovalRequest.payload` 同样是 `ApprovalEventPayload`；JobRunner 不再先转成 `Value`。`ApprovalRequest.payload` 与 `RunEvent.payload` 读出仍为 JSON。worker 内部控制 HTTP 使用 domain 请求类型；产品 runtime session 仍写入 `acp_session_id` 列。ACP `MockMsg` 与 `optionId` 只留在 adapter。
+   - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeNotification.payload` 是 `RuntimePayload`（分类 kind 持有 domain 结构体，含 `ProjectionPayload`；未识别/提取失败为 `Json`）。审批请求 `context` 是 `ApprovalEventPayload`。`CreateApprovalRequest.payload` 同样是 `ApprovalEventPayload`；JobRunner 不再先转成 `Value`。`ApprovalRequest.payload` 与 `RunEvent.payload` 读出仍为 JSON。worker 内部控制 HTTP 使用 domain 请求类型；产品 runtime session 仍写入 `acp_session_id` 列。ACP `MockMsg` 与 `optionId` 只留在 adapter。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1223,10 +1224,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | 审批写入 payload 已是 ApprovalEventPayload；Steer/SetMode 与整型 crate 仍分叉 |
+| 当前最大杠杆 | **Wave 16 剩余 command** | 分类 payload 已收口到 domain 结构体；Steer/SetMode 与整型 crate 仍分叉 |
 | 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
 
-推荐组合：**审批写入 payload 已是 ApprovalEventPayload**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
+推荐组合：**分类事件 payload 已收口到 domain 结构体**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1393,5 +1394,11 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 - `CreateApprovalRequest.payload` 是 `ApprovalEventPayload`；worker 不再先转成 `Value`。
 - `ApprovalRequest.payload` 读出仍为 JSON，不迁移已存 ACP 信封。Console 审批卡按产品字段渲染，legacy `params` / `method` 仍 JSON。
+- 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
+
+### 2026-08-13 — projection_ready payload
+
+- `RuntimePayload::Projection` 持有 domain `ProjectionPayload`；`_meta` 额外字段经 flatten 保留。
+- Console 不新增 plan/usage/projection 时间线 chrome。
 - 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #88 把审批写入收成 `ApprovalEventPayload` 之后，分类事件里 `projection_ready` 仍把 `_meta` 当原始 JSON。本 PR 把 **projection payload** 收成 domain 结构体。

`RuntimePayload::Projection` 持有 `ProjectionPayload`（`sourceMessageCount` / `projectedMessageCount` / `delivery` / `contextEpoch`）；其余 `_meta` 字段经 flatten 保留。JobRunner 仍在 HTTP 边界序列化。Console 类型对齐，但不新增 plan/usage/projection 时间线 chrome。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不改 Console 布局。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-runtime-client --locked` 与 `cd cloud/apps/web && npm run typecheck` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

