### PR TITLE
feat: Cloud GitHub mode 使用 GithubMode

### DIFF
--- a/cloud/apps/api/src/routes.rs
+++ b/cloud/apps/api/src/routes.rs
@@ -12,7 +12,8 @@ use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 use zene_cloud_domain::{
     ClaimedRun, CreateApprovalRequest, CreatePullRequestBody, CreateRepositoryRequest,
-    CreateRunRequest, DecideApprovalRequest, GithubBranchSummary, GithubProviderConfigView,
+    CreateRunRequest, DecideApprovalRequest, GithubBranchSummary, GithubMode,
+    GithubProviderConfigView,
     LlmAuthResponse, LlmSettingsView, LoginRequest, PostMessageRequest, QueueStats, RegisterRequest,
     MessageRole, RunStatus, UpdateGithubProviderConfigRequest, UpdateLlmSettingsRequest, UpdateRunRequest,
     WorkerCommandAckRequest, WorkerCommandsResponse, WorkerEventRequest, WorkerFence,
@@ -120,7 +121,7 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
         "ok": true,
         "service": "zene-cloud-api",
         "version": env!("CARGO_PKG_VERSION"),
-        "githubMode": format!("{:?}", github.mode()).to_lowercase(),
+        "githubMode": github.mode(),
     }))
 }
 
@@ -150,7 +151,7 @@ async fn me(
         "user": user,
         "organization": org,
         "github": gh_account,
-        "githubMode": format!("{:?}", github.mode()).to_lowercase(),
+        "githubMode": github.mode(),
         "githubConfigured": github.config().is_app_configured(),
     })))
 }
@@ -308,7 +309,7 @@ async fn github_status(
         })
         .or_else(|| installations.first().map(|i| i.account_login.clone()));
     Ok(Json(serde_json::json!({
-        "mode": format!("{:?}", github.mode()).to_lowercase(),
+        "mode": github.mode(),
         "configured": github.config().is_app_configured(),
         "connected": connected,
         "account": account,
@@ -1256,7 +1257,7 @@ async fn clone_auth(
         .await
         .map_err(AppError::from)?;
     let github = state.github_client().await;
-    let mock = token.mode == "mock" || github.is_mock();
+    let mock = token.mode == GithubMode::Mock || github.is_mock();
     Ok(Json(zene_cloud_domain::CloneAuthResponse {
         run_id: run.id,
         repository_id: run.repository_id,

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -17,8 +17,11 @@ export interface GithubInstallation {
   accountLogin?: string;
 }
 
+/** GitHub integration mode. Matches domain `GithubMode`. */
+export type GithubMode = "mock" | "live";
+
 export interface GithubStatus {
-  mode?: string;
+  mode?: GithubMode;
   configured?: boolean;
   connected?: boolean;
   account?: GithubAccount | null;

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -681,8 +681,8 @@ pub struct WorkerEventRequest {
 mod tests {
     use super::{
         ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, ApprovalStatus,
-        CloudEventKind, CreateApprovalRequest, MessageRole, PlatformEvent, PermissionMode,
-        ProjectionPayload,
+        CloudEventKind, CreateApprovalRequest, GithubMode, MessageRole, PlatformEvent,
+        PermissionMode, ProjectionPayload,
         RunEventKind, RunStatus, TextEventPayload, ToolCallPayload, WorkerCommand,
         WorkerCommandAckRequest, WorkerCommandKind, WorkerEventRequest, WorkerFence,
         WorkerClaimRequest, WorkerPushRequest, WorkerSessionRequest,
@@ -882,6 +882,16 @@ mod tests {
                 "text": "follow-up"
             })
         );
+    }
+
+    #[test]
+    fn github_mode_round_trips_snake_case() {
+        for mode in [GithubMode::Mock, GithubMode::Live] {
+            let encoded = serde_json::to_value(mode).expect("serialize");
+            assert_eq!(encoded, serde_json::json!(mode.as_str()));
+            assert_eq!(GithubMode::parse(mode.as_str()), Some(mode));
+        }
+        assert_eq!(GithubMode::parse("other"), None);
     }
 
     #[test]
@@ -1377,6 +1387,14 @@ impl GithubMode {
             Self::Live => "live",
         }
     }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "mock" => Self::Mock,
+            "live" => Self::Live,
+            _ => return None,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1666,7 +1684,7 @@ pub struct CloneTokenResponse {
     pub token: String,
     pub clone_url: String,
     pub expires_at: DateTime<Utc>,
-    pub mode: String,
+    pub mode: GithubMode,
 }
 
 /// User-facing BYOK settings (never includes full api_key).

--- a/cloud/crates/git-broker/src/lib.rs
+++ b/cloud/crates/git-broker/src/lib.rs
@@ -61,7 +61,7 @@ impl GitBroker {
         let (token, mode) = if self.mode == GithubMode::Mock || self.github.is_mock() {
             (
                 format!("mock_clone_{}", &run.id.to_string()[..8]),
-                "mock".to_string(),
+                GithubMode::Mock,
             )
         } else {
             let installation_id = repo
@@ -69,7 +69,7 @@ impl GitBroker {
                 .as_deref()
                 .context("repository has no GitHub installation_id")?;
             let tok = self.github.installation_token(installation_id).await?;
-            (tok.token, "live".to_string())
+            (tok.token, GithubMode::Live)
         };
 
         self.db

--- a/cloud/crates/git-broker/tests/mock_flow.rs
+++ b/cloud/crates/git-broker/tests/mock_flow.rs
@@ -1,6 +1,7 @@
 use zene_cloud_db::Db;
 use zene_cloud_domain::{
-    CreatePullRequestBody, CreateRunRequest, GithubRepoSummary, PermissionMode, RegisterRequest,
+    CreatePullRequestBody, CreateRunRequest, GithubMode, GithubRepoSummary, PermissionMode,
+    RegisterRequest,
 };
 use zene_cloud_git_broker::GitBroker;
 
@@ -54,7 +55,7 @@ async fn mock_clone_push_and_draft_pr() {
 
     let broker = GitBroker::mock(db.clone());
     let token = broker.issue_read_clone_token(&run).await.unwrap();
-    assert_eq!(token.mode, "mock");
+    assert_eq!(token.mode, GithubMode::Mock);
     assert!(token.token.starts_with("mock_clone_"));
 
     let pushed = broker

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `0736667`（PR #91 已合并）。**
+> **进度快照：2026-08-13，基线 `2779b53`（PR #92 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是 Cloud 消息 `role` 使用 `MessageRole`；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是 Cloud GitHub `mode` 使用 `GithubMode`；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -1071,7 +1071,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          projection_ready payload 使用 ProjectionPayload
          Console Run.status 使用 RunStatus
          Cloud permission_mode 使用 PermissionMode
-         Cloud 消息 role 使用 MessageRole（本轮）
+         Cloud 消息 role 使用 MessageRole
+         Cloud GitHub mode 使用 GithubMode（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1096,13 +1097,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | Cloud 消息 `role` 已是 `MessageRole`；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | Cloud GitHub `mode` 已是 `GithubMode`；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体；`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`，`ApprovalRequest.payload` 读出仍为 JSON；`projection_ready` 写入 `ProjectionPayload`；Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；Cloud `Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`；`RunMessage.role` 与 `PlatformEvent::MessageCreated.role` 使用 `MessageRole`；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体；`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`，`ApprovalRequest.payload` 读出仍为 JSON；`projection_ready` 写入 `ProjectionPayload`；Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；Cloud `Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`；`RunMessage.role` 与 `PlatformEvent::MessageCreated.role` 使用 `MessageRole`；`CloneTokenResponse.mode` 与 Console `GithubStatus.mode` 使用已有 `GithubMode`；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1205,6 +1206,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；审批平台事件的 `status` / `decision` / `kind` 使用已有产品枚举。`eventKind()` 返回 `RunEventType`，未知历史 kind 回落 `"acp"`。`RunEvent.event_type` 读出仍为字符串。不改 pill 文案/颜色，不改 Sidebar 过滤。
    - Cloud `Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`（`default` / `accept_edits` / `yolo` / 历史 `auto`）。`default` / `yolo` / `auto` 仍自动 resolve 审批；未知历史值读成 `accept_edits`（不自动批准、不启用 `--yolo`）。不补 SetMode。
    - `RunMessage.role` 与 `PlatformEvent::MessageCreated.role` 使用 `MessageRole`（`user` / `assistant`）。未知历史值读成 `assistant`，与 Console `bubbleRole` 一致。
+   - `CloneTokenResponse.mode`、API `githubMode` / GitHub status `mode` 与 Console `GithubStatus.mode` 使用已有 `GithubMode`。不再用 Debug 格式拼 wire 字符串。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1424,5 +1426,11 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 - domain `MessageRole` 用于 `RunMessage.role`、`PlatformEvent::MessageCreated.role` 与 `add_message`。Console `RunMessage.role` 对齐。
 - 未知历史值读成 `assistant`，与 Console `bubbleRole` 一致。不改气泡布局。
+- 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
+
+### 2026-08-13 — Cloud GitHub mode
+
+- `CloneTokenResponse.mode` 使用已有 `GithubMode`。clone-auth 用枚举比较 mock。
+- API `githubMode` / GitHub status `mode` 直接序列化 `GithubMode`，不再 `format!("{:?}", …)`。Console `GithubStatus.mode` 对齐。
 - 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #92 把消息 `role` 收成 `MessageRole` 之后，GitHub `mode` 仍有裸字符串。本 PR 把剩余调用方接到已有 `GithubMode`。

`CloneTokenResponse.mode` 使用 `GithubMode`。clone-auth 用枚举比较 mock。API `githubMode` / GitHub status `mode` 直接序列化该枚举，不再 `format!("{:?}", …)`。Console `GithubStatus.mode` 对齐。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不改 Console 布局。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-git-broker -p zene-cloud-api --locked` 与 `cd cloud/apps/web && npm run typecheck` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

