### PR TITLE
feat: Console Run.status 使用 RunStatus

### DIFF
--- a/cloud/apps/web/components/RunView.tsx
+++ b/cloud/apps/web/components/RunView.tsx
@@ -31,7 +31,16 @@ import {
   saveSelectedModel,
 } from "@/lib/models";
 import { allowsDeny, allowsOnce, approvalCardBody, extraDecisions } from "@/lib/approval";
-import type { Approval, ApprovalDecision, LlmSettingsView, Repo, Run, RunEvent, RunMessage } from "@/lib/types";
+import type {
+  Approval,
+  ApprovalDecision,
+  LlmSettingsView,
+  Repo,
+  Run,
+  RunEvent,
+  RunMessage,
+  RunStatus,
+} from "@/lib/types";
 import { platformEventFromPayload } from "@/lib/platformEvent";
 import { timelineProductFromEvent, timelineToolOutput, type TimelineProduct } from "@/lib/runtimeEvent";
 import { CodePanel, useCodePanelWidth } from "./CodePanel";
@@ -41,7 +50,7 @@ import { StatusDot } from "./StatusPill";
 import { useToast } from "./Toast";
 
 /** Show Stop — agent/session is in progress (includes setup). */
-const BUSY_STATUSES = new Set([
+const BUSY_STATUSES: ReadonlySet<string> = new Set<RunStatus>([
   "running",
   "starting",
   "cloning",
@@ -52,11 +61,20 @@ const BUSY_STATUSES = new Set([
 ]);
 
 /** Block Send only while a turn is actively executing (follow-ups still OK when queued/ready). */
-const SEND_BLOCKED_STATUSES = new Set(["running", "waiting_for_approval", "stopping"]);
+const SEND_BLOCKED_STATUSES: ReadonlySet<string> = new Set<RunStatus>([
+  "running",
+  "waiting_for_approval",
+  "stopping",
+]);
 
-const SETUP_STATUSES = new Set(["queued", "provisioning", "starting", "cloning"]);
+const SETUP_STATUSES: ReadonlySet<string> = new Set<RunStatus>([
+  "queued",
+  "provisioning",
+  "starting",
+  "cloning",
+]);
 
-function setupStatusCopy(status: string, repo?: string): { title: string; detail: string } {
+function setupStatusCopy(status: RunStatus | string, repo?: string): { title: string; detail: string } {
   const repoLabel = repo && repo !== "—" ? repo : "repository";
   switch (status) {
     case "cloning":

--- a/cloud/apps/web/components/StatusPill.tsx
+++ b/cloud/apps/web/components/StatusPill.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { statusLabel, statusTone } from "@/lib/api";
+import type { RunStatus } from "@/lib/types";
 
 const TONE_CLASSES: Record<string, string> = {
   ok: "bg-ok-soft text-ok",
@@ -9,7 +10,7 @@ const TONE_CLASSES: Record<string, string> = {
   idle: "bg-secondary text-muted",
 };
 
-export function StatusPill({ status }: { status?: string }) {
+export function StatusPill({ status }: { status?: RunStatus | string }) {
   const tone = statusTone(status);
   return (
     <div className={`whitespace-nowrap rounded-md px-2 py-0.5 text-[11px] font-medium ${TONE_CLASSES[tone]}`}>
@@ -25,7 +26,7 @@ const DOT_TONE_CLASSES: Record<string, string> = {
   idle: "bg-placeholder",
 };
 
-export function StatusDot({ status }: { status?: string }) {
+export function StatusDot({ status }: { status?: RunStatus | string }) {
   const tone = statusTone(status);
   return (
     <span className={`mr-1.5 inline-block h-1.5 w-1.5 rounded-full align-middle ${DOT_TONE_CLASSES[tone]}`} />

--- a/cloud/apps/web/lib/api.ts
+++ b/cloud/apps/web/lib/api.ts
@@ -1,3 +1,5 @@
+import type { RunStatus } from "@/lib/types";
+
 let authToken = "";
 
 export function setToken(token: string) {
@@ -38,28 +40,36 @@ export async function api<T = unknown>(path: string, options: RequestInit = {}):
   return data as T;
 }
 
-export function statusClass(status?: string): string {
+export function statusClass(status?: RunStatus | string): string {
   return String(status || "")
     .toLowerCase()
     .replace(/\s+/g, "_");
 }
 
-const OK_STATUSES = ["running", "starting", "cloning", "provisioning", "queued", "completed"];
-const DANGER_STATUSES = ["failed", "timed_out", "cancelled"];
-const WARN_STATUSES = ["waiting_for_approval"];
-const IDLE_STATUSES = ["waiting_for_user", "ready"];
+const OK_STATUSES = [
+  "running",
+  "starting",
+  "cloning",
+  "provisioning",
+  "queued",
+  "completed",
+] as const satisfies readonly RunStatus[];
+const DANGER_STATUSES = ["failed", "timed_out", "cancelled"] as const satisfies readonly RunStatus[];
+const WARN_STATUSES = ["waiting_for_approval"] as const satisfies readonly RunStatus[];
+/** `ready` is the display alias for `waiting_for_user`, not a stored RunStatus. */
+const IDLE_STATUSES = ["waiting_for_user", "ready"] as const;
 
-export function statusTone(status?: string): "ok" | "warn" | "danger" | "idle" {
+export function statusTone(status?: RunStatus | string): "ok" | "warn" | "danger" | "idle" {
   const s = statusClass(status);
-  if (OK_STATUSES.includes(s)) return "ok";
-  if (DANGER_STATUSES.includes(s)) return "danger";
-  if (WARN_STATUSES.includes(s)) return "warn";
-  if (IDLE_STATUSES.includes(s)) return "idle";
+  if ((OK_STATUSES as readonly string[]).includes(s)) return "ok";
+  if ((DANGER_STATUSES as readonly string[]).includes(s)) return "danger";
+  if ((WARN_STATUSES as readonly string[]).includes(s)) return "warn";
+  if ((IDLE_STATUSES as readonly string[]).includes(s)) return "idle";
   return "idle";
 }
 
 /** Human-readable run status for pills / lists. */
-export function statusLabel(status?: string): string {
+export function statusLabel(status?: RunStatus | string): string {
   const s = statusClass(status);
   if (s === "waiting_for_user") return "ready";
   if (s === "waiting_for_approval") return "waiting";

--- a/cloud/apps/web/lib/runtimeEvent.ts
+++ b/cloud/apps/web/lib/runtimeEvent.ts
@@ -1,4 +1,4 @@
-import type { AcpSessionUpdate, CloudEventKind, RunEvent } from "@/lib/types";
+import type { AcpSessionUpdate, CloudEventKind, RunEvent, RunEventType } from "@/lib/types";
 
 /** Classified product kinds that already have a Console timeline surface. */
 export const TIMELINE_EVENT_KINDS = [
@@ -24,8 +24,27 @@ export interface TimelineProduct {
   isError?: boolean;
 }
 
-export function eventKind(event: Pick<RunEvent, "eventType" | "event_type">): string {
-  return (event.eventType || event.event_type || "acp").toLowerCase();
+const RUN_EVENT_TYPES: readonly RunEventType[] = [
+  "text_delta",
+  "thought_delta",
+  "user_message",
+  "tool_call",
+  "tool_result",
+  "state_changed",
+  "usage_update",
+  "projection_ready",
+  "plan",
+  "available_commands",
+  "session_started",
+  "approval_requested",
+  "acp",
+  "platform",
+  "runtime",
+];
+
+export function eventKind(event: Pick<RunEvent, "eventType" | "event_type">): RunEventType {
+  const raw = (event.eventType || event.event_type || "acp").toLowerCase();
+  return (RUN_EVENT_TYPES as readonly string[]).includes(raw) ? (raw as RunEventType) : "acp";
 }
 
 function isTimelineKind(kind: string): kind is TimelineEventKind {

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -40,10 +40,26 @@ export interface Branch {
   default?: boolean;
 }
 
+/** Stored run lifecycle. Matches domain `RunStatus`. */
+export type RunStatus =
+  | "created"
+  | "queued"
+  | "provisioning"
+  | "cloning"
+  | "starting"
+  | "running"
+  | "waiting_for_approval"
+  | "waiting_for_user"
+  | "stopping"
+  | "completed"
+  | "failed"
+  | "timed_out"
+  | "cancelled";
+
 export interface Run {
   id: string;
   title: string;
-  status: string;
+  status: RunStatus;
   repositoryId: string;
   headBranch?: string;
   baseRef?: string;
@@ -197,16 +213,16 @@ export type PlatformEvent =
   | { event: "run.created"; title?: string; prompt?: string }
   | { event: "run.title"; title?: string }
   | { event: "run.archived" }
-  | { event: "run.status"; status?: string; headSha?: string }
+  | { event: "run.status"; status?: RunStatus; headSha?: string }
   | { event: "message.created"; role?: string; text?: string }
   | {
       event: "approval.created";
       approvalId?: string;
-      status?: string;
-      decision?: string;
-      kind?: string;
+      status?: ApprovalStatus;
+      decision?: ApprovalDecision | null;
+      kind?: ApprovalKind;
     }
-  | { event: "approval.decided"; approvalId?: string; decision?: string };
+  | { event: "approval.decided"; approvalId?: string; decision?: ApprovalDecision };
 
 export type ApprovalDecision =
   | "allow-once"

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `6c51aed`（PR #88 已合并）。**
+> **进度快照：2026-08-13，基线 `eedead8`（PR #89 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是 `projection_ready` payload 使用 `ProjectionPayload`；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是 Console `Run.status` 使用 `RunStatus`；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -1068,7 +1068,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          ACP session 收成产品 runtime session
          RuntimeClient 产品 payload 保持 domain 结构体直到 HTTP 边界
          审批写入 payload 使用 ApprovalEventPayload
-         projection_ready payload 使用 ProjectionPayload（本轮）
+         projection_ready payload 使用 ProjectionPayload
+         Console Run.status 使用 RunStatus（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1093,13 +1094,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | projection_ready payload 已是 ProjectionPayload；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | Console `Run.status` 已是 `RunStatus`；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体；`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`，`ApprovalRequest.payload` 读出仍为 JSON；`projection_ready` 写入 `ProjectionPayload`；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体；`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`，`ApprovalRequest.payload` 读出仍为 JSON；`projection_ready` 写入 `ProjectionPayload`；Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1199,6 +1200,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
    - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
    - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeNotification.payload` 是 `RuntimePayload`（分类 kind 持有 domain 结构体，含 `ProjectionPayload`；未识别/提取失败为 `Json`）。审批请求 `context` 是 `ApprovalEventPayload`。`CreateApprovalRequest.payload` 同样是 `ApprovalEventPayload`；JobRunner 不再先转成 `Value`。`ApprovalRequest.payload` 与 `RunEvent.payload` 读出仍为 JSON。worker 内部控制 HTTP 使用 domain 请求类型；产品 runtime session 仍写入 `acp_session_id` 列。ACP `MockMsg` 与 `optionId` 只留在 adapter。
+   - Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；审批平台事件的 `status` / `decision` / `kind` 使用已有产品枚举。`eventKind()` 返回 `RunEventType`，未知历史 kind 回落 `"acp"`。`RunEvent.event_type` 读出仍为字符串。不改 pill 文案/颜色，不改 Sidebar 过滤。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1401,4 +1403,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 - `RuntimePayload::Projection` 持有 domain `ProjectionPayload`；`_meta` 额外字段经 flatten 保留。
 - Console 不新增 plan/usage/projection 时间线 chrome。
 - 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
+
+### 2026-08-13 — Console Run.status
+
+- Console `Run.status` 与 `PlatformEvent["run.status"]` 对齐 domain `RunStatus`。
+- `PlatformEvent` 审批分支使用 `ApprovalStatus` / `ApprovalDecision` / `ApprovalKind`。`eventKind()` 返回 `RunEventType`，未知历史 kind 回落 `"acp"`。
+- 不改 pill 文案/颜色，不改 Sidebar 过滤。`onMeta` 仍收 `string`（含 `"idle"`）。不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #89 把 `projection_ready` 收成 `ProjectionPayload` 之后，Console 的 `Run.status` 仍是裸 `string`。本 PR 把它收成与 domain `RunStatus` 同形的产品类型。

`Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`。审批平台事件的 `status` / `decision` / `kind` 复用已有 `ApprovalStatus` / `ApprovalDecision` / `ApprovalKind`。`eventKind()` 返回 `RunEventType`，未知历史 kind 回落 `"acp"`。

不改 pill 文案/颜色，不改 Sidebar 过滤。`onMeta` 仍收 `string`（含 `"idle"`）。不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不改 Console 布局。

`cd cloud/apps/web && npm run typecheck` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

