### PR TITLE
feat: Wave 14 第一刀 RuntimeScope / ToolCatalog

### DIFF
--- a/crates/core/src/subagent.rs
+++ b/crates/core/src/subagent.rs
@@ -8,7 +8,7 @@ use zene_config::ZeneConfig;
 use zene_llm::{ChatClient, ChatRequest, ChatResponse, Message, TokenUsage, ToolCall};
 use zene_sandbox::Sandbox;
 use zene_tools::{
-    tools_for_profile, SubagentEnv, SubagentProfile, SubagentRunner, ToolContext,
+    RuntimeScope, SubagentEnv, SubagentProfile, SubagentRunner, ToolCatalog, ToolContext,
     ToolRegistry, DEFAULT_SUBAGENT_MAX_DEPTH,
 };
 
@@ -125,23 +125,13 @@ pub(crate) async fn run_subagent_with_runner(
     runner: Option<Arc<dyn SubagentRunner>>,
     broker: Option<zene_permission::SharedApprovalBroker>,
 ) -> Result<String> {
-    let subagent_depth = parent_depth + 1;
-    if subagent_depth > DEFAULT_SUBAGENT_MAX_DEPTH {
-        anyhow::bail!(
-            "Subagent nesting limit reached (max depth {DEFAULT_SUBAGENT_MAX_DEPTH})"
-        );
-    }
-
+    let scope = RuntimeScope::subagent(profile, parent_depth)?;
     let runner = runner.unwrap_or_else(|| {
         Arc::new(CoreSubagentRunner::new(config.clone()).with_broker(broker.clone()))
     });
-    let subagent_env = SubagentEnv {
-        depth: subagent_depth,
-        max_depth: DEFAULT_SUBAGENT_MAX_DEPTH,
-        runner,
-    };
+    let subagent_env = scope.env(runner);
     let mut runtime = SubagentTurnRuntime::new(
-        profile,
+        scope,
         sandbox,
         config,
         backend,
@@ -160,10 +150,15 @@ pub(crate) async fn run_subagent_with_runner(
 ///
 /// Subagents share the generic turn state machine. Conversation stays in
 /// memory; they do not publish the parent runtime's events or checkpoints.
+/// Tools come from [`RuntimeScope`] so Explore/Coder differ by scope, not a
+/// parallel wiring path.
 struct SubagentTurnRuntime<'a> {
     sandbox: Arc<dyn Sandbox>,
     config: &'a ZeneConfig,
     backend: &'a dyn ChatBackend,
+    /// Retained for later ToolPolicy / SessionPolicy injection.
+    #[allow(dead_code)]
+    scope: RuntimeScope,
     subagent_env: SubagentEnv,
     permission: Option<SharedToolPermission>,
     broker: Option<zene_permission::SharedApprovalBroker>,
@@ -175,7 +170,7 @@ struct SubagentTurnRuntime<'a> {
 
 impl<'a> SubagentTurnRuntime<'a> {
     fn new(
-        profile: SubagentProfile,
+        scope: RuntimeScope,
         sandbox: Arc<dyn Sandbox>,
         config: &'a ZeneConfig,
         backend: &'a dyn ChatBackend,
@@ -183,15 +178,17 @@ impl<'a> SubagentTurnRuntime<'a> {
         permission: Option<SharedToolPermission>,
         broker: Option<zene_permission::SharedApprovalBroker>,
     ) -> Self {
-        let system_prompt = subagent_system_prompt(profile, sandbox.workdir());
+        let system_prompt = subagent_system_prompt(scope.profile, sandbox.workdir());
+        let tools = scope.tools();
         Self {
             sandbox,
             config,
             backend,
+            scope,
             subagent_env,
             permission,
             broker,
-            tools: tools_for_profile(profile),
+            tools,
             messages: vec![Message::system(&system_prompt)],
             compaction_config: subagent_compaction_config(
                 &context_config::context_compaction_config(&config.compaction),
@@ -217,7 +214,7 @@ impl<'a> SubagentTurnRuntime<'a> {
         .await?;
         Ok(PreparedContext {
             messages: self.messages.clone(),
-            tools: self.tools.definitions(),
+            tools: ToolCatalog::definitions(&self.tools),
             context_epoch: None,
             metadata: None,
             estimate_tokens: None,
@@ -795,7 +792,8 @@ mod tests {
         .await
         .expect("subagent should complete");
 
-        let explore_tools: Vec<_> = tools_for_profile(SubagentProfile::Explore)
+        let explore_tools: Vec<_> = RuntimeScope::subagent(SubagentProfile::Explore, 0)
+            .expect("explore scope")
             .definitions()
             .into_iter()
             .map(|t| t.name)
@@ -808,7 +806,9 @@ mod tests {
         assert!(result.contains("beta.txt"));
         assert!(!result.contains("notes.md"));
 
-        let write_attempt = tools_for_profile(SubagentProfile::Explore)
+        let write_attempt = RuntimeScope::subagent(SubagentProfile::Explore, 0)
+            .expect("explore scope")
+            .tools()
             .execute(
                 "Write",
                 r#"{"path":"blocked.txt","content":"nope"}"#,

--- a/crates/core/src/subagent.rs
+++ b/crates/core/src/subagent.rs
@@ -9,7 +9,7 @@ use zene_llm::{ChatClient, ChatRequest, ChatResponse, Message, TokenUsage, ToolC
 use zene_sandbox::Sandbox;
 use zene_tools::{
     RuntimeScope, SubagentEnv, SubagentProfile, SubagentRunner, ToolCatalog, ToolContext,
-    ToolRegistry, DEFAULT_SUBAGENT_MAX_DEPTH,
+    ToolRegistry,
 };
 
 use zene_context::{
@@ -632,7 +632,7 @@ mod tests {
     use tempfile::tempdir;
     use zene_llm::ToolCall;
     use zene_sandbox::LocalSandbox;
-    use zene_tools::default_builtin_tools;
+    use zene_tools::{default_builtin_tools, DEFAULT_SUBAGENT_MAX_DEPTH};
 
     fn test_permission_deny() -> SharedToolPermission {
         Arc::new(Mutex::new(PermissionGate::with_prompter(

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -13,6 +13,7 @@ mod plan_mode;
 mod read;
 mod registry;
 mod repomap;
+mod scope;
 mod skill;
 mod subagent;
 mod task;
@@ -29,6 +30,7 @@ pub use background::{
 };
 pub use builtin::{agent_tools, builtin_tools, default_builtin_tools, tools_for_profile};
 pub use todo_store::{shared_todo_store, shared_todo_store_from, SharedTodoStore, TodoItem, TodoStatus, TodoStore};
+pub use scope::RuntimeScope;
 pub use subagent::{
     SubagentEnv, SubagentProfile, SubagentRunner, DEFAULT_SUBAGENT_MAX_DEPTH,
 };
@@ -38,7 +40,7 @@ pub use line_endings::{
 };
 pub use permission::{SharedToolPermission, ToolPermission};
 pub use plan_mode::{shared_plan_mode, PlanModeState, SharedPlanMode};
-pub use registry::{Tool, ToolContext, ToolRegistry, ToolResult};
+pub use registry::{Tool, ToolCatalog, ToolContext, ToolRegistry, ToolResult};
 pub use zene_sandbox::Sandbox;
 pub use fetch_url::FetchUrlTool;
 pub use web_search::WebSearchTool;

--- a/crates/tools/src/registry.rs
+++ b/crates/tools/src/registry.rs
@@ -77,6 +77,26 @@ pub struct ToolRegistry {
     tools: Vec<Box<dyn Tool>>,
 }
 
+/// Read-only tool definitions for a runtime scope.
+///
+/// Wave 14 splits catalog (what the model may see) from execution. Existing
+/// [`ToolRegistry`] remains the concrete catalog+executor; callers that only
+/// need definitions should depend on this trait.
+pub trait ToolCatalog: Send + Sync {
+    fn definitions(&self) -> Vec<ToolDefinition>;
+    fn contains(&self, name: &str) -> bool;
+}
+
+impl ToolCatalog for ToolRegistry {
+    fn definitions(&self) -> Vec<ToolDefinition> {
+        ToolRegistry::definitions(self)
+    }
+
+    fn contains(&self, name: &str) -> bool {
+        ToolRegistry::contains(self, name)
+    }
+}
+
 impl ToolRegistry {
     pub fn new(tools: Vec<Box<dyn Tool>>) -> Self {
         Self { tools }

--- a/crates/tools/src/scope.rs
+++ b/crates/tools/src/scope.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+
+use anyhow::{bail, Result};
+
+use crate::builtin::tools_for_profile;
+use crate::registry::{ToolCatalog, ToolRegistry};
+use crate::subagent::{SubagentEnv, SubagentProfile, SubagentRunner, DEFAULT_SUBAGENT_MAX_DEPTH};
+
+/// Capability boundary for a child/runtime turn.
+///
+/// Wave 14 first slice: Subagent construction goes through a scope so profile,
+/// nesting depth, and tool catalog stay one injection point. Full-agent scopes
+/// and ToolPolicy/SessionPolicy land in later slices.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RuntimeScope {
+    pub profile: SubagentProfile,
+    pub depth: u32,
+    pub max_depth: u32,
+}
+
+impl RuntimeScope {
+    /// Build a child scope under `parent_depth`. Depth `0` is the main agent.
+    pub fn subagent(profile: SubagentProfile, parent_depth: u32) -> Result<Self> {
+        let depth = parent_depth.saturating_add(1);
+        if depth > DEFAULT_SUBAGENT_MAX_DEPTH {
+            bail!("Subagent nesting limit reached (max depth {DEFAULT_SUBAGENT_MAX_DEPTH})");
+        }
+        Ok(Self {
+            profile,
+            depth,
+            max_depth: DEFAULT_SUBAGENT_MAX_DEPTH,
+        })
+    }
+
+    pub fn tools(&self) -> ToolRegistry {
+        tools_for_profile(self.profile)
+    }
+
+    pub fn catalog(&self) -> ToolRegistry {
+        self.tools()
+    }
+
+    pub fn definitions(&self) -> Vec<zene_llm::ToolDefinition> {
+        self.catalog().definitions()
+    }
+
+    pub fn env(&self, runner: Arc<dyn SubagentRunner>) -> SubagentEnv {
+        SubagentEnv {
+            depth: self.depth,
+            max_depth: self.max_depth,
+            runner,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explore_scope_exposes_read_only_catalog() {
+        let scope = RuntimeScope::subagent(SubagentProfile::Explore, 0).expect("scope");
+        assert_eq!(scope.depth, 1);
+        let names: Vec<_> = scope
+            .definitions()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect();
+        assert!(names.contains(&"Read".into()));
+        assert!(names.contains(&"Grep".into()));
+        assert!(!names.iter().any(|name| name == "Write" || name == "Edit"));
+    }
+
+    #[test]
+    fn coder_scope_includes_write_tools() {
+        let scope = RuntimeScope::subagent(SubagentProfile::Coder, 0).expect("scope");
+        let names: Vec<_> = scope
+            .definitions()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect();
+        assert!(names.contains(&"Write".into()));
+        assert!(names.contains(&"Bash".into()));
+    }
+
+    #[test]
+    fn nested_scope_rejects_over_max_depth() {
+        let err = RuntimeScope::subagent(SubagentProfile::Explore, DEFAULT_SUBAGENT_MAX_DEPTH)
+            .expect_err("over max");
+        assert!(err.to_string().contains("nesting limit"));
+    }
+}

--- a/crates/tools/src/scope.rs
+++ b/crates/tools/src/scope.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::{bail, Result};
 
 use crate::builtin::tools_for_profile;
-use crate::registry::{ToolCatalog, ToolRegistry};
+use crate::registry::ToolRegistry;
 use crate::subagent::{SubagentEnv, SubagentProfile, SubagentRunner, DEFAULT_SUBAGENT_MAX_DEPTH};
 
 /// Capability boundary for a child/runtime turn.

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -1096,7 +1096,7 @@ Wave 16  统一 transport command/event  ← 当前工作
 | Wave 11 | 已完成第一阶段 | ModelExecutor、ContextModel、usage boundary、runtime protocol 和 lifecycle publisher 已落地；Agent-specific actor 尚在 core |
 | Wave 12 | 已完成第一阶段 | safe resume、Cloud RuntimeClient、neutral runtime notifications、fenced command lease/ack、atomic state/event writes、outbox replay 和真实 replacement 测试已落地 |
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
-| Wave 14 | 未开始 | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
+| Wave 14 | 进行中 | RuntimeScope + ToolCatalog 第一刀已接到 Subagent；Agent 退回 wiring 仍待做 |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
 | Wave 16 | 进行中 | Cloud git/queue 剩余产品枚举已收口；Steer/SetMode 与整型 crate 仍待统一 |
 
@@ -1442,3 +1442,9 @@ Wave 16  统一 transport command/event  ← 当前工作
 - installation `account_type` / `status` 使用 `GithubAccountType`（wire 仍为 `User` / `Organization`）与 `GithubInstallationStatus`。
 - 未知历史值分别读成 `failed` / `open` / `Organization` / `active`。不补 Steer/SetMode。不把 `zene-runtime` 引入 Cloud。
 
+
+### 2026-08-13 — Wave 14 RuntimeScope / ToolCatalog
+
+- 新增 `zene_tools::RuntimeScope`：Subagent 经 scope 注入 profile / depth / max_depth / tool catalog。
+- 新增 `ToolCatalog` trait；`ToolRegistry` 实现该 trait。Subagent `PreparedContext.tools` 经 catalog 取定义。
+- 保留 `SubagentRunner` facade。不搬 Agent actor。不做 Cloud 改动。

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `6ba0347`（PR #94 已合并）。**
+> **进度快照：2026-08-13，基线 `ad7e8e9`（PR #95 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 的 Steer/SetMode 已对齐；下一步进入 Wave 14（RuntimeScope / ToolCatalog）。
+> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（RuntimeScope / ToolCatalog 第一刀）。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Wave 16 的 Steer/SetMode 已在 #95 对齐。本 PR 进入 Wave 14 第一刀：给 Subagent 接上 `RuntimeScope` 与 `ToolCatalog`。

新增 `zene_tools::RuntimeScope`（profile / depth / max_depth / tool catalog）。新增 `ToolCatalog` trait，`ToolRegistry` 实现它。Subagent 经 scope 构造工具集与 nesting 校验，`PreparedContext.tools` 经 catalog 取定义。保留 `SubagentRunner` facade。

已与 main（含 #95）合并，解决 `docs/agent-runtime-optimization.md` 冲突：保留 Steer/SetMode 与 Wave 14 两段 changelog。

不搬 Agent actor。不把 Agent 退回 composition root。不做 Cloud 改动。不拆 DefaultToolExecutor。

`cargo test -p zene-tools -p zene-core --locked --lib` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

