### PR TITLE
feat: Cloud 消息 role 使用 MessageRole

### DIFF
--- a/cloud/apps/api/src/routes.rs
+++ b/cloud/apps/api/src/routes.rs
@@ -14,7 +14,7 @@ use zene_cloud_domain::{
     ClaimedRun, CreateApprovalRequest, CreatePullRequestBody, CreateRepositoryRequest,
     CreateRunRequest, DecideApprovalRequest, GithubBranchSummary, GithubProviderConfigView,
     LlmAuthResponse, LlmSettingsView, LoginRequest, PostMessageRequest, QueueStats, RegisterRequest,
-    RunStatus, UpdateGithubProviderConfigRequest, UpdateLlmSettingsRequest, UpdateRunRequest,
+    MessageRole, RunStatus, UpdateGithubProviderConfigRequest, UpdateLlmSettingsRequest, UpdateRunRequest,
     WorkerCommandAckRequest, WorkerCommandsResponse, WorkerEventRequest, WorkerFence,
     WorkerSessionRequest, WorkerClaimRequest, WorkerPullRequestRequest, WorkerPushRequest,
     WorkerStatusRequest, WorkerTitleRequest,
@@ -820,7 +820,7 @@ async fn post_message(
             .add_message(
                 run_id,
                 Some(user.id),
-                "user",
+                MessageRole::User,
                 &req.text,
                 req.client_message_id.as_deref(),
             )

--- a/cloud/apps/web/components/RunView.tsx
+++ b/cloud/apps/web/components/RunView.tsx
@@ -35,6 +35,7 @@ import type {
   Approval,
   ApprovalDecision,
   LlmSettingsView,
+  MessageRole,
   Repo,
   Run,
   RunEvent,
@@ -126,7 +127,7 @@ type TimelineItem =
     }
   | { kind: "approval"; id: number; approval: Approval; decision?: ApprovalDecision };
 
-function bubbleRole(role?: string): "user" | "assistant" {
+function bubbleRole(role?: MessageRole | string): MessageRole {
   return (role || "").toLowerCase() === "user" ? "user" : "assistant";
 }
 
@@ -957,7 +958,7 @@ export function RunView({
   }, []);
 
   const appendBubble = useCallback(
-    (role: string, text: string) => {
+    (role: MessageRole, text: string) => {
       const r = bubbleRole(role);
       setItems((prev) => [...prev, { kind: "bubble", id: nextId.current++, role: r, text }]);
       hasAssistantTail.current = r === "assistant";

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -59,6 +59,9 @@ export type RunStatus =
 /** Stored run permission mode. `auto` is historical; the composer picker does not offer it. */
 export type PermissionMode = "default" | "accept_edits" | "yolo" | "auto";
 
+/** Stored chat turn author. Matches domain `MessageRole`. */
+export type MessageRole = "user" | "assistant";
+
 export interface Run {
   id: string;
   title: string;
@@ -78,7 +81,7 @@ export interface Run {
 }
 
 export interface RunMessage {
-  role: string;
+  role: MessageRole;
   content: string;
   createdAt: string;
 }
@@ -217,7 +220,7 @@ export type PlatformEvent =
   | { event: "run.title"; title?: string }
   | { event: "run.archived" }
   | { event: "run.status"; status?: RunStatus; headSha?: string }
-  | { event: "message.created"; role?: string; text?: string }
+  | { event: "message.created"; role?: MessageRole; text?: string }
   | {
       event: "approval.created";
       approvalId?: string;

--- a/cloud/crates/db/src/lib.rs
+++ b/cloud/crates/db/src/lib.rs
@@ -17,7 +17,7 @@ use zene_cloud_domain::{
     ApprovalDecision, ApprovalKind, ApprovalRequest, ApprovalRisk, ApprovalStatus, AuthResponse,
     CloneAuthResponse, CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest, LoginRequest, Organization,
     PlatformEvent, QueueActive, QueueHold, QueueStats, RegisterRequest, Repository, Run, RunEvent, RunEventKind, RunMessage,
-    RunStatus, PermissionMode, User, WorkerCommand, WorkerFence,
+    RunStatus, PermissionMode, MessageRole, User, WorkerCommand, WorkerFence,
 };
 
 #[derive(Clone)]
@@ -463,7 +463,7 @@ impl Db {
         .bind(msg_id.to_string())
         .bind(run.id.to_string())
         .bind(user_id.to_string())
-        .bind("user")
+        .bind(MessageRole::User.as_str())
         .bind(&req.prompt)
         .bind(now.to_rfc3339())
         .execute(&mut *tx)
@@ -1238,7 +1238,7 @@ impl Db {
         &self,
         run_id: Uuid,
         author_id: Option<Uuid>,
-        role: &str,
+        role: MessageRole,
         content: &str,
         client_message_id: Option<&str>,
     ) -> Result<RunMessage> {
@@ -1253,7 +1253,7 @@ impl Db {
         .bind(id.to_string())
         .bind(run_id.to_string())
         .bind(author_id.map(|v| v.to_string()))
-        .bind(role)
+        .bind(role.as_str())
         .bind(content)
         .bind(client_message_id)
         .bind(now.to_rfc3339())
@@ -1267,7 +1267,7 @@ impl Db {
             None,
             RunEventKind::Platform,
             platform_payload(PlatformEvent::MessageCreated {
-                role: role.to_string(),
+                role,
                 text: content.to_string(),
             }),
         )
@@ -1314,7 +1314,7 @@ impl Db {
             id,
             run_id,
             author_id,
-            role: role.into(),
+            role,
             content: content.into(),
             created_at: now,
         })
@@ -1334,7 +1334,7 @@ impl Db {
                 id: Uuid::parse_str(&id).unwrap(),
                 run_id: Uuid::parse_str(&run_id).unwrap(),
                 author_id: author_id.and_then(|v| Uuid::parse_str(&v).ok()),
-                role,
+                role: MessageRole::parse(&role).unwrap_or(MessageRole::Assistant),
                 content,
                 created_at: parse_time(&created_at),
             })

--- a/cloud/crates/db/tests/smoke.rs
+++ b/cloud/crates/db/tests/smoke.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 use zene_cloud_db::Db;
 use zene_cloud_domain::{
     ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, ApprovalStatus,
-    CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest, PermissionMode,
+    CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest, MessageRole, PermissionMode,
     RegisterRequest, RunEventKind, RunStatus, WorkerCommandKind, WorkerFence,
 };
 
@@ -279,7 +279,7 @@ async fn run_state_mutations_have_matching_events() {
     assert!(updated.finished_at.is_some());
 
     let message = db
-        .add_message(run.id, Some(auth.user.id), "user", "follow-up", None)
+        .add_message(run.id, Some(auth.user.id), MessageRole::User, "follow-up", None)
         .await
         .unwrap();
     assert_eq!(db.get_run(run.id).await.unwrap().unwrap().status, RunStatus::Queued);
@@ -445,7 +445,7 @@ async fn worker_command_is_retried_until_fenced_ack() {
     let claimed = db.claim_next_run("worker-delivery", std::path::Path::new("/tmp/zc-workspaces"))
         .await.unwrap().unwrap();
     let fence = WorkerFence { attempt_id: claimed.1, generation: claimed.2, worker_id: "worker-delivery".into() };
-    let message = db.add_message(run.id, Some(auth.user.id), "user", "follow-up", None).await.unwrap();
+    let message = db.add_message(run.id, Some(auth.user.id), MessageRole::User, "follow-up", None).await.unwrap();
     let commands = db.poll_worker_commands_fenced(run.id, &fence).await.unwrap();
     assert_eq!(commands.iter().filter_map(|command| command.message_id).collect::<Vec<_>>(), vec![message.id]);
     assert!(commands.iter().all(|command| command.kind == WorkerCommandKind::Prompt));
@@ -456,7 +456,7 @@ async fn worker_command_is_retried_until_fenced_ack() {
     db.ack_worker_command_fenced(run.id, &fence, message.id).await.unwrap();
     assert!(db.poll_worker_commands_fenced(run.id, &fence).await.unwrap().iter().all(|command| command.message_id != Some(message.id)));
 
-    let message = db.add_message(run.id, Some(auth.user.id), "user", "retry me", None).await.unwrap();
+    let message = db.add_message(run.id, Some(auth.user.id), MessageRole::User, "retry me", None).await.unwrap();
     let first_claim = chrono::Utc::now();
     let _ = db.poll_worker_commands_fenced_at(run.id, &fence, first_claim).await.unwrap();
     let retry = db.poll_worker_commands_fenced_at(

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -154,6 +154,31 @@ impl PermissionMode {
     }
 }
 
+/// Stored chat turn author. Matches Console bubble roles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageRole {
+    User,
+    Assistant,
+}
+
+impl MessageRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Assistant => "assistant",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "user" => Self::User,
+            "assistant" => Self::Assistant,
+            _ => return None,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Run {
@@ -471,7 +496,7 @@ pub enum PlatformEvent {
         head_sha: Option<String>,
     },
     #[serde(rename = "message.created")]
-    MessageCreated { role: String, text: String },
+    MessageCreated { role: MessageRole, text: String },
     #[serde(rename = "approval.created")]
     ApprovalCreated {
         approval_id: Id,
@@ -505,7 +530,7 @@ pub struct RunMessage {
     pub id: Id,
     pub run_id: Id,
     pub author_id: Option<Id>,
-    pub role: String,
+    pub role: MessageRole,
     pub content: String,
     pub created_at: DateTime<Utc>,
 }
@@ -656,7 +681,8 @@ pub struct WorkerEventRequest {
 mod tests {
     use super::{
         ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, ApprovalStatus,
-        CloudEventKind, CreateApprovalRequest, PlatformEvent, PermissionMode, ProjectionPayload,
+        CloudEventKind, CreateApprovalRequest, MessageRole, PlatformEvent, PermissionMode,
+        ProjectionPayload,
         RunEventKind, RunStatus, TextEventPayload, ToolCallPayload, WorkerCommand,
         WorkerCommandAckRequest, WorkerCommandKind, WorkerEventRequest, WorkerFence,
         WorkerClaimRequest, WorkerPushRequest, WorkerSessionRequest,
@@ -833,6 +859,29 @@ mod tests {
         assert!(PermissionMode::Auto.auto_resolves_approvals());
         assert!(!PermissionMode::AcceptEdits.auto_resolves_approvals());
         assert_eq!(PermissionMode::parse("manual"), None);
+    }
+
+    #[test]
+    fn message_role_round_trips_snake_case() {
+        for role in [MessageRole::User, MessageRole::Assistant] {
+            let encoded = serde_json::to_value(role).expect("serialize");
+            assert_eq!(encoded, serde_json::json!(role.as_str()));
+            assert_eq!(MessageRole::parse(role.as_str()), Some(role));
+        }
+        assert_eq!(MessageRole::parse("system"), None);
+        let encoded = serde_json::to_value(PlatformEvent::MessageCreated {
+            role: MessageRole::User,
+            text: "follow-up".into(),
+        })
+        .expect("message");
+        assert_eq!(
+            encoded,
+            serde_json::json!({
+                "event": "message.created",
+                "role": "user",
+                "text": "follow-up"
+            })
+        );
     }
 
     #[test]

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `4f32021`（PR #90 已合并）。**
+> **进度快照：2026-08-13，基线 `0736667`（PR #91 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是 Cloud `permission_mode` 使用 `PermissionMode`；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是 Cloud 消息 `role` 使用 `MessageRole`；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -1070,7 +1070,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          审批写入 payload 使用 ApprovalEventPayload
          projection_ready payload 使用 ProjectionPayload
          Console Run.status 使用 RunStatus
-         Cloud permission_mode 使用 PermissionMode（本轮）
+         Cloud permission_mode 使用 PermissionMode
+         Cloud 消息 role 使用 MessageRole（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1095,13 +1096,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | Cloud `permission_mode` 已是 `PermissionMode`；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | Cloud 消息 `role` 已是 `MessageRole`；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体；`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`，`ApprovalRequest.payload` 读出仍为 JSON；`projection_ready` 写入 `ProjectionPayload`；Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；Cloud `Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体；`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`，`ApprovalRequest.payload` 读出仍为 JSON；`projection_ready` 写入 `ProjectionPayload`；Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；Cloud `Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`；`RunMessage.role` 与 `PlatformEvent::MessageCreated.role` 使用 `MessageRole`；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1203,6 +1204,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeNotification.payload` 是 `RuntimePayload`（分类 kind 持有 domain 结构体，含 `ProjectionPayload`；未识别/提取失败为 `Json`）。审批请求 `context` 是 `ApprovalEventPayload`。`CreateApprovalRequest.payload` 同样是 `ApprovalEventPayload`；JobRunner 不再先转成 `Value`。`ApprovalRequest.payload` 与 `RunEvent.payload` 读出仍为 JSON。worker 内部控制 HTTP 使用 domain 请求类型；产品 runtime session 仍写入 `acp_session_id` 列。ACP `MockMsg` 与 `optionId` 只留在 adapter。
    - Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；审批平台事件的 `status` / `decision` / `kind` 使用已有产品枚举。`eventKind()` 返回 `RunEventType`，未知历史 kind 回落 `"acp"`。`RunEvent.event_type` 读出仍为字符串。不改 pill 文案/颜色，不改 Sidebar 过滤。
    - Cloud `Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`（`default` / `accept_edits` / `yolo` / 历史 `auto`）。`default` / `yolo` / `auto` 仍自动 resolve 审批；未知历史值读成 `accept_edits`（不自动批准、不启用 `--yolo`）。不补 SetMode。
+   - `RunMessage.role` 与 `PlatformEvent::MessageCreated.role` 使用 `MessageRole`（`user` / `assistant`）。未知历史值读成 `assistant`，与 Console `bubbleRole` 一致。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1417,4 +1419,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 - domain `PermissionMode` 用于 `Run.permission_mode` 与 `CreateRunRequest.permission_mode`。Console `Run.permissionMode` 对齐；composer 选择器仍只提供 `default` / `accept_edits` / `yolo`。
 - `default` / `yolo` / `auto` 仍自动 resolve 审批；worker 仅 `yolo` 传 `--yolo`。未知历史值读成 `accept_edits`。
 - 不补 SetMode。不把 `zene-runtime` 引入 Cloud。不改 CLI config 的 `permission_mode`。
+
+### 2026-08-13 — Cloud 消息 role
+
+- domain `MessageRole` 用于 `RunMessage.role`、`PlatformEvent::MessageCreated.role` 与 `add_message`。Console `RunMessage.role` 对齐。
+- 未知历史值读成 `assistant`，与 Console `bubbleRole` 一致。不改气泡布局。
+- 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #91 把 `permission_mode` 收成 `PermissionMode` 之后，消息 `role` 仍是裸字符串。本 PR 把它收成 domain `MessageRole`。

`RunMessage.role` 与 `PlatformEvent::MessageCreated.role` 使用 `MessageRole`（`user` / `assistant`）。`add_message` 写入该枚举。Console `RunMessage.role` 与 `bubbleRole` 对齐。未知历史值读成 `assistant`，与现有气泡回落一致。

不改气泡布局。不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-db -p zene-cloud-api --locked` 与 `cd cloud/apps/web && npm run typecheck` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

