### PR TITLE
feat: Cloud git/queue 剩余产品枚举一次收口

### DIFF
--- a/cloud/apps/api/src/routes.rs
+++ b/cloud/apps/api/src/routes.rs
@@ -12,8 +12,8 @@ use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 use zene_cloud_domain::{
     ClaimedRun, CreateApprovalRequest, CreatePullRequestBody, CreateRepositoryRequest,
-    CreateRunRequest, DecideApprovalRequest, GithubBranchSummary, GithubMode,
-    GithubProviderConfigView,
+    CreateRunRequest, DecideApprovalRequest, GithubAccountType, GithubBranchSummary,
+    GithubInstallationStatus, GithubMode, GithubProviderConfigView,
     LlmAuthResponse, LlmSettingsView, LoginRequest, PostMessageRequest, QueueStats, RegisterRequest,
     MessageRole, RunStatus, UpdateGithubProviderConfigRequest, UpdateLlmSettingsRequest, UpdateRunRequest,
     WorkerCommandAckRequest, WorkerCommandsResponse, WorkerEventRequest, WorkerFence,
@@ -394,8 +394,8 @@ async fn github_install_callback(
             org.id,
             &remote.id,
             &remote.account_login,
-            &remote.account_type,
-            "active",
+            remote.account_type,
+            GithubInstallationStatus::Active,
         )
         .await?;
     if !github.is_mock() {
@@ -533,8 +533,8 @@ async fn github_mock_connect(
             org.id,
             "10001",
             "mock-org",
-            "Organization",
-            "active",
+            GithubAccountType::Organization,
+            GithubInstallationStatus::Active,
         )
         .await?;
     let listed = github
@@ -578,7 +578,7 @@ async fn github_sync(
             .await?;
         let installation = state
             .db
-            .upsert_installation(org.id, "10001", "mock-org", "Organization", "active")
+            .upsert_installation(org.id, "10001", "mock-org", GithubAccountType::Organization, GithubInstallationStatus::Active)
             .await?;
         let listed = github
             .list_installation_repos("10001")
@@ -615,8 +615,8 @@ async fn github_sync(
                     org.id,
                     &remote.id,
                     &remote.account_login,
-                    &remote.account_type,
-                    "active",
+                    remote.account_type,
+                    GithubInstallationStatus::Active,
                 )
                 .await?;
             synced_installations.push(installation);
@@ -651,7 +651,7 @@ async fn github_mock_install(
     let org = state.db.primary_org(user.id).await?;
     let installation = state
         .db
-        .upsert_installation(org.id, "10001", "mock-org", "Organization", "active")
+        .upsert_installation(org.id, "10001", "mock-org", GithubAccountType::Organization, GithubInstallationStatus::Active)
         .await?;
     Ok(Json(installation))
 }

--- a/cloud/apps/web/components/GitPanel.tsx
+++ b/cloud/apps/web/components/GitPanel.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useState } from "react";
+import type { PullRequestState } from "@/lib/types";
 import { ChangesPanel } from "./ChangesPanel";
 import { CommitsPanel } from "./CommitsPanel";
 import { ReviewPanel } from "./ReviewPanel";
 
 export type GitSubTab = "diff" | "review" | "commits";
 
-function prStateClass(state?: string): string {
+function prStateClass(state?: PullRequestState | string): string {
   const s = (state || "").toLowerCase();
   if (s === "merged") return "bg-active text-ink";
   if (s === "open") return "bg-[#e6ffec] text-[#1a7f37]";
@@ -29,7 +30,7 @@ export function GitPanel({
   defaultBaseRef?: string;
   headBranch?: string;
   prUrl?: string;
-  prState?: string;
+  prState?: PullRequestState;
 }) {
   const [subTab, setSubTab] = useState<GitSubTab>("diff");
   const title = defaultTitle || "Changes";

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -15,10 +15,18 @@ export interface GithubAccount {
 
 export interface GithubInstallation {
   accountLogin?: string;
+  accountType?: GithubAccountType;
+  status?: GithubInstallationStatus;
 }
 
 /** GitHub integration mode. Matches domain `GithubMode`. */
 export type GithubMode = "mock" | "live";
+
+/** GitHub account kind stored on installations. Matches domain `GithubAccountType`. */
+export type GithubAccountType = "User" | "Organization";
+
+/** GitHub App installation status. Matches domain `GithubInstallationStatus`. */
+export type GithubInstallationStatus = "active" | "suspended";
 
 export interface GithubStatus {
   mode?: GithubMode;
@@ -295,11 +303,14 @@ export interface GitCommit {
   authoredAt: string;
 }
 
+/** Stored pull-request lifecycle. Matches domain `PullRequestState`. */
+export type PullRequestState = "open" | "closed" | "merged" | "draft";
+
 export interface PullRequest {
   title: string;
   url?: string;
   providerNumber?: number;
-  state: string;
+  state: PullRequestState;
   draft?: boolean;
 }
 

--- a/cloud/crates/db/src/github.rs
+++ b/cloud/crates/db/src/github.rs
@@ -3,7 +3,8 @@ use chrono::{Duration, Utc};
 use uuid::Uuid;
 use zene_cloud_domain::{
     ApprovalDecision, ApprovalRequest, AuditLog, GitOperation, GitOperationKind, GitOperationStatus,
-    GithubAccount, GithubInstallation, GithubRepoSummary, OauthState, PullRequest, Repository,
+    GithubAccount, GithubAccountType, GithubInstallation, GithubInstallationStatus, GithubRepoSummary,
+    OauthState, PullRequest, PullRequestState, Repository,
 };
 
 use crate::{parse_time, Db};
@@ -185,8 +186,8 @@ impl Db {
         organization_id: Uuid,
         installation_id: &str,
         account_login: &str,
-        account_type: &str,
-        status: &str,
+        account_type: GithubAccountType,
+        status: GithubInstallationStatus,
     ) -> Result<GithubInstallation> {
         let now = Utc::now();
         let existing: Option<(String, String)> = sqlx::query_as(
@@ -204,8 +205,8 @@ impl Db {
             )
             .bind(organization_id.to_string())
             .bind(account_login)
-            .bind(account_type)
-            .bind(status)
+            .bind(account_type.as_str())
+            .bind(status.as_str())
             .bind(now.to_rfc3339())
             .bind(&id)
             .execute(&self.pool)
@@ -223,8 +224,8 @@ impl Db {
             .bind(organization_id.to_string())
             .bind(installation_id)
             .bind(account_login)
-            .bind(account_type)
-            .bind(status)
+            .bind(account_type.as_str())
+            .bind(status.as_str())
             .bind(now.to_rfc3339())
             .bind(now.to_rfc3339())
             .execute(&self.pool)
@@ -236,8 +237,8 @@ impl Db {
             organization_id,
             installation_id: installation_id.into(),
             account_login: account_login.into(),
-            account_type: account_type.into(),
-            status: status.into(),
+            account_type,
+            status,
             created_at,
             updated_at: now,
         })
@@ -259,16 +260,7 @@ impl Db {
             .await?;
         Ok(rows
             .into_iter()
-            .map(|r| GithubInstallation {
-                id: Uuid::parse_str(&r.0).unwrap(),
-                organization_id: Uuid::parse_str(&r.1).unwrap(),
-                installation_id: r.2,
-                account_login: r.3,
-                account_type: r.4,
-                status: r.5,
-                created_at: parse_time(&r.6),
-                updated_at: parse_time(&r.7),
-            })
+            .map(installation_from_row)
             .collect())
     }
 
@@ -285,16 +277,7 @@ impl Db {
             .bind(installation_id)
             .fetch_optional(&self.pool)
             .await?;
-        Ok(row.map(|r| GithubInstallation {
-            id: Uuid::parse_str(&r.0).unwrap(),
-            organization_id: Uuid::parse_str(&r.1).unwrap(),
-            installation_id: r.2,
-            account_login: r.3,
-            account_type: r.4,
-            status: r.5,
-            created_at: parse_time(&r.6),
-            updated_at: parse_time(&r.7),
-        }))
+        Ok(row.map(installation_from_row))
     }
 
     /// Upsert repositories discovered from a GitHub installation listing.
@@ -599,7 +582,7 @@ impl Db {
         url: Option<&str>,
         base_sha: Option<&str>,
         head_sha: Option<&str>,
-        state: &str,
+        state: PullRequestState,
         draft: bool,
     ) -> Result<PullRequest> {
         let id = Uuid::new_v4();
@@ -619,7 +602,7 @@ impl Db {
         .bind(body)
         .bind(base_sha)
         .bind(head_sha)
-        .bind(state)
+        .bind(state.as_str())
         .bind(if draft { 1 } else { 0 })
         .bind(now.to_rfc3339())
         .execute(&self.pool)
@@ -634,7 +617,7 @@ impl Db {
             body: body.map(|s| s.into()),
             base_sha: base_sha.map(|s| s.into()),
             head_sha: head_sha.map(|s| s.into()),
-            state: state.into(),
+            state,
             draft,
             created_at: now,
         })
@@ -689,7 +672,7 @@ impl Db {
                         body,
                         base_sha,
                         head_sha,
-                        state,
+                        state: PullRequestState::parse(&state).unwrap_or(PullRequestState::Open),
                         draft: draft != 0,
                         created_at: parse_time(&created_at),
                     }
@@ -973,6 +956,22 @@ impl Db {
             .execute(&self.pool)
             .await?;
         Ok(())
+    }
+}
+
+fn installation_from_row(
+    row: (String, String, String, String, String, String, String, String),
+) -> GithubInstallation {
+    GithubInstallation {
+        id: Uuid::parse_str(&row.0).unwrap(),
+        organization_id: Uuid::parse_str(&row.1).unwrap(),
+        installation_id: row.2,
+        account_login: row.3,
+        account_type: GithubAccountType::parse(&row.4).unwrap_or(GithubAccountType::Organization),
+        status: GithubInstallationStatus::parse(&row.5)
+            .unwrap_or(GithubInstallationStatus::Active),
+        created_at: parse_time(&row.6),
+        updated_at: parse_time(&row.7),
     }
 }
 

--- a/cloud/crates/db/src/lib.rs
+++ b/cloud/crates/db/src/lib.rs
@@ -995,7 +995,7 @@ impl Db {
                 Some(QueueActive {
                     worker_id,
                     run_id,
-                    status,
+                    status: RunStatus::parse(&status).unwrap_or(RunStatus::Failed),
                 })
             })
             .collect::<Vec<_>>();

--- a/cloud/crates/db/tests/github_git.rs
+++ b/cloud/crates/db/tests/github_git.rs
@@ -1,7 +1,8 @@
 use zene_cloud_db::Db;
 use zene_cloud_domain::{
     CreateRepositoryRequest, CreateRunRequest, GitOperationKind, GitOperationStatus,
-    GithubRepoSummary, PermissionMode, RegisterRequest,
+    GithubAccountType, GithubInstallationStatus, GithubRepoSummary, PermissionMode, PullRequestState,
+    RegisterRequest,
 };
 
 #[tokio::test]
@@ -41,7 +42,7 @@ async fn github_crud_and_migrations() {
     assert_eq!(account.login, "octocat");
 
     let inst = db
-        .upsert_installation(auth.organization.id, "999", "acme", "Organization", "active")
+        .upsert_installation(auth.organization.id, "999", "acme", GithubAccountType::Organization, GithubInstallationStatus::Active)
         .await
         .unwrap();
     assert_eq!(inst.installation_id, "999");
@@ -116,7 +117,7 @@ async fn github_crud_and_migrations() {
             Some("https://github.com/acme/app/pull/7"),
             None,
             Some("def456"),
-            "draft",
+            PullRequestState::Draft,
             true,
         )
         .await

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -652,7 +652,7 @@ pub struct QueueHold {
 pub struct QueueActive {
     pub worker_id: String,
     pub run_id: Id,
-    pub status: String,
+    pub status: RunStatus,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -681,8 +681,9 @@ pub struct WorkerEventRequest {
 mod tests {
     use super::{
         ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, ApprovalStatus,
-        CloudEventKind, CreateApprovalRequest, GithubMode, MessageRole, PlatformEvent,
-        PermissionMode, ProjectionPayload,
+        CloudEventKind, CreateApprovalRequest, GithubAccountType, GithubInstallationStatus,
+        GithubMode, MessageRole, PlatformEvent, PermissionMode, ProjectionPayload,
+        PullRequestState,
         RunEventKind, RunStatus, TextEventPayload, ToolCallPayload, WorkerCommand,
         WorkerCommandAckRequest, WorkerCommandKind, WorkerEventRequest, WorkerFence,
         WorkerClaimRequest, WorkerPushRequest, WorkerSessionRequest,
@@ -892,6 +893,32 @@ mod tests {
             assert_eq!(GithubMode::parse(mode.as_str()), Some(mode));
         }
         assert_eq!(GithubMode::parse("other"), None);
+    }
+
+    #[test]
+    fn git_product_enums_round_trip_wire_strings() {
+        for state in [
+            PullRequestState::Open,
+            PullRequestState::Closed,
+            PullRequestState::Merged,
+            PullRequestState::Draft,
+        ] {
+            let encoded = serde_json::to_value(state).expect("serialize");
+            assert_eq!(encoded, serde_json::json!(state.as_str()));
+            assert_eq!(PullRequestState::parse(state.as_str()), Some(state));
+        }
+        let encoded = serde_json::to_value(GithubAccountType::Organization).expect("account");
+        assert_eq!(encoded, serde_json::json!("Organization"));
+        assert_eq!(
+            GithubAccountType::parse("User"),
+            Some(GithubAccountType::User)
+        );
+        let encoded = serde_json::to_value(GithubInstallationStatus::Active).expect("status");
+        assert_eq!(encoded, serde_json::json!("active"));
+        assert_eq!(
+            GithubInstallationStatus::parse("suspended"),
+            Some(GithubInstallationStatus::Suspended)
+        );
     }
 
     #[test]
@@ -1397,6 +1424,57 @@ impl GithubMode {
     }
 }
 
+/// GitHub account kind stored on installations. Wire JSON stays `User` / `Organization`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum GithubAccountType {
+    User,
+    #[default]
+    Organization,
+}
+
+impl GithubAccountType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "User",
+            Self::Organization => "Organization",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "User" | "user" => Self::User,
+            "Organization" | "organization" => Self::Organization,
+            _ => return None,
+        })
+    }
+}
+
+/// GitHub App installation status. Wire JSON stays snake_case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum GithubInstallationStatus {
+    #[default]
+    Active,
+    Suspended,
+}
+
+impl GithubInstallationStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Suspended => "suspended",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "active" => Self::Active,
+            "suspended" => Self::Suspended,
+            _ => return None,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GithubAccount {
@@ -1418,8 +1496,8 @@ pub struct GithubInstallation {
     pub organization_id: Id,
     pub installation_id: String,
     pub account_login: String,
-    pub account_type: String,
-    pub status: String,
+    pub account_type: GithubAccountType,
+    pub status: GithubInstallationStatus,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -1516,6 +1594,37 @@ pub struct GitOperation {
     pub finished_at: Option<DateTime<Utc>>,
 }
 
+/// Stored pull-request lifecycle. Mock rows may use `draft`; GitHub live rows use `open` / `closed`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PullRequestState {
+    Open,
+    Closed,
+    Merged,
+    Draft,
+}
+
+impl PullRequestState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Closed => "closed",
+            Self::Merged => "merged",
+            Self::Draft => "draft",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        Some(match value {
+            "open" => Self::Open,
+            "closed" => Self::Closed,
+            "merged" => Self::Merged,
+            "draft" => Self::Draft,
+            _ => return None,
+        })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PullRequest {
@@ -1528,7 +1637,7 @@ pub struct PullRequest {
     pub body: Option<String>,
     pub base_sha: Option<String>,
     pub head_sha: Option<String>,
-    pub state: String,
+    pub state: PullRequestState,
     pub draft: bool,
     pub created_at: DateTime<Utc>,
 }
@@ -1601,18 +1710,10 @@ pub struct GithubOauthCallbackRequest {
 pub struct UpsertInstallationRequest {
     pub installation_id: String,
     pub account_login: String,
-    #[serde(default = "default_account_type")]
-    pub account_type: String,
-    #[serde(default = "default_installation_status")]
-    pub status: String,
-}
-
-fn default_account_type() -> String {
-    "Organization".into()
-}
-
-fn default_installation_status() -> String {
-    "active".into()
+    #[serde(default)]
+    pub account_type: GithubAccountType,
+    #[serde(default)]
+    pub status: GithubInstallationStatus,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/cloud/crates/git-broker/src/lib.rs
+++ b/cloud/crates/git-broker/src/lib.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 use zene_cloud_db::Db;
 use zene_cloud_domain::{
     AcceptBundleResult, CloneTokenResponse, CreatePullRequestBody, GitOperationKind,
-    GitOperationStatus, GithubMode, PullRequest, Run,
+    GitOperationStatus, GithubMode, PullRequest, PullRequestState, Run,
 };
 use zene_cloud_github::{CreatePullRequestParams, GithubClient};
 
@@ -273,7 +273,11 @@ impl GitBroker {
                 remote.url.as_deref(),
                 run.base_sha.as_deref(),
                 run.head_sha.as_deref(),
-                if draft { "draft" } else { "open" },
+                if draft {
+                    PullRequestState::Draft
+                } else {
+                    PullRequestState::Open
+                },
                 draft,
             )
             .await?;

--- a/cloud/crates/git-broker/tests/mock_flow.rs
+++ b/cloud/crates/git-broker/tests/mock_flow.rs
@@ -1,7 +1,7 @@
 use zene_cloud_db::Db;
 use zene_cloud_domain::{
-    CreatePullRequestBody, CreateRunRequest, GithubMode, GithubRepoSummary, PermissionMode,
-    RegisterRequest,
+    CreatePullRequestBody, CreateRunRequest, GithubAccountType, GithubInstallationStatus,
+    GithubMode, GithubRepoSummary, PermissionMode, RegisterRequest,
 };
 use zene_cloud_git_broker::GitBroker;
 
@@ -17,7 +17,7 @@ async fn mock_clone_push_and_draft_pr() {
         })
         .await
         .unwrap();
-    db.upsert_installation(auth.organization.id, "1", "acme", "Organization", "active")
+    db.upsert_installation(auth.organization.id, "1", "acme", GithubAccountType::Organization, GithubInstallationStatus::Active)
         .await
         .unwrap();
     let repos = db

--- a/cloud/crates/github/src/client.rs
+++ b/cloud/crates/github/src/client.rs
@@ -1,6 +1,8 @@
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
-use zene_cloud_domain::{GithubRepoSummary, GithubUser, PullRequest};
+use zene_cloud_domain::{
+    GithubAccountType, GithubRepoSummary, GithubUser, PullRequest, PullRequestState,
+};
 
 use crate::app::{GithubAppAuth, InstallationToken};
 use crate::oauth::{self, OauthConfig, OauthTokens};
@@ -10,7 +12,7 @@ use crate::types::{CreatePullRequestParams, GithubConfig, ListedRepo};
 pub struct AppInstallation {
     pub id: String,
     pub account_login: String,
-    pub account_type: String,
+    pub account_type: GithubAccountType,
 }
 
 #[derive(Clone)]
@@ -129,7 +131,7 @@ impl GithubClient {
             return Ok(AppInstallation {
                 id: installation_id.into(),
                 account_login: "mock-org".into(),
-                account_type: "Organization".into(),
+                account_type: GithubAccountType::Organization,
             });
         }
 
@@ -168,7 +170,7 @@ impl GithubClient {
         Ok(AppInstallation {
             id: body.id.to_string(),
             account_login: body.account.login,
-            account_type: body.account.account_type,
+            account_type: github_account_type(&body.account.account_type),
         })
     }
 
@@ -177,7 +179,7 @@ impl GithubClient {
             return Ok(vec![AppInstallation {
                 id: "10001".into(),
                 account_login: "mock-org".into(),
-                account_type: "Organization".into(),
+                account_type: GithubAccountType::Organization,
             }]);
         }
 
@@ -222,7 +224,7 @@ impl GithubClient {
                 out.push(AppInstallation {
                     id: inst.id.to_string(),
                     account_login: inst.account.login,
-                    account_type: inst.account.account_type,
+                    account_type: github_account_type(&inst.account.account_type),
                 });
             }
             if count < 100 {
@@ -441,9 +443,9 @@ impl GithubClient {
                 base_sha: None,
                 head_sha: None,
                 state: if params.draft {
-                    "draft".into()
+                    PullRequestState::Draft
                 } else {
-                    "open".into()
+                    PullRequestState::Open
                 },
                 draft: params.draft,
                 created_at: chrono::Utc::now(),
@@ -507,9 +509,21 @@ impl GithubClient {
             body: pr.body,
             base_sha: None,
             head_sha: None,
-            state: pr.state,
+            state: pull_request_state(&pr.state, pr.draft.unwrap_or(params.draft)),
             draft: pr.draft.unwrap_or(params.draft),
             created_at: chrono::Utc::now(),
         })
     }
+}
+
+fn github_account_type(value: &str) -> GithubAccountType {
+    GithubAccountType::parse(value).unwrap_or(GithubAccountType::Organization)
+}
+
+fn pull_request_state(value: &str, draft: bool) -> PullRequestState {
+    PullRequestState::parse(value).unwrap_or(if draft {
+        PullRequestState::Draft
+    } else {
+        PullRequestState::Open
+    })
 }

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `2779b53`（PR #92 已合并）。**
+> **进度快照：2026-08-13，基线 `bbb7030`（PR #93 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是 Cloud GitHub `mode` 使用 `GithubMode`；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 当前工作是 Cloud git/queue 剩余产品枚举一次收口；Steer/SetMode 与整型 crate 仍未做。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -1072,7 +1072,8 @@ Wave 16  统一 transport command/event  ← 当前工作
          Console Run.status 使用 RunStatus
          Cloud permission_mode 使用 PermissionMode
          Cloud 消息 role 使用 MessageRole
-         Cloud GitHub mode 使用 GithubMode（本轮）
+         Cloud GitHub mode 使用 GithubMode
+         Cloud git/queue 剩余产品枚举一次收口（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
 ```
@@ -1097,13 +1098,13 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | Cloud GitHub `mode` 已是 `GithubMode`；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 进行中 | Cloud git/queue 剩余产品枚举已收口；Steer/SetMode 与整型 crate 仍待统一 |
 
 ### 当前收口状态与剩余边界
 
 本轮已完成仓库内可以安全验证的主要优化，并保持旧协议兼容。当前剩余项分为三类：
 
-- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体；`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`，`ApprovalRequest.payload` 读出仍为 JSON；`projection_ready` 写入 `ProjectionPayload`；Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；Cloud `Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`；`RunMessage.role` 与 `PlatformEvent::MessageCreated.role` 使用 `MessageRole`；`CloneTokenResponse.mode` 与 Console `GithubStatus.mode` 使用已有 `GithubMode`；未识别帧仍为 ACP JSON。
+- **本轮已完成的审批/事件收口**：runtime-owned waiter 与 Cloud `RuntimeCommand::Approval`；已分类 Cloud payload 与审批表 payload 已是产品字段（domain 结构体）；平台事件 payload 同样是 domain `PlatformEvent`（`run.status` 带 `headSha`）；写入路径 `event_type` 是 domain `RunEventKind`（`RunEvent` 读出仍为字符串）；`RuntimeRequest::Approval.allowed_decisions` 来自 ACP options，JobRunner 不再写死三按钮；API→worker `WorkerCommand` 为 Prompt/Cancel；Cloud 审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；产品审批类型不再携带 `jsonrpc_id`；domain `CloudEventKind` 与 Console 时间线共用分类结果；JobRunner mock 与真实 ACP 共用同一条 runtime session（event / command / hold）；worker 内部控制 HTTP 使用 domain 请求类型，产品 runtime session 写入 `acp_session_id` 列；`RuntimeNotification.payload` 与 `RuntimeRequest` 审批 context 在内存中是 domain 结构体；`CreateApprovalRequest.payload` 是 `ApprovalEventPayload`，`ApprovalRequest.payload` 读出仍为 JSON；`projection_ready` 写入 `ProjectionPayload`；Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；Cloud `Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`；`RunMessage.role` 与 `PlatformEvent::MessageCreated.role` 使用 `MessageRole`；`CloneTokenResponse.mode` 与 Console `GithubStatus.mode` 使用已有 `GithubMode`；`QueueActive.status` 使用 `RunStatus`；`PullRequest.state` 使用 `PullRequestState`；installation `account_type` / `status` 使用 `GithubAccountType` / `GithubInstallationStatus`；未识别帧仍为 ACP JSON。
 - **可继续做但需要协议的产品面解耦**：本地/Cloud 统一 `RuntimeCommand`/`RuntimeEvent`、`RuntimeScope`。这些改动跨 transport，不应通过局部兼容代码伪装完成。
 - **需要部署基础设施决策**：本地 EventOutbox 不能单独提供跨 VM durability。跨 VM replacement 必须使用共享 POSIX 持久卷，或实现 DB/object-backed spool。
 
@@ -1207,6 +1208,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - Cloud `Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`（`default` / `accept_edits` / `yolo` / 历史 `auto`）。`default` / `yolo` / `auto` 仍自动 resolve 审批；未知历史值读成 `accept_edits`（不自动批准、不启用 `--yolo`）。不补 SetMode。
    - `RunMessage.role` 与 `PlatformEvent::MessageCreated.role` 使用 `MessageRole`（`user` / `assistant`）。未知历史值读成 `assistant`，与 Console `bubbleRole` 一致。
    - `CloneTokenResponse.mode`、API `githubMode` / GitHub status `mode` 与 Console `GithubStatus.mode` 使用已有 `GithubMode`。不再用 Debug 格式拼 wire 字符串。
+   - `QueueActive.status` 使用 `RunStatus`。`PullRequest.state` 使用 `PullRequestState`（含 mock `draft`）。installation `account_type` / `status` 使用 `GithubAccountType`（`User` / `Organization`）与 `GithubInstallationStatus`。未知历史值分别读成 `failed` / `open` / `Organization` / `active`。
    - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
 
 8. **持续质量门槛**
@@ -1433,4 +1435,10 @@ Wave 16  统一 transport command/event  ← 当前工作
 - `CloneTokenResponse.mode` 使用已有 `GithubMode`。clone-auth 用枚举比较 mock。
 - API `githubMode` / GitHub status `mode` 直接序列化 `GithubMode`，不再 `format!("{:?}", …)`。Console `GithubStatus.mode` 对齐。
 - 不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
+
+### 2026-08-13 — Cloud git/queue 剩余产品枚举
+
+- `QueueActive.status` 使用 `RunStatus`。`PullRequest.state` 使用 `PullRequestState`（`open` / `closed` / `merged` / mock `draft`）。Console GitPanel 对齐，不改颜色。
+- installation `account_type` / `status` 使用 `GithubAccountType`（wire 仍为 `User` / `Organization`）与 `GithubInstallationStatus`。
+- 未知历史值分别读成 `failed` / `open` / `Organization` / `active`。不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #93 把 GitHub `mode` 收成 `GithubMode` 之后，queue / PR / installation 仍有裸字符串。本 PR 把 Cloud 自有的剩余 git/queue 产品字段一次收口，不再拆成单字段小 PR。

`QueueActive.status` 使用已有 `RunStatus`。`PullRequest.state` 使用 `PullRequestState`（`open` / `closed` / `merged` / mock `draft`）。installation `account_type` / `status` 使用 `GithubAccountType`（wire 仍为 GitHub PascalCase `User` / `Organization`）与 `GithubInstallationStatus`。未知历史值分别读成 `failed` / `open` / `Organization` / `active`。Console GitPanel 对齐，不改颜色。

不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。不改 GitPanel 颜色。不迁 `acp_session_id`。

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-db -p zene-cloud-github -p zene-cloud-git-broker -p zene-cloud-api --locked`、`cd cloud && cargo test -p zene-cloud-worker --locked --no-run` 与 `cd cloud/apps/web && npm run typecheck` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

