### PR TITLE
feat: Cloud permission_mode 使用 PermissionMode

### DIFF
--- a/cloud/apps/api/src/routes.rs
+++ b/cloud/apps/api/src/routes.rs
@@ -1424,9 +1424,9 @@ mod reconnect_replay_tests {
     use uuid::Uuid;
     use zene_cloud_db::Db;
     use zene_cloud_domain::{
-        AuthResponse, ClaimedRun, CreateRepositoryRequest, CreateRunRequest, RegisterRequest,
-        Repository, Run, RunEvent, RunEventKind, RunStatus, UpdateLlmSettingsRequest, WorkerEventRequest,
-        WorkerFence, WorkerTitleRequest,
+        AuthResponse, ClaimedRun, CreateRepositoryRequest, CreateRunRequest, PermissionMode,
+        RegisterRequest, Repository, Run, RunEvent, RunEventKind, RunStatus, UpdateLlmSettingsRequest,
+        WorkerEventRequest, WorkerFence,
     };
     use zene_cloud_github::{GithubClient, GithubConfig};
 
@@ -1551,7 +1551,7 @@ mod reconnect_replay_tests {
                     prompt: "replay integration".into(),
                     base_ref: Some("main".into()),
                     model: "default".into(),
-                    permission_mode: "default".into(),
+                    permission_mode: PermissionMode::Default,
                     max_turns: 10,
                 }),
             )

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -56,6 +56,9 @@ export type RunStatus =
   | "timed_out"
   | "cancelled";
 
+/** Stored run permission mode. `auto` is historical; the composer picker does not offer it. */
+export type PermissionMode = "default" | "accept_edits" | "yolo" | "auto";
+
 export interface Run {
   id: string;
   title: string;
@@ -64,7 +67,7 @@ export interface Run {
   headBranch?: string;
   baseRef?: string;
   model?: string;
-  permissionMode?: string;
+  permissionMode?: PermissionMode;
   /** Agent step budget; `0` = unlimited. */
   maxTurns?: number;
   headSha?: string;
@@ -309,7 +312,6 @@ export interface Skill {
 
 export type ListGroup = "project" | "date" | "status" | "none";
 export type ListFilter = "none" | "running" | "completed" | "failed" | "project";
-export type PermissionMode = "default" | "accept_edits" | "yolo";
 export type View = "new" | "settings" | "run";
 
 export interface LlmSettingsView {

--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -23,8 +23,8 @@ use zene_cloud_runtime_client::{
 use zene_cloud_domain::{
     ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRequest, ApprovalRisk,
     ApprovalStatus, ClaimedRun, CloneAuthResponse, CreateApprovalRequest, LlmAuthResponse,
-    RunStatus, WorkerClaimRequest, WorkerCommand, WorkerCommandAckRequest, WorkerCommandKind,
-    WorkerCommandsResponse, WorkerEventRequest, WorkerFence, WorkerPullRequestRequest,
+    PermissionMode, RunStatus, WorkerClaimRequest, WorkerCommand, WorkerCommandAckRequest,
+    WorkerCommandKind, WorkerCommandsResponse, WorkerEventRequest, WorkerFence, WorkerPullRequestRequest,
     WorkerPushRequest, WorkerSessionRequest, WorkerStatusRequest, WorkerTitleRequest,
 };
 
@@ -1029,7 +1029,7 @@ async fn run_with_real_acp(
         .await
         .context("flush recovered event outbox")?;
     let yolo = cli.acp_yolo
-        || claimed.run.permission_mode == "yolo"
+        || claimed.run.permission_mode == PermissionMode::Yolo
         || std::env::var("ZENE_YOLO").ok().as_deref() == Some("1");
 
     let mut llm_env = match fetch_llm_auth(client, cli, run_id).await {
@@ -1868,8 +1868,8 @@ mod title_tests {
         use zene_cloud_api::{router, AppState};
         use zene_cloud_db::Db;
         use zene_cloud_domain::{
-            CreateRepositoryRequest, CreateRunRequest, RegisterRequest, RunEvent, RunStatus,
-            UpdateLlmSettingsRequest, WorkerClaimRequest,
+            CreateRepositoryRequest, CreateRunRequest, PermissionMode, RegisterRequest, RunEvent,
+            RunStatus, UpdateLlmSettingsRequest, WorkerClaimRequest,
         };
         use zene_cloud_github::{GithubClient, GithubConfig};
 
@@ -1947,7 +1947,7 @@ mod title_tests {
                 prompt: "worker reconnect".into(),
                 base_ref: Some("main".into()),
                 model: "default".into(),
-                permission_mode: "default".into(),
+                permission_mode: PermissionMode::Default,
                 max_turns: 10,
             })
             .send()

--- a/cloud/crates/db/src/lib.rs
+++ b/cloud/crates/db/src/lib.rs
@@ -17,7 +17,7 @@ use zene_cloud_domain::{
     ApprovalDecision, ApprovalKind, ApprovalRequest, ApprovalRisk, ApprovalStatus, AuthResponse,
     CloneAuthResponse, CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest, LoginRequest, Organization,
     PlatformEvent, QueueActive, QueueHold, QueueStats, RegisterRequest, Repository, Run, RunEvent, RunEventKind, RunMessage,
-    RunStatus, User, WorkerCommand, WorkerFence,
+    RunStatus, PermissionMode, User, WorkerCommand, WorkerFence,
 };
 
 #[derive(Clone)]
@@ -444,7 +444,7 @@ impl Db {
         .bind(&run.head_branch)
         .bind(&run.head_sha)
         .bind(&run.model)
-        .bind(&run.permission_mode)
+        .bind(run.permission_mode.as_str())
         .bind(run.max_turns as i64)
         .bind(run.created_at.to_rfc3339())
         .bind(Option::<String>::None)
@@ -1557,10 +1557,7 @@ impl Db {
 
         let id = Uuid::new_v4();
         let now = Utc::now();
-        let auto = matches!(
-            run.permission_mode.as_str(),
-            "yolo" | "auto" | "default"
-        );
+        let auto = run.permission_mode.auto_resolves_approvals();
         let status = if auto {
             ApprovalStatus::Resolved
         } else {
@@ -1894,7 +1891,8 @@ impl RunRow {
             head_branch: self.head_branch,
             head_sha: self.head_sha,
             model: self.model,
-            permission_mode: self.permission_mode,
+            permission_mode: PermissionMode::parse(&self.permission_mode)
+                .unwrap_or(PermissionMode::AcceptEdits),
             max_turns: self.max_turns.max(0) as u32,
             created_at: parse_time(&self.created_at),
             started_at: self.started_at.as_deref().map(parse_time),

--- a/cloud/crates/db/tests/github_git.rs
+++ b/cloud/crates/db/tests/github_git.rs
@@ -1,7 +1,7 @@
 use zene_cloud_db::Db;
 use zene_cloud_domain::{
     CreateRepositoryRequest, CreateRunRequest, GitOperationKind, GitOperationStatus,
-    GithubRepoSummary, RegisterRequest,
+    GithubRepoSummary, PermissionMode, RegisterRequest,
 };
 
 #[tokio::test]
@@ -75,7 +75,7 @@ async fn github_crud_and_migrations() {
                 prompt: "ship it".into(),
                 base_ref: Some("main".into()),
                 model: "default".into(),
-                permission_mode: "default".into(),
+                permission_mode: PermissionMode::Default,
                 max_turns: 50,
             },
         )

--- a/cloud/crates/db/tests/smoke.rs
+++ b/cloud/crates/db/tests/smoke.rs
@@ -3,8 +3,8 @@ use uuid::Uuid;
 use zene_cloud_db::Db;
 use zene_cloud_domain::{
     ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, ApprovalStatus,
-    CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest, RegisterRequest,
-    RunEventKind, RunStatus, WorkerCommandKind, WorkerFence,
+    CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest, PermissionMode,
+    RegisterRequest, RunEventKind, RunStatus, WorkerCommandKind, WorkerFence,
 };
 
 #[tokio::test]
@@ -44,7 +44,7 @@ async fn register_create_run_and_claim() {
                 prompt: "hello cloud".into(),
                 base_ref: Some("main".into()),
                 model: "default".into(),
-                permission_mode: "default".into(),
+                permission_mode: PermissionMode::Default,
                 max_turns: 50,
             },
         )
@@ -249,7 +249,7 @@ async fn run_state_mutations_have_matching_events() {
                 prompt: "initial prompt".into(),
                 base_ref: None,
                 model: "default".into(),
-                permission_mode: "default".into(),
+                permission_mode: PermissionMode::Default,
                 max_turns: 10,
             },
         )
@@ -303,7 +303,7 @@ async fn run_state_mutations_have_matching_events() {
     assert_eq!(message.content, "follow-up");
 }
 
-async fn approval_test_run(permission_mode: &str) -> (Db, Uuid) {
+async fn approval_test_run(permission_mode: PermissionMode) -> (Db, Uuid) {
     let db = Db::connect("sqlite::memory:").await.unwrap();
     db.migrate().await.unwrap();
     let auth = db
@@ -335,7 +335,7 @@ async fn approval_test_run(permission_mode: &str) -> (Db, Uuid) {
                 prompt: "approval race".into(),
                 base_ref: Some("main".into()),
                 model: "default".into(),
-                permission_mode: permission_mode.into(),
+                permission_mode,
                 max_turns: 10,
             },
         )
@@ -365,7 +365,7 @@ fn approval_request(request_key: &str) -> CreateApprovalRequest {
 
 #[tokio::test]
 async fn concurrent_approval_creation_has_one_row_and_event() {
-    let (db, run_id) = approval_test_run("manual").await;
+    let (db, run_id) = approval_test_run(PermissionMode::AcceptEdits).await;
     let first = approval_request("permission-stable");
     let second = approval_request("permission-stable");
 
@@ -392,7 +392,7 @@ async fn concurrent_approval_creation_has_one_row_and_event() {
 
 #[tokio::test]
 async fn concurrent_approval_decisions_have_one_winner_event() {
-    let (db, run_id) = approval_test_run("manual").await;
+    let (db, run_id) = approval_test_run(PermissionMode::AcceptEdits).await;
     let approval = db
         .create_approval(run_id, approval_request("decision-stable"))
         .await
@@ -440,7 +440,7 @@ async fn worker_command_is_retried_until_fenced_ack() {
         .unwrap();
     let run = db.create_run(auth.organization.id, auth.user.id, CreateRunRequest {
         repository_id: repo.id, prompt: "initial".into(), base_ref: None, model: "default".into(),
-        permission_mode: "default".into(), max_turns: 10,
+        permission_mode: PermissionMode::Default, max_turns: 10,
     }).await.unwrap();
     let claimed = db.claim_next_run("worker-delivery", std::path::Path::new("/tmp/zc-workspaces"))
         .await.unwrap().unwrap();
@@ -479,7 +479,7 @@ async fn stale_waiting_for_user_attempt_is_requeued_but_approval_holds_are_not()
         }).await.unwrap();
         let run = db.create_run(auth.organization.id, auth.user.id, CreateRunRequest {
             repository_id: repo.id, prompt: suffix.into(), base_ref: None, model: "default".into(),
-            permission_mode: "default".into(), max_turns: 10,
+            permission_mode: PermissionMode::Default, max_turns: 10,
         }).await.unwrap();
         let claimed = db.claim_next_run("stale-policy-worker", std::path::Path::new("/tmp/zc-workspaces"))
             .await.unwrap().unwrap();
@@ -540,7 +540,7 @@ async fn worker_title_is_fenced_and_retry_idempotent() {
                 prompt: "title fencing".into(),
                 base_ref: None,
                 model: "default".into(),
-                permission_mode: "default".into(),
+                permission_mode: PermissionMode::Default,
                 max_turns: 10,
             },
         )

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -116,6 +116,44 @@ impl RunStatus {
     }
 }
 
+/// Stored run permission mode. Matches Console `PermissionMode`.
+/// `auto` is a historical alias; it still auto-resolves approvals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionMode {
+    #[default]
+    Default,
+    AcceptEdits,
+    Yolo,
+    Auto,
+}
+
+impl PermissionMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::AcceptEdits => "accept_edits",
+            Self::Yolo => "yolo",
+            Self::Auto => "auto",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "default" => Self::Default,
+            "accept_edits" => Self::AcceptEdits,
+            "yolo" => Self::Yolo,
+            "auto" => Self::Auto,
+            _ => return None,
+        })
+    }
+
+    /// `default` / `yolo` / `auto` auto-resolve approval rows on create.
+    pub fn auto_resolves_approvals(self) -> bool {
+        matches!(self, Self::Default | Self::Yolo | Self::Auto)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Run {
@@ -132,7 +170,7 @@ pub struct Run {
     pub head_branch: String,
     pub head_sha: Option<String>,
     pub model: String,
-    pub permission_mode: String,
+    pub permission_mode: PermissionMode,
     /// Agent step budget for this run; `0` means unlimited.
     #[serde(default = "default_max_turns")]
     pub max_turns: u32,
@@ -481,8 +519,8 @@ pub struct CreateRunRequest {
     pub base_ref: Option<String>,
     #[serde(default = "default_model")]
     pub model: String,
-    #[serde(default = "default_permission_mode")]
-    pub permission_mode: String,
+    #[serde(default)]
+    pub permission_mode: PermissionMode,
     /// Agent step budget; `0` = unlimited. Defaults to 50.
     #[serde(default = "default_max_turns")]
     pub max_turns: u32,
@@ -493,10 +531,6 @@ fn default_branch_name() -> String {
 }
 
 fn default_model() -> String {
-    "default".into()
-}
-
-fn default_permission_mode() -> String {
     "default".into()
 }
 
@@ -622,10 +656,10 @@ pub struct WorkerEventRequest {
 mod tests {
     use super::{
         ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, ApprovalStatus,
-        CloudEventKind, CreateApprovalRequest, PlatformEvent, ProjectionPayload, RunEventKind,
-        RunStatus, TextEventPayload, ToolCallPayload, WorkerCommand, WorkerCommandAckRequest,
-        WorkerCommandKind, WorkerEventRequest, WorkerFence, WorkerClaimRequest,
-        WorkerPushRequest, WorkerSessionRequest,
+        CloudEventKind, CreateApprovalRequest, PlatformEvent, PermissionMode, ProjectionPayload,
+        RunEventKind, RunStatus, TextEventPayload, ToolCallPayload, WorkerCommand,
+        WorkerCommandAckRequest, WorkerCommandKind, WorkerEventRequest, WorkerFence,
+        WorkerClaimRequest, WorkerPushRequest, WorkerSessionRequest,
     };
 
     #[test]
@@ -780,6 +814,25 @@ mod tests {
         assert_eq!(encoded["kind"], "permission");
         assert_eq!(encoded["payload"]["requestId"], "permission-1");
         assert_eq!(encoded["payload"]["rawInput"]["path"], "notes.txt");
+    }
+
+    #[test]
+    fn permission_mode_round_trips_snake_case() {
+        for mode in [
+            PermissionMode::Default,
+            PermissionMode::AcceptEdits,
+            PermissionMode::Yolo,
+            PermissionMode::Auto,
+        ] {
+            let encoded = serde_json::to_value(mode).expect("serialize");
+            assert_eq!(encoded, serde_json::json!(mode.as_str()));
+            assert_eq!(PermissionMode::parse(mode.as_str()), Some(mode));
+        }
+        assert!(PermissionMode::Default.auto_resolves_approvals());
+        assert!(PermissionMode::Yolo.auto_resolves_approvals());
+        assert!(PermissionMode::Auto.auto_resolves_approvals());
+        assert!(!PermissionMode::AcceptEdits.auto_resolves_approvals());
+        assert_eq!(PermissionMode::parse("manual"), None);
     }
 
     #[test]

--- a/cloud/crates/git-broker/tests/mock_flow.rs
+++ b/cloud/crates/git-broker/tests/mock_flow.rs
@@ -1,6 +1,6 @@
 use zene_cloud_db::Db;
 use zene_cloud_domain::{
-    CreatePullRequestBody, CreateRunRequest, GithubRepoSummary, RegisterRequest,
+    CreatePullRequestBody, CreateRunRequest, GithubRepoSummary, PermissionMode, RegisterRequest,
 };
 use zene_cloud_git_broker::GitBroker;
 
@@ -45,7 +45,7 @@ async fn mock_clone_push_and_draft_pr() {
                 prompt: "add feature".into(),
                 base_ref: Some("main".into()),
                 model: "default".into(),
-                permission_mode: "default".into(),
+                permission_mode: PermissionMode::Default,
                 max_turns: 50,
             },
         )

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `eedead8`（PR #89 已合并）。**
+> **进度快照：2026-08-13，基线 `4f32021`（PR #90 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是 Console `Run.status` 使用 `RunStatus`；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是 Cloud `permission_mode` 使用 `PermissionMode`；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -1069,7 +1069,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          RuntimeClient 产品 payload 保持 domain 结构体直到 HTTP 边界
          审批写入 payload 使用 ApprovalEventPayload
          projection_ready payload 使用 ProjectionPayload
-         Console Run.status 使用 RunStatus（本轮）
+         Console Run.status 使用 RunStatus
+         Cloud permission_mode 使用 PermissionMode（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1094,13 +1095,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | Console `Run.status` 已是 `RunStatus`；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | Cloud `permission_mode` 已是 `PermissionMode`；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体；`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`，`ApprovalRequest.payload` 读出仍为 JSON；`projection_ready` 写入 `ProjectionPayload`；Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体；`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`，`ApprovalRequest.payload` 读出仍为 JSON；`projection_ready` 写入 `ProjectionPayload`；Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；Cloud `Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1201,6 +1202,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
    - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeNotification.payload` 是 `RuntimePayload`（分类 kind 持有 domain 结构体，含 `ProjectionPayload`；未识别/提取失败为 `Json`）。审批请求 `context` 是 `ApprovalEventPayload`。`CreateApprovalRequest.payload` 同样是 `ApprovalEventPayload`；JobRunner 不再先转成 `Value`。`ApprovalRequest.payload` 与 `RunEvent.payload` 读出仍为 JSON。worker 内部控制 HTTP 使用 domain 请求类型；产品 runtime session 仍写入 `acp_session_id` 列。ACP `MockMsg` 与 `optionId` 只留在 adapter。
    - Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；审批平台事件的 `status` / `decision` / `kind` 使用已有产品枚举。`eventKind()` 返回 `RunEventType`，未知历史 kind 回落 `"acp"`。`RunEvent.event_type` 读出仍为字符串。不改 pill 文案/颜色，不改 Sidebar 过滤。
+   - Cloud `Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`（`default` / `accept_edits` / `yolo` / 历史 `auto`）。`default` / `yolo` / `auto` 仍自动 resolve 审批；未知历史值读成 `accept_edits`（不自动批准、不启用 `--yolo`）。不补 SetMode。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1409,4 +1411,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 - Console `Run.status` 与 `PlatformEvent["run.status"]` 对齐 domain `RunStatus`。
 - `PlatformEvent` 审批分支使用 `ApprovalStatus` / `ApprovalDecision` / `ApprovalKind`。`eventKind()` 返回 `RunEventType`，未知历史 kind 回落 `"acp"`。
 - 不改 pill 文案/颜色，不改 Sidebar 过滤。`onMeta` 仍收 `string`（含 `"idle"`）。不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
+
+### 2026-08-13 — Cloud permission_mode
+
+- domain `PermissionMode` 用于 `Run.permission_mode` 与 `CreateRunRequest.permission_mode`。Console `Run.permissionMode` 对齐；composer 选择器仍只提供 `default` / `accept_edits` / `yolo`。
+- `default` / `yolo` / `auto` 仍自动 resolve 审批；worker 仅 `yolo` 传 `--yolo`。未知历史值读成 `accept_edits`。
+- 不补 SetMode。不把 `zene-runtime` 引入 Cloud。不改 CLI config 的 `permission_mode`。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #90 把 Console `Run.status` 收成 `RunStatus` 之后，`permission_mode` 仍是裸字符串。本 PR 把它收成 domain `PermissionMode`。

`Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`（`default` / `accept_edits` / `yolo` / 历史 `auto`）。Console `Run.permissionMode` 对齐；composer 选择器仍只提供前三个。`default` / `yolo` / `auto` 仍自动 resolve 审批；worker 仅 `yolo` 传 `--yolo`。未知历史值读成 `accept_edits`。

不补 SetMode。不把 `zene-runtime` 引入 Cloud。不改 CLI config 的 `permission_mode`。不改 Console 布局。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-db -p zene-cloud-git-broker -p zene-cloud-api --locked` 与 `cd cloud/apps/web && npm run typecheck` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

