### PR TITLE
feat: Cloud Steer/SetMode 一次对齐

### DIFF
--- a/apps/cli/src/acp/mod.rs
+++ b/apps/cli/src/acp/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Speaks JSON-RPC 2.0 NDJSON over stdin/stdout:
 //! `initialize`, `session/new`, `session/load`, `session/resume`, `session/list`,
-//! `session/close`, `session/set_mode`, `session/prompt`, `session/cancel`,
+//! `session/close`, `session/set_mode`, `session/steer`, `session/prompt`, `session/cancel`,
 //! plus outbound `session/update` notifications
 //! (`agent_message_chunk`, `agent_thought_chunk`, `user_message_chunk`, `tool_call`,
 //! `tool_call_update`, `plan`, `current_mode_update`, `available_commands_update`,

--- a/apps/cli/src/acp/server.rs
+++ b/apps/cli/src/acp/server.rs
@@ -290,6 +290,7 @@ impl AcpServer {
             "session/list" => self.handle_session_list(params),
             "session/close" => self.handle_session_close(params).await,
             "session/set_mode" => self.handle_session_set_mode(params).await,
+            "session/steer" => self.handle_session_steer(params).await,
             "authenticate" => Ok(json!({})),
             "session/prompt" => Err(anyhow!(
                 "session/prompt is handled by the async prompt queue"
@@ -485,6 +486,29 @@ impl AcpServer {
         let active = sess.runtime.set_mode(mode_id).await?;
         self.writer
             .session_update(&sid, current_mode_update(&active))?;
+        Ok(json!({}))
+    }
+
+    async fn handle_session_steer(&mut self, params: Value) -> Result<Value> {
+        let sid = params
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("sessionId required"))?
+            .to_string();
+        let text = params
+            .get("text")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| prompt_text_from_params(&params));
+        if text.trim().is_empty() {
+            bail!("text required");
+        }
+        let sess = self
+            .sessions
+            .get_mut(&sid)
+            .ok_or_else(|| anyhow!("unknown sessionId: {sid}"))?;
+        sess.runtime.steer(text).await?;
         Ok(json!({}))
     }
 

--- a/cloud/apps/api/src/routes.rs
+++ b/cloud/apps/api/src/routes.rs
@@ -15,7 +15,7 @@ use zene_cloud_domain::{
     CreateRunRequest, DecideApprovalRequest, GithubAccountType, GithubBranchSummary,
     GithubInstallationStatus, GithubMode, GithubProviderConfigView,
     LlmAuthResponse, LlmSettingsView, LoginRequest, PostMessageRequest, QueueStats, RegisterRequest,
-    MessageRole, RunStatus, UpdateGithubProviderConfigRequest, UpdateLlmSettingsRequest, UpdateRunRequest,
+    MessageRole, RunStatus, SetRunModeRequest, UpdateGithubProviderConfigRequest, UpdateLlmSettingsRequest, UpdateRunRequest,
     WorkerCommandAckRequest, WorkerCommandsResponse, WorkerEventRequest, WorkerFence,
     WorkerSessionRequest, WorkerClaimRequest, WorkerPullRequestRequest, WorkerPushRequest,
     WorkerStatusRequest, WorkerTitleRequest,
@@ -61,6 +61,7 @@ pub fn router(state: AppState) -> Router {
             "/api/v1/runs/{run_id}/messages",
             get(list_messages).post(post_message),
         )
+        .route("/api/v1/runs/{run_id}/mode", post(set_run_mode))
         .route("/api/v1/runs/{run_id}/events", get(list_events))
         .route("/api/v1/runs/{run_id}/events/stream", get(stream_events))
         .route("/api/v1/runs/{run_id}/cancel", post(cancel_run))
@@ -99,6 +100,8 @@ pub fn router(state: AppState) -> Router {
         .route("/internal/v1/runs/{run_id}/llm-auth", get(llm_auth))
         .route("/internal/v1/runs/{run_id}/commands", get(worker_commands))
         .route("/internal/v1/runs/{run_id}/commands/ack", post(worker_command_ack))
+        .route("/internal/v1/runs/{run_id}/mode", post(worker_set_pending_mode))
+        .route("/internal/v1/runs/{run_id}/mode/take", post(worker_take_pending_mode))
         .route(
             "/internal/v1/runs/{run_id}/approvals",
             post(create_approval),
@@ -829,6 +832,23 @@ async fn post_message(
     ))
 }
 
+async fn set_run_mode(
+    State(state): State<AppState>,
+    AuthUser(user): AuthUser,
+    Path(run_id): Path<Uuid>,
+    Json(req): Json<SetRunModeRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let run = authorize_run(&state, user.id, run_id).await?;
+    if !run.status.accepts_messages() {
+        return Err(AppError::conflict(format!(
+            "run status {} does not accept mode changes",
+            run.status.as_str()
+        )));
+    }
+    state.db.set_pending_mode(run_id, &req.mode_id).await?;
+    Ok(Json(serde_json::json!({ "ok": true, "modeId": req.mode_id.trim() })))
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct EventsQuery {
@@ -1276,9 +1296,28 @@ async fn worker_commands(
     Path(run_id): Path<Uuid>,
     Query(req): Query<WorkerFence>,
 ) -> Result<impl IntoResponse, AppError> {
-    Ok(Json(WorkerCommandsResponse {
-        commands: state.db.poll_worker_commands_fenced(run_id, &req).await?,
-    }))
+    let commands = state.db.poll_worker_commands_fenced(run_id, &req).await?;
+    let mode_id = state.db.take_pending_mode(run_id).await?;
+    Ok(Json(WorkerCommandsResponse { commands, mode_id }))
+}
+
+async fn worker_set_pending_mode(
+    State(state): State<AppState>,
+    _worker: WorkerAuth,
+    Path(run_id): Path<Uuid>,
+    Json(req): Json<SetRunModeRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    state.db.set_pending_mode(run_id, &req.mode_id).await?;
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+async fn worker_take_pending_mode(
+    State(state): State<AppState>,
+    _worker: WorkerAuth,
+    Path(run_id): Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let mode_id = state.db.take_pending_mode(run_id).await?;
+    Ok(Json(serde_json::json!({ "modeId": mode_id })))
 }
 
 async fn worker_command_ack(
@@ -1554,6 +1593,7 @@ mod reconnect_replay_tests {
                     model: "default".into(),
                     permission_mode: PermissionMode::Default,
                     max_turns: 10,
+                    mode_id: None,
                 }),
             )
             .await

--- a/cloud/apps/worker/src/main.rs
+++ b/cloud/apps/worker/src/main.rs
@@ -23,7 +23,7 @@ use zene_cloud_runtime_client::{
 use zene_cloud_domain::{
     ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRequest, ApprovalRisk,
     ApprovalStatus, ClaimedRun, CloneAuthResponse, CreateApprovalRequest, LlmAuthResponse,
-    PermissionMode, RunStatus, WorkerClaimRequest, WorkerCommand, WorkerCommandAckRequest,
+    PermissionMode, RunStatus, WorkerClaimRequest, WorkerCommandAckRequest,
     WorkerCommandKind, WorkerCommandsResponse, WorkerEventRequest, WorkerFence, WorkerPullRequestRequest,
     WorkerPushRequest, WorkerSessionRequest, WorkerStatusRequest, WorkerTitleRequest,
 };
@@ -735,12 +735,41 @@ fn spawn_command_poller<R: RuntimeClient + 'static>(
     fence: WorkerFence,
     cancelled: Arc<AtomicBool>,
     last_activity: Arc<tokio::sync::Mutex<tokio::time::Instant>>,
+    turn_busy: Arc<AtomicBool>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         loop {
             match fetch_commands(&client, &api_url, &token, run_id, &fence).await {
-                Ok(commands) => {
-                    for cmd in commands {
+                Ok(response) => {
+                    if let Some(mode_id) = response.mode_id {
+                        if turn_busy.load(Ordering::SeqCst) {
+                            // SetMode is idle-only; put the mode back until the turn ends.
+                            let _ = set_pending_mode(
+                                &client, &api_url, &token, run_id, &mode_id,
+                            )
+                            .await;
+                        } else {
+                            match runtime
+                                .send(RuntimeCommand::SetMode {
+                                    mode_id: mode_id.clone(),
+                                })
+                                .await
+                            {
+                                Ok(()) => {
+                                    let mut ts = last_activity.lock().await;
+                                    *ts = tokio::time::Instant::now();
+                                }
+                                Err(err) => {
+                                    warn!(error = %err, "set_mode failed; re-queue pending mode");
+                                    let _ = set_pending_mode(
+                                        &client, &api_url, &token, run_id, &mode_id,
+                                    )
+                                    .await;
+                                }
+                            }
+                        }
+                    }
+                    for cmd in response.commands {
                         if cmd.kind == WorkerCommandKind::Cancel {
                             cancelled.store(true, Ordering::SeqCst);
                             let _ = runtime.send(RuntimeCommand::Cancel).await;
@@ -752,50 +781,84 @@ fn spawn_command_poller<R: RuntimeClient + 'static>(
                                     let mut ts = last_activity.lock().await;
                                     *ts = tokio::time::Instant::now();
                                 }
-                                let _ = set_status_raw(
-                                    &client,
-                                    &api_url,
-                                    &token,
-                                    run_id,
-                                    &fence,
-                                    RunStatus::Running,
-                                )
-                                .await;
-                                match runtime.send(RuntimeCommand::Prompt { text }).await {
-                                    Ok(()) => {
-                                        if let Some(message_id) = cmd.message_id {
-                                            if let Err(err) = ack_command(
-                                                &client,
-                                                &api_url,
-                                                &token,
-                                                run_id,
-                                                &fence,
-                                                message_id,
-                                            )
-                                            .await
-                                            {
-                                                warn!(error = %err, "follow-up command acknowledgement failed");
+                                let busy = turn_busy.load(Ordering::SeqCst);
+                                if busy {
+                                    match runtime
+                                        .send(RuntimeCommand::Steer { text })
+                                        .await
+                                    {
+                                        Ok(()) => {
+                                            if let Some(message_id) = cmd.message_id {
+                                                if let Err(err) = ack_command(
+                                                    &client,
+                                                    &api_url,
+                                                    &token,
+                                                    run_id,
+                                                    &fence,
+                                                    message_id,
+                                                )
+                                                .await
+                                                {
+                                                    warn!(error = %err, "steer command acknowledgement failed");
+                                                }
                                             }
                                         }
+                                        Err(err) => {
+                                            warn!(error = %err, "steer failed; command will be retried");
+                                        }
                                     }
-                                    Err(err) => {
-                                        warn!(error = %err, "follow-up prompt failed; command will be retried");
-                                    }
-                                }
-                                {
-                                    let mut ts = last_activity.lock().await;
-                                    *ts = tokio::time::Instant::now();
-                                }
-                                if !cancelled.load(Ordering::SeqCst) {
+                                } else {
                                     let _ = set_status_raw(
                                         &client,
                                         &api_url,
                                         &token,
                                         run_id,
                                         &fence,
-                                        RunStatus::WaitingForUser,
+                                        RunStatus::Running,
                                     )
                                     .await;
+                                    turn_busy.store(true, Ordering::SeqCst);
+                                    match runtime.send(RuntimeCommand::Prompt { text }).await {
+                                        Ok(()) => {
+                                            if let Some(message_id) = cmd.message_id {
+                                                if let Err(err) = ack_command(
+                                                    &client,
+                                                    &api_url,
+                                                    &token,
+                                                    run_id,
+                                                    &fence,
+                                                    message_id,
+                                                )
+                                                .await
+                                                {
+                                                    warn!(error = %err, "follow-up command acknowledgement failed");
+                                                }
+                                            }
+                                        }
+                                        Err(err) => {
+                                            warn!(error = %err, "follow-up prompt failed; command will be retried");
+                                        }
+                                    }
+                                    turn_busy.store(false, Ordering::SeqCst);
+                                    {
+                                        let mut ts = last_activity.lock().await;
+                                        *ts = tokio::time::Instant::now();
+                                    }
+                                    if !cancelled.load(Ordering::SeqCst) {
+                                        let _ = set_status_raw(
+                                            &client,
+                                            &api_url,
+                                            &token,
+                                            run_id,
+                                            &fence,
+                                            RunStatus::WaitingForUser,
+                                        )
+                                        .await;
+                                    }
+                                }
+                                {
+                                    let mut ts = last_activity.lock().await;
+                                    *ts = tokio::time::Instant::now();
                                 }
                             }
                         }
@@ -836,6 +899,7 @@ async fn run_runtime_session<R: RuntimeClient + 'static>(
     );
     let cancelled = Arc::new(AtomicBool::new(false));
     let last_activity = Arc::new(tokio::sync::Mutex::new(tokio::time::Instant::now()));
+    let turn_busy = Arc::new(AtomicBool::new(false));
     let cmd_task = spawn_command_poller(
         runtime.clone(),
         client.clone(),
@@ -845,14 +909,25 @@ async fn run_runtime_session<R: RuntimeClient + 'static>(
         (*fence).clone(),
         cancelled.clone(),
         last_activity.clone(),
+        turn_busy.clone(),
     );
 
-    runtime
+    if let Some(mode_id) = take_pending_mode(client, cli, run_id).await? {
+        runtime
+            .send(RuntimeCommand::SetMode { mode_id })
+            .await
+            .context("runtime set_mode")?;
+    }
+
+    turn_busy.store(true, Ordering::SeqCst);
+    let prompt_result = runtime
         .send(RuntimeCommand::Prompt {
             text: claimed.run.prompt.clone(),
         })
         .await
-        .context("runtime prompt")?;
+        .context("runtime prompt");
+    turn_busy.store(false, Ordering::SeqCst);
+    prompt_result?;
     {
         let mut ts = last_activity.lock().await;
         *ts = tokio::time::Instant::now();
@@ -1207,7 +1282,7 @@ async fn fetch_commands(
     token: &str,
     run_id: Uuid,
     fence: &WorkerFence,
-) -> Result<Vec<WorkerCommand>> {
+) -> Result<WorkerCommandsResponse> {
     let response: WorkerCommandsResponse = client
         .get(format!(
             "{api_url}/internal/v1/runs/{run_id}/commands?attemptId={}&generation={}&workerId={}",
@@ -1219,7 +1294,48 @@ async fn fetch_commands(
         .error_for_status()?
         .json()
         .await?;
-    Ok(response.commands)
+    Ok(response)
+}
+
+async fn take_pending_mode(
+    client: &reqwest::Client,
+    cli: &Cli,
+    run_id: Uuid,
+) -> Result<Option<String>> {
+    let resp = client
+        .post(format!(
+            "{}/internal/v1/runs/{run_id}/mode/take",
+            cli.api_url
+        ))
+        .bearer_auth(&cli.worker_token)
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<serde_json::Value>()
+        .await?;
+    Ok(resp
+        .get("modeId")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .filter(|s| !s.is_empty()))
+}
+
+async fn set_pending_mode(
+    client: &reqwest::Client,
+    api_url: &str,
+    token: &str,
+    run_id: Uuid,
+    mode_id: &str,
+) -> Result<()> {
+    client
+        .post(format!("{api_url}/internal/v1/runs/{run_id}/mode"))
+        .bearer_auth(token)
+        .json(&serde_json::json!({ "modeId": mode_id }))
+        .send()
+        .await?
+        .error_for_status()
+        .context("set pending mode")?;
+    Ok(())
 }
 
 fn event_to_req(event: RuntimeNotification) -> WorkerEventRequest {
@@ -1949,6 +2065,7 @@ mod title_tests {
                 model: "default".into(),
                 permission_mode: PermissionMode::Default,
                 max_turns: 10,
+                mode_id: None,
             })
             .send()
             .await

--- a/cloud/crates/acp-bridge/src/lib.rs
+++ b/cloud/crates/acp-bridge/src/lib.rs
@@ -324,6 +324,28 @@ impl AcpBridge {
         .await
     }
 
+    pub async fn steer(&self, session_id: &str, text: &str) -> Result<Value> {
+        self.request(
+            "session/steer",
+            json!({
+                "sessionId": session_id,
+                "text": text
+            }),
+        )
+        .await
+    }
+
+    pub async fn set_mode(&self, session_id: &str, mode_id: &str) -> Result<Value> {
+        self.request(
+            "session/set_mode",
+            json!({
+                "sessionId": session_id,
+                "modeId": mode_id
+            }),
+        )
+        .await
+    }
+
     pub async fn cancel(&self, session_id: &str) -> Result<()> {
         self.notify("session/cancel", json!({ "sessionId": session_id }))
             .await
@@ -599,6 +621,39 @@ impl MockAgent {
         &self.session_id
     }
 
+    pub fn emit_steer(&self, text: &str, msg_tx: mpsc::UnboundedSender<MockMsg>) -> Result<()> {
+        let raw = json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": self.session_id,
+                "update": {
+                    "sessionUpdate": "user_message_chunk",
+                    "content": { "type": "text", "text": text }
+                }
+            }
+        });
+        let _ = msg_tx.send(MockMsg::Event(AcpEvent::from_notification(&raw)));
+        Ok(())
+    }
+
+    pub fn emit_mode(&self, mode_id: &str, msg_tx: mpsc::UnboundedSender<MockMsg>) -> Result<()> {
+        let mode_id = normalize_mock_mode(mode_id)?;
+        let raw = json!({
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": self.session_id,
+                "update": {
+                    "sessionUpdate": "current_mode_update",
+                    "currentModeId": mode_id
+                }
+            }
+        });
+        let _ = msg_tx.send(MockMsg::Event(AcpEvent::from_notification(&raw)));
+        Ok(())
+    }
+
     /// Run a prompt, streaming mock ACP events and a permission request.
     pub async fn run_prompt(
         &self,
@@ -769,6 +824,16 @@ impl MockAgent {
         );
 
         Ok(())
+    }
+}
+
+fn normalize_mock_mode(mode_id: &str) -> Result<String> {
+    let mode_id = mode_id.trim();
+    match mode_id {
+        "plan" | "architect" => Ok("plan".into()),
+        "default" | "agent" | "code" | "ask" => Ok("default".into()),
+        other if !other.is_empty() => Ok(other.to_string()),
+        _ => Err(anyhow!("mode_id cannot be empty")),
     }
 }
 

--- a/cloud/crates/db/src/lib.rs
+++ b/cloud/crates/db/src/lib.rs
@@ -99,6 +99,10 @@ impl Db {
                 "011_worker_command_leases",
                 include_str!("../../../migrations/011_worker_command_leases.sql"),
             ),
+            (
+                "012_run_pending_mode",
+                include_str!("../../../migrations/012_run_pending_mode.sql"),
+            ),
         ];
 
         for (version, sql) in migrations {
@@ -115,7 +119,8 @@ impl Db {
                 || version.starts_with("003")
                 || version.starts_with("007")
                 || version.starts_with("010")
-                || version.starts_with("011");
+                || version.starts_with("011")
+                || version.starts_with("012");
             for statement in split_sql_statements(sql) {
                 match sqlx::query(&statement).execute(&self.pool).await {
                     Ok(_) => {}
@@ -428,8 +433,8 @@ impl Db {
             "INSERT INTO runs
              (id, organization_id, repository_id, requested_by, status, status_version, title,
               prompt, base_ref, base_sha, head_branch, head_sha, model, permission_mode, max_turns,
-              created_at, started_at, finished_at, archived_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+              created_at, started_at, finished_at, archived_at, pending_mode_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(run.id.to_string())
         .bind(run.organization_id.to_string())
@@ -450,6 +455,12 @@ impl Db {
         .bind(Option::<String>::None)
         .bind(Option::<String>::None)
         .bind(Option::<String>::None)
+        .bind(
+            req.mode_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty()),
+        )
         .execute(&mut *tx)
         .await?;
 
@@ -1470,6 +1481,48 @@ impl Db {
         }
         tx.commit().await?;
         Ok(commands)
+    }
+
+    /// Queue an ACP session mode for the worker to apply via SetMode.
+    pub async fn set_pending_mode(&self, run_id: Uuid, mode_id: &str) -> Result<()> {
+        let mode_id = mode_id.trim();
+        if mode_id.is_empty() {
+            bail!("mode_id cannot be empty");
+        }
+        let updated = sqlx::query("UPDATE runs SET pending_mode_id = ? WHERE id = ?")
+            .bind(mode_id)
+            .bind(run_id.to_string())
+            .execute(&self.pool)
+            .await?;
+        if updated.rows_affected() != 1 {
+            bail!("run not found");
+        }
+        Ok(())
+    }
+
+    /// Take and clear a pending ACP session mode, if any.
+    pub async fn take_pending_mode(&self, run_id: Uuid) -> Result<Option<String>> {
+        let mut tx = self.pool.begin().await?;
+        let row: Option<(Option<String>,)> =
+            sqlx::query_as("SELECT pending_mode_id FROM runs WHERE id = ?")
+                .bind(run_id.to_string())
+                .fetch_optional(&mut *tx)
+                .await?;
+        let Some((Some(mode_id),)) = row else {
+            tx.commit().await?;
+            return Ok(None);
+        };
+        let mode_id = mode_id.trim().to_string();
+        if mode_id.is_empty() {
+            tx.commit().await?;
+            return Ok(None);
+        }
+        sqlx::query("UPDATE runs SET pending_mode_id = NULL WHERE id = ?")
+            .bind(run_id.to_string())
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(Some(mode_id))
     }
 
     pub async fn ack_worker_command_fenced(

--- a/cloud/crates/db/tests/github_git.rs
+++ b/cloud/crates/db/tests/github_git.rs
@@ -78,6 +78,7 @@ async fn github_crud_and_migrations() {
                 model: "default".into(),
                 permission_mode: PermissionMode::Default,
                 max_turns: 50,
+                mode_id: None,
             },
         )
         .await

--- a/cloud/crates/db/tests/smoke.rs
+++ b/cloud/crates/db/tests/smoke.rs
@@ -46,6 +46,7 @@ async fn register_create_run_and_claim() {
                 model: "default".into(),
                 permission_mode: PermissionMode::Default,
                 max_turns: 50,
+                mode_id: None,
             },
         )
         .await
@@ -251,6 +252,7 @@ async fn run_state_mutations_have_matching_events() {
                 model: "default".into(),
                 permission_mode: PermissionMode::Default,
                 max_turns: 10,
+                mode_id: None,
             },
         )
         .await
@@ -337,6 +339,7 @@ async fn approval_test_run(permission_mode: PermissionMode) -> (Db, Uuid) {
                 model: "default".into(),
                 permission_mode,
                 max_turns: 10,
+                mode_id: None,
             },
         )
         .await
@@ -440,7 +443,7 @@ async fn worker_command_is_retried_until_fenced_ack() {
         .unwrap();
     let run = db.create_run(auth.organization.id, auth.user.id, CreateRunRequest {
         repository_id: repo.id, prompt: "initial".into(), base_ref: None, model: "default".into(),
-        permission_mode: PermissionMode::Default, max_turns: 10,
+        permission_mode: PermissionMode::Default, max_turns: 10, mode_id: None,
     }).await.unwrap();
     let claimed = db.claim_next_run("worker-delivery", std::path::Path::new("/tmp/zc-workspaces"))
         .await.unwrap().unwrap();
@@ -479,7 +482,7 @@ async fn stale_waiting_for_user_attempt_is_requeued_but_approval_holds_are_not()
         }).await.unwrap();
         let run = db.create_run(auth.organization.id, auth.user.id, CreateRunRequest {
             repository_id: repo.id, prompt: suffix.into(), base_ref: None, model: "default".into(),
-            permission_mode: PermissionMode::Default, max_turns: 10,
+            permission_mode: PermissionMode::Default, max_turns: 10, mode_id: None,
         }).await.unwrap();
         let claimed = db.claim_next_run("stale-policy-worker", std::path::Path::new("/tmp/zc-workspaces"))
             .await.unwrap().unwrap();
@@ -542,6 +545,7 @@ async fn worker_title_is_fenced_and_retry_idempotent() {
                 model: "default".into(),
                 permission_mode: PermissionMode::Default,
                 max_turns: 10,
+                mode_id: None,
             },
         )
         .await
@@ -633,4 +637,52 @@ async fn event_cursor_migration_retries_after_partial_ddl() {
     drop(pool);
 
     db.migrate().await.unwrap();
+}
+
+
+#[tokio::test]
+async fn pending_mode_is_queued_and_taken_once() {
+    let db = Db::connect("sqlite::memory:").await.unwrap();
+    db.migrate().await.unwrap();
+    let auth = db
+        .register(RegisterRequest {
+            email: "mode@example.com".into(),
+            password: "password1".into(),
+            display_name: "Mode".into(),
+        })
+        .await
+        .unwrap();
+    let repo = db
+        .create_repository(
+            auth.organization.id,
+            CreateRepositoryRequest {
+                owner: "acme".into(),
+                name: "app".into(),
+                default_branch: "main".into(),
+                clone_url: None,
+            },
+        )
+        .await
+        .unwrap();
+    let run = db
+        .create_run(
+            auth.organization.id,
+            auth.user.id,
+            CreateRunRequest {
+                repository_id: repo.id,
+                prompt: "plan first".into(),
+                base_ref: Some("main".into()),
+                model: "default".into(),
+                permission_mode: PermissionMode::Default,
+                max_turns: 10,
+                mode_id: Some("plan".into()),
+            },
+        )
+        .await
+        .unwrap();
+    let taken = db.take_pending_mode(run.id).await.unwrap();
+    assert_eq!(taken.as_deref(), Some("plan"));
+    assert_eq!(db.take_pending_mode(run.id).await.unwrap(), None);
+    db.set_pending_mode(run.id, "default").await.unwrap();
+    assert_eq!(db.take_pending_mode(run.id).await.unwrap().as_deref(), Some("default"));
 }

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -549,6 +549,11 @@ pub struct CreateRunRequest {
     /// Agent step budget; `0` = unlimited. Defaults to 50.
     #[serde(default = "default_max_turns")]
     pub max_turns: u32,
+    /// Optional ACP session mode (`plan` / `default` / …). Applied via
+    /// `RuntimeCommand::SetMode` when the worker is idle. Orthogonal to
+    /// [`PermissionMode`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode_id: Option<String>,
 }
 
 fn default_branch_name() -> String {
@@ -568,6 +573,13 @@ fn default_max_turns() -> u32 {
 pub struct PostMessageRequest {
     pub text: String,
     pub client_message_id: Option<String>,
+}
+
+/// Request to queue an ACP session mode change for the worker.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetRunModeRequest {
+    pub mode_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1168,6 +1180,10 @@ impl WorkerCommand {
 #[serde(rename_all = "camelCase")]
 pub struct WorkerCommandsResponse {
     pub commands: Vec<WorkerCommand>,
+    /// Pending ACP session mode, if any. Worker applies via
+    /// `RuntimeCommand::SetMode` while idle. Not a [`WorkerCommandKind`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/cloud/crates/git-broker/tests/mock_flow.rs
+++ b/cloud/crates/git-broker/tests/mock_flow.rs
@@ -48,6 +48,7 @@ async fn mock_clone_push_and_draft_pr() {
                 model: "default".into(),
                 permission_mode: PermissionMode::Default,
                 max_turns: 50,
+                mode_id: None,
             },
         )
         .await

--- a/cloud/crates/runtime-client/src/lib.rs
+++ b/cloud/crates/runtime-client/src/lib.rs
@@ -66,12 +66,16 @@ fn map_session_update(update: &str) -> CloudEventKind {
 /// Transport-neutral command accepted by Cloud's runtime client.
 ///
 /// Variant names match `zene_runtime::RuntimeCommand` where Cloud has a
-/// counterpart. ACP JSON-RPC ids stay inside this adapter.
+/// counterpart. Cloud does not depend on `zene-runtime`. ACP JSON-RPC ids
+/// stay inside this adapter. `ResumeSafeTurn` / `GetMode` stay local-only
+/// until Cloud has a reply-shaped control channel.
 #[derive(Debug, Clone)]
 pub enum RuntimeCommand {
     Prompt { text: String },
+    Steer { text: String },
     Cancel,
     Approval { request_id: String, decision: ApprovalDecision },
+    SetMode { mode_id: String },
     Shutdown,
 }
 
@@ -537,6 +541,15 @@ impl RuntimeClient for AcpRuntimeClient {
                     .await
                     .map(|_| ())
             }
+            RuntimeCommand::Steer { text } => {
+                let guard = self.bridge.lock().await;
+                guard
+                    .as_ref()
+                    .context("runtime bridge missing")?
+                    .steer(&self.session_id, &text)
+                    .await
+                    .map(|_| ())
+            }
             RuntimeCommand::Cancel => {
                 let guard = self.bridge.lock().await;
                 guard
@@ -558,6 +571,15 @@ impl RuntimeClient for AcpRuntimeClient {
                     .context("runtime bridge missing")?
                     .respond(&id, acp_permission_result(decision))
                     .await
+            }
+            RuntimeCommand::SetMode { mode_id } => {
+                let guard = self.bridge.lock().await;
+                guard
+                    .as_ref()
+                    .context("runtime bridge missing")?
+                    .set_mode(&self.session_id, &mode_id)
+                    .await
+                    .map(|_| ())
             }
             RuntimeCommand::Shutdown => {
                 let mut guard = self.bridge.lock().await;
@@ -673,6 +695,24 @@ impl RuntimeClient for MockRuntimeClient {
                     .ok_or_else(|| anyhow!("mock runtime shut down"))?;
                 self.agent.run_prompt(&text, msg_tx).await
             }
+            RuntimeCommand::Steer { text } => {
+                let text = text.trim();
+                if text.is_empty() {
+                    return Err(anyhow!("steer message cannot be empty"));
+                }
+                if self.prompt_lock.try_lock().is_ok() {
+                    return Err(anyhow!(
+                        "no turn in progress; use prompt() to start a new turn"
+                    ));
+                }
+                let msg_tx = self
+                    .msg_tx
+                    .lock()
+                    .await
+                    .clone()
+                    .ok_or_else(|| anyhow!("mock runtime shut down"))?;
+                self.agent.emit_steer(text, msg_tx)
+            }
             RuntimeCommand::Cancel => Ok(()),
             RuntimeCommand::Approval { request_id, decision } => {
                 let respond = self
@@ -683,6 +723,18 @@ impl RuntimeClient for MockRuntimeClient {
                     .ok_or_else(|| anyhow!("unknown approval request_id {request_id}"))?;
                 let _ = respond.send(to_permission_decision(decision));
                 Ok(())
+            }
+            RuntimeCommand::SetMode { mode_id } => {
+                if self.prompt_lock.try_lock().is_err() {
+                    return Err(anyhow!("cannot change or read mode while a turn is active"));
+                }
+                let msg_tx = self
+                    .msg_tx
+                    .lock()
+                    .await
+                    .clone()
+                    .ok_or_else(|| anyhow!("mock runtime shut down"))?;
+                self.agent.emit_mode(&mode_id, msg_tx)
             }
             RuntimeCommand::Shutdown => {
                 self.alive.store(false, Ordering::SeqCst);
@@ -1147,6 +1199,15 @@ mod tests {
     fn runtime_commands_are_transport_neutral() {
         let command = RuntimeCommand::Prompt { text: "hello".into() };
         assert!(matches!(command, RuntimeCommand::Prompt { text } if text == "hello"));
+        let command = RuntimeCommand::Steer { text: "nudge".into() };
+        assert!(matches!(command, RuntimeCommand::Steer { text } if text == "nudge"));
+        let command = RuntimeCommand::SetMode {
+            mode_id: "plan".into(),
+        };
+        assert!(matches!(
+            command,
+            RuntimeCommand::SetMode { mode_id } if mode_id == "plan"
+        ));
         let command = RuntimeCommand::Approval {
             request_id: "call-7".into(),
             decision: ApprovalDecision::AllowOnce,
@@ -1255,6 +1316,49 @@ mod tests {
         let (saw_text, saw_tool_approval) = pump_task.await.expect("pump");
         assert!(saw_text, "expected classified text_delta");
         assert!(saw_tool_approval, "expected tool approval request");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn mock_runtime_client_set_mode_when_idle() {
+        let dir = std::env::temp_dir().join(format!("zene-mock-mode-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let client = MockRuntimeClient::connect(&dir);
+        client
+            .send(RuntimeCommand::SetMode {
+                mode_id: "plan".into(),
+            })
+            .await
+            .expect("set mode");
+        let mut saw_mode = false;
+        while let Some(event) = client.next_event().await {
+            match event {
+                RuntimeEvent::Notification(event)
+                    if event.event_type == CloudEventKind::StateChanged =>
+                {
+                    saw_mode = true;
+                    break;
+                }
+                RuntimeEvent::ChildExited => break,
+                _ => {}
+            }
+        }
+        assert!(saw_mode, "expected current_mode_update");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn mock_runtime_client_rejects_idle_steer() {
+        let dir = std::env::temp_dir().join(format!("zene-mock-steer-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).expect("temp dir");
+        let client = MockRuntimeClient::connect(&dir);
+        let err = client
+            .send(RuntimeCommand::Steer {
+                text: "nudge".into(),
+            })
+            .await
+            .expect_err("idle steer");
+        assert!(err.to_string().contains("no turn in progress"));
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/cloud/migrations/012_run_pending_mode.sql
+++ b/cloud/migrations/012_run_pending_mode.sql
@@ -1,0 +1,3 @@
+-- Pending ACP session mode for RuntimeCommand::SetMode.
+-- Consumed by the worker when the runtime is idle.
+ALTER TABLE runs ADD COLUMN pending_mode_id TEXT;

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `bbb7030`（PR #93 已合并）。**
+> **进度快照：2026-08-13，基线 `6ba0347`（PR #94 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 当前工作是 Cloud git/queue 剩余产品枚举一次收口；Steer/SetMode 与整型 crate 仍未做。
+> Wave 16 的 Steer/SetMode 已对齐；下一步进入 Wave 14（RuntimeScope / ToolCatalog）。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -1043,7 +1043,7 @@ Wave 15  ApprovalBroker
          PermissionService（纯判定）与异步 ApprovalBroker 拆开
          Runtime-owned waiter：Approval command 唤醒 in-flight tool
 
-Wave 16  统一 transport command/event  ← 当前工作
+Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
          Cloud 审批 command 使用 ApprovalDecision
          Cloud event_type 使用中性 kind
          Console 按 event_type 分发时间线
@@ -1073,6 +1073,7 @@ Wave 16  统一 transport command/event  ← 当前工作
          Cloud permission_mode 使用 PermissionMode
          Cloud 消息 role 使用 MessageRole
          Cloud GitHub mode 使用 GithubMode
+         Cloud Steer/SetMode 对齐（不依赖 zene-runtime）
          Cloud git/queue 剩余产品枚举一次收口（本轮）
          Cloud payload 不再以 ACP JSON 为产品语义
          本地与 Cloud 共用同一套 RuntimeCommand / RuntimeEvent
@@ -1098,7 +1099,7 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
 | Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
-| Wave 16 | 进行中 | Cloud git/queue 剩余产品枚举已收口；Steer/SetMode 与整型 crate 仍待统一 |
+| Wave 16 | 已完成 command 对齐 | Cloud RuntimeCommand 含 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；仍不依赖 `zene-runtime` |
 
 ### 当前收口状态与剩余边界
 
@@ -1133,7 +1134,7 @@ Wave 16  统一 transport command/event  ← 当前工作
    - pending tool / approval 的任意副作用自动 replay：继续采用 inspection/manual intervention，避免重复写操作。
    - `Agent` 从 step orchestrator 完全退回 composition root。
    - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor` / ModelExecutor，而不是并行 `ChatBackend`。
-   - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Cancel/Approval/Shutdown；API→worker 已是 Prompt/Cancel；审批产品面已收口；仍缺 Steer/SetMode，且不依赖 `zene-runtime`）。未识别 Cloud 帧仍为 ACP JSON。
+   - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；API→worker 仍是 Prompt/Cancel；不依赖 `zene-runtime`）。`GetMode` / `ResumeSafeTurn` 仍仅本地。未识别 Cloud 帧仍为 ACP JSON。
    - Agent-specific actor 从 `zene-core` 移入独立 runtime implementation crate（应在 ports/审批稳定之后）。
    - 跨 VM outbox 的共享持久化实现；当前部署文档要求共享 POSIX volume 或后续 DB/object spool。
 
@@ -1196,20 +1197,19 @@ Wave 16  统一 transport command/event  ← 当前工作
    - ACP 监听 `ApprovalRequested`，`session/request_permission` 结束后发 `RuntimeCommand::Approval`。
    - Cloud JobRunner 用 `ApprovalDecision` 回复审批；ACP JSON 只在 RuntimeClient adapter 内构造。
 
-7. **Wave 16：统一 command/event（进行中）**
-   - JobRunner 经 `RuntimeClient::send` 发送 Prompt/Cancel/Approval/Shutdown；`Approval` 携带 `request_id` + `ApprovalDecision`。
+   - JobRunner 经 `RuntimeClient::send` 发送 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；`Approval` 携带 `request_id` + `ApprovalDecision`。
    - ACP jsonrpc id 与 `optionId` 只留在 RuntimeClient adapter。审批表 payload 存产品字段，不再存 ACP params。Cloud 产品审批类型不再携带 `jsonrpc_id`；DB 列保留但不读写。
    - RuntimeClient 把 ACP `sessionUpdate` 分类为 domain `CloudEventKind`；已分类 payload 存产品字段。
    - Console 按 `event_type` 分发时间线：`text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result` 直接渲染产品字段，legacy `params.update` 仍可回放。plan/usage/projection/session_started/approval_requested 不进时间线。
-   - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer。
+   - API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举，wire JSON 仍为 `"prompt"` / `"cancel"`。不包含 Approval/Shutdown/Steer/SetMode。
    - Cloud 存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`；`ApprovalKind` / `ApprovalRisk` 同样是产品枚举。ACP `optionId` 仍只在 adapter 内映射到 `PermissionDecision`。
    - JobRunner mock 与真实 ACP 共用 `run_runtime_session`：同一条 event pump、command poller 与 idle hold。只发送 `RuntimeCommand`，只消费 `RuntimeEvent` / `RuntimeRequest`。`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeNotification.payload` 是 `RuntimePayload`（分类 kind 持有 domain 结构体，含 `ProjectionPayload`；未识别/提取失败为 `Json`）。审批请求 `context` 是 `ApprovalEventPayload`。`CreateApprovalRequest.payload` 同样是 `ApprovalEventPayload`；JobRunner 不再先转成 `Value`。`ApprovalRequest.payload` 与 `RunEvent.payload` 读出仍为 JSON。worker 内部控制 HTTP 使用 domain 请求类型；产品 runtime session 仍写入 `acp_session_id` 列。ACP `MockMsg` 与 `optionId` 只留在 adapter。
    - Console `Run.status` 与 `PlatformEvent["run.status"]` 使用 `RunStatus`；审批平台事件的 `status` / `decision` / `kind` 使用已有产品枚举。`eventKind()` 返回 `RunEventType`，未知历史 kind 回落 `"acp"`。`RunEvent.event_type` 读出仍为字符串。不改 pill 文案/颜色，不改 Sidebar 过滤。
-   - Cloud `Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`（`default` / `accept_edits` / `yolo` / 历史 `auto`）。`default` / `yolo` / `auto` 仍自动 resolve 审批；未知历史值读成 `accept_edits`（不自动批准、不启用 `--yolo`）。不补 SetMode。
+   - Cloud `Run.permission_mode` 与 `CreateRunRequest.permission_mode` 使用 `PermissionMode`（`default` / `accept_edits` / `yolo` / 历史 `auto`）。`default` / `yolo` / `auto` 仍自动 resolve 审批；未知历史值读成 `accept_edits`（不自动批准、不启用 `--yolo`）。
    - `RunMessage.role` 与 `PlatformEvent::MessageCreated.role` 使用 `MessageRole`（`user` / `assistant`）。未知历史值读成 `assistant`，与 Console `bubbleRole` 一致。
    - `CloneTokenResponse.mode`、API `githubMode` / GitHub status `mode` 与 Console `GithubStatus.mode` 使用已有 `GithubMode`。不再用 Debug 格式拼 wire 字符串。
    - `QueueActive.status` 使用 `RunStatus`。`PullRequest.state` 使用 `PullRequestState`（含 mock `draft`）。installation `account_type` / `status` 使用 `GithubAccountType`（`User` / `Organization`）与 `GithubInstallationStatus`。未知历史值分别读成 `failed` / `open` / `Organization` / `active`。
-   - 未做：Cloud 补齐 Steer/SetMode 并与 `zene-runtime` 合成一套类型。
+   - Cloud `RuntimeCommand` 补齐 `Steer` / `SetMode`，字段与本地 `zene-runtime` 同形，但不依赖该 crate。ACP 增加 `session/steer`；`session/set_mode` 经 bridge 可达。JobRunner：turn 进行中的 follow-up 发 `Steer`，空闲发 `Prompt`；`pending_mode_id` + `POST /runs/{id}/mode` 在空闲时发 `SetMode`。`GetMode` / `ResumeSafeTurn` 仍仅本地。
 
 8. **持续质量门槛**
    - 每个 wave 保持 `cargo test --workspace --locked`；
@@ -1234,10 +1234,11 @@ Wave 16  统一 transport command/event  ← 当前工作
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 16 剩余 command** | 分类 payload 已收口到 domain 结构体；Steer/SetMode 与整型 crate 仍分叉 |
-| 结构清理 | Wave 14 | Agent 退回 wiring，应在审批/事件稳定之后 |
+| 当前最大杠杆 | **Wave 14** | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
+| 结构清理 | Wave 14 | command 面已稳定，可开始能力注入 |
+| 可选后续 | 整型 crate / GetMode | Cloud 仍不引入 `zene-runtime`；本地 GetMode/ResumeSafeTurn 仍仅本地 |
 
-推荐组合：**分类事件 payload 已收口到 domain 结构体**；下一步不要先补无调用方的 Steer/SetMode，也不要先搬 runtime crate。Wave 14 把 `Agent` 收成 wiring 仍应在 command 稳定之后。
+推荐组合：**Steer/SetMode 已对齐**。下一步做 Wave 14 的 `RuntimeScope` + `ToolCatalog` 第一刀，不要先搬 Agent actor。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1441,4 +1442,11 @@ Wave 16  统一 transport command/event  ← 当前工作
 - `QueueActive.status` 使用 `RunStatus`。`PullRequest.state` 使用 `PullRequestState`（`open` / `closed` / `merged` / mock `draft`）。Console GitPanel 对齐，不改颜色。
 - installation `account_type` / `status` 使用 `GithubAccountType`（wire 仍为 `User` / `Organization`）与 `GithubInstallationStatus`。
 - 未知历史值分别读成 `failed` / `open` / `Organization` / `active`。不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
+
+### 2026-08-13 — Cloud Steer / SetMode
+
+- Cloud `RuntimeCommand` 增加 `Steer { text }` 与 `SetMode { mode_id }`，与本地字段同形，不依赖 `zene-runtime`。
+- ACP 增加 `session/steer`；`AcpBridge` / mock 支持 `steer` 与 `set_mode`。
+- JobRunner：turn 进行中 follow-up 发 `Steer`，空闲发 `Prompt`。`pending_mode_id` + `POST /api/v1/runs/{id}/mode`（及 worker take/requeue）在空闲时发 `SetMode`。
+- `WorkerCommandKind` 仍只有 Prompt/Cancel。不把 `zene-runtime` 引入 Cloud。不改 Console 布局。
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #94 收完 git/queue 产品枚举后，Cloud `RuntimeCommand` 仍缺 `Steer` / `SetMode`。本 PR 一次对齐本地 command 面，不把 `zene-runtime` 引入 Cloud。

Cloud `RuntimeCommand` 增加 `Steer { text }` 与 `SetMode { mode_id }`。ACP 增加 `session/steer`；`AcpBridge` / mock 支持 `steer` 与 `set_mode`。JobRunner：turn 进行中的 follow-up 发 `Steer`，空闲发 `Prompt`。`pending_mode_id` + `POST /api/v1/runs/{id}/mode`（及 worker take/requeue）在空闲时发 `SetMode`。`CreateRunRequest.mode_id` 可预置 pending mode。

`WorkerCommandKind` 仍只有 Prompt/Cancel。不改 Console 布局。`GetMode` / `ResumeSafeTurn` 仍仅本地。

`cd cloud && cargo test -p zene-cloud-runtime-client -p zene-cloud-acp-bridge -p zene-cloud-domain -p zene-cloud-db -p zene-cloud-api -p zene-cloud-git-broker --locked`、`cargo test -p zene-cloud-worker --locked --no-run` 与 `cargo test -p zene-cli --locked --no-run` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

