### PR TITLE
feat: Wave 14 Subagent 工具执行走 DefaultToolExecutor

### DIFF
--- a/crates/core/src/subagent.rs
+++ b/crates/core/src/subagent.rs
@@ -11,13 +11,14 @@ use zene_tools::{
     RuntimeScope, SubagentEnv, SubagentProfile, SubagentRunner, ToolCatalog, ToolContext,
     ToolRegistry,
 };
+use crate::tool_executor::execute_subagent_tool_batch;
 
 use zene_context::{
     compact_message_list_with_chat, estimate_context, should_compact,
     subagent_compaction_config, TokenEstimator,
 };
 use crate::context_config;
-use zene_permission::{PermissionGate, SharedToolPermission};
+use zene_permission::SharedToolPermission;
 use zene_turn::{
     aborted_error, max_turns_notice, ContextAssemblerPort, EventSinkPort, ModelExecutorPort,
     PreparedContext, StepResult, ToolBatchOutcome, ToolExecutorPort, TurnEngine, TurnEnginePorts,
@@ -162,7 +163,7 @@ struct SubagentTurnRuntime<'a> {
     subagent_env: SubagentEnv,
     permission: Option<SharedToolPermission>,
     broker: Option<zene_permission::SharedApprovalBroker>,
-    tools: ToolRegistry,
+    tools: Arc<ToolRegistry>,
     messages: Vec<Message>,
     compaction_config: zene_context::CompactionConfig,
     active_turn: Option<TurnState>,
@@ -179,7 +180,7 @@ impl<'a> SubagentTurnRuntime<'a> {
         broker: Option<zene_permission::SharedApprovalBroker>,
     ) -> Self {
         let system_prompt = subagent_system_prompt(scope.profile, sandbox.workdir());
-        let tools = scope.tools();
+        let tools = Arc::new(scope.tools());
         Self {
             sandbox,
             config,
@@ -206,7 +207,7 @@ impl<'a> SubagentTurnRuntime<'a> {
         }
         maybe_compact_subagent_messages(
             &mut self.messages,
-            &self.tools,
+            self.tools.as_ref(),
             &self.compaction_config,
             &self.config.model,
             self.backend,
@@ -214,11 +215,37 @@ impl<'a> SubagentTurnRuntime<'a> {
         .await?;
         Ok(PreparedContext {
             messages: self.messages.clone(),
-            tools: ToolCatalog::definitions(&self.tools),
+            tools: ToolCatalog::definitions(self.tools.as_ref()),
             context_epoch: None,
             metadata: None,
             estimate_tokens: None,
         })
+    }
+
+    async fn execute_tools(
+        &mut self,
+        tool_calls: &[ToolCall],
+        cancel: Option<&CancellationToken>,
+    ) -> Result<ToolBatchOutcome> {
+        let batch = execute_subagent_tool_batch(
+            Arc::clone(&self.tools),
+            Arc::clone(&self.sandbox),
+            tool_calls,
+            cancel,
+            self.subagent_env.clone(),
+            self.permission.clone(),
+            self.broker.clone(),
+        )
+        .await?;
+        for message in batch.messages {
+            self.messages.push(Message::tool_result_with_error(
+                &message.call.id,
+                &message.call.name,
+                message.content,
+                message.is_error,
+            ));
+        }
+        Ok(batch.outcome)
     }
 
     async fn invoke_model(
@@ -341,18 +368,7 @@ impl ToolExecutorPort<()> for SubagentTurnRuntime<'_> {
         _options: &(),
         cancel: Option<&CancellationToken>,
     ) -> Result<ToolBatchOutcome> {
-        run_subagent_tools(
-            &self.tools,
-            tool_calls,
-            &self.sandbox,
-            cancel,
-            &self.subagent_env,
-            self.permission.clone(),
-            self.broker.clone(),
-            &mut self.messages,
-        )
-        .await?;
-        Ok(ToolBatchOutcome::Continue)
+        self.execute_tools(tool_calls, cancel).await
     }
 }
 
@@ -417,18 +433,7 @@ impl TurnRuntime for SubagentTurnRuntime<'_> {
         _options: &Self::Options,
         cancel: Option<&CancellationToken>,
     ) -> Result<ToolBatchOutcome> {
-        run_subagent_tools(
-            &self.tools,
-            tool_calls,
-            &self.sandbox,
-            cancel,
-            &self.subagent_env,
-            self.permission.clone(),
-            self.broker.clone(),
-            &mut self.messages,
-        )
-        .await?;
-        Ok(ToolBatchOutcome::Continue)
+        self.execute_tools(tool_calls, cancel).await
     }
 
     fn inject_steer(&mut self, _options: &Self::Options) -> Result<bool> {
@@ -458,84 +463,6 @@ impl TurnRuntime for SubagentTurnRuntime<'_> {
     async fn finish_turn(&mut self) -> Result<()> {
         Ok(())
     }
-}
-
-async fn run_subagent_tools(
-    tools: &ToolRegistry,
-    tool_calls: &[ToolCall],
-    sandbox: &Arc<dyn Sandbox>,
-    cancel: Option<&CancellationToken>,
-    subagent_env: &SubagentEnv,
-    permission: Option<SharedToolPermission>,
-    broker: Option<zene_permission::SharedApprovalBroker>,
-    messages: &mut Vec<Message>,
-) -> Result<()> {
-    let ctx = ToolContext {
-        sandbox: Arc::clone(sandbox),
-        cancel: cancel.cloned(),
-        subagent: Some(subagent_env.clone()),
-        permission: permission.clone(),
-        plan_mode: None,
-        todos: None,
-        ask_user: None,
-        background: None,
-    };
-
-    for call in tool_calls {
-        if check_cancelled(cancel)? {
-            return Err(aborted_error());
-        }
-
-        let allowed = if let Some(ref gate) = permission {
-            zene_permission::resolve_permission(
-                gate,
-                broker.as_ref(),
-                zene_permission::ApprovalRequest {
-                    request_id: call.id.clone(),
-                    tool_name: call.name.clone(),
-                    arguments: call.arguments.clone(),
-                    tool_call_id: Some(call.id.clone()),
-                },
-            )
-            .await?
-        } else {
-            true
-        };
-
-        let result = if !allowed {
-            zene_tools::ToolResult {
-                content: PermissionGate::denied_message(&call.name),
-                is_error: true,
-            }
-        } else {
-            tools
-                .execute(&call.name, &call.arguments, &ctx)
-                .await
-                .unwrap_or_else(|err| zene_tools::ToolResult {
-                    content: err.to_string(),
-                    is_error: true,
-                })
-        };
-
-        let content = if result.content.is_empty() {
-            if result.is_error {
-                "(tool returned empty error output)".to_string()
-            } else {
-                "(tool returned no output)".to_string()
-            }
-        } else {
-            result.content
-        };
-
-        messages.push(Message::tool_result_with_error(
-            &call.id,
-            &call.name,
-            content,
-            result.is_error,
-        ));
-    }
-
-    Ok(())
 }
 
 fn subagent_system_prompt(profile: SubagentProfile, workdir: &Path) -> String {

--- a/crates/core/src/tool_executor.rs
+++ b/crates/core/src/tool_executor.rs
@@ -3,13 +3,15 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::Result;
+use parking_lot::Mutex;
 use tokio_util::sync::CancellationToken;
 use zene_llm::ToolCall;
-use zene_permission::PermissionGate;
+use zene_permission::{PermissionGate, PermissionMode, SharedApprovalBroker};
 use zene_tool_runtime::{apply_tool_bound_plan, plan_tool_output_bound, FsToolOutputStore};
 use zene_tools::{
+    default_ask_user_prompter, shared_background_tasks, shared_plan_mode, shared_todo_store,
     PlanModeState, SharedAskUserPrompter, SharedBackgroundTasks, SharedPlanMode, SharedTodoStore,
-    SubagentEnv, ToolContext, ToolRegistry,
+    SharedToolPermission, SubagentEnv, ToolContext, ToolRegistry,
 };
 use zene_turn::ToolBatchOutcome;
 
@@ -338,6 +340,62 @@ impl<'a> DefaultToolExecutor<'a> {
             messages,
         })
     }
+}
+
+/// Run one Subagent tool batch through the same executor as the main Agent.
+///
+/// Plan mode stays inactive; hooks are empty. Missing permission inherits
+/// bypass so Explore/Coder keep prior auto-allow behavior unless a gate is
+/// passed from the parent.
+pub(crate) async fn execute_subagent_tool_batch(
+    tools: Arc<ToolRegistry>,
+    sandbox: Arc<dyn Sandbox>,
+    tool_calls: &[ToolCall],
+    cancel: Option<&CancellationToken>,
+    subagent_env: SubagentEnv,
+    permission: Option<SharedToolPermission>,
+    broker: Option<SharedApprovalBroker>,
+) -> Result<ToolBatchResult> {
+    let permission = permission.unwrap_or_else(|| {
+        Arc::new(Mutex::new(PermissionGate::new(
+            PermissionMode::BypassPermissions,
+        )))
+    });
+    let plan_mode = shared_plan_mode();
+    let plan_approval: PlanApprovalPrompter = Arc::new(|_path, _body| Ok(false));
+    let todos = shared_todo_store();
+    let ask_user = default_ask_user_prompter();
+    let background = shared_background_tasks();
+    let hooks = HookRunner::with_bash(Vec::new(), sandbox.workdir().to_path_buf());
+    let options = PromptOptions {
+        stream: false,
+        quiet: true,
+        ..PromptOptions::default()
+    };
+    let mut dedup = ToolDedup::new();
+    let executor = DefaultToolExecutor::new(ToolExecutorDeps {
+        tools,
+        sandbox: Arc::clone(&sandbox),
+        permission,
+        approval_broker: broker,
+        plan_mode,
+        plan_approval: &plan_approval,
+        todos,
+        ask_user,
+        background,
+        subagent: Some(subagent_env),
+        hooks: &hooks,
+    });
+    executor
+        .execute(
+            tool_calls,
+            &options,
+            cancel,
+            "subagent",
+            sandbox.workdir(),
+            &mut dedup,
+        )
+        .await
 }
 
 fn outcome_for_batch(results: &[(bool, bool)]) -> ToolBatchOutcome {

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `ad7e8e9`（PR #95 已合并）。**
+> **进度快照：2026-08-13，基线 `fa5a1dd`（PR #96 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（RuntimeScope / ToolCatalog 第一刀）。
+> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（Subagent 已走 RuntimeScope + DefaultToolExecutor）。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -33,7 +33,7 @@
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者，但 Agent-specific actor 仍在 `zene-core`，ACP 仍保留 transport 层 session bookkeeping。
 6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 与 option 列表只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`，并带 `ApprovalKind` / `ApprovalRisk`。已分类 Cloud payload 与审批表 payload 已是产品字段；未识别帧仍为 ACP JSON。API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举。
-7. `ToolRegistry` 仍同时承担目录与执行；`RuntimeScope` 尚未成为 Subagent 的正式差异注入面。
+7. `ToolRegistry` 仍同时承担目录与执行；`ToolCatalog` 已抽出定义端口，Subagent 经 `RuntimeScope` 注入。主 Agent 仍直接持有 registry。
 
 本文目标不是立刻重写 runtime，而是建立一个可以渐进落地的目标架构：
 
@@ -1097,7 +1097,7 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 | Wave 11 | 已完成第一阶段 | ModelExecutor、ContextModel、usage boundary、runtime protocol 和 lifecycle publisher 已落地；Agent-specific actor 尚在 core |
 | Wave 12 | 已完成第一阶段 | safe resume、Cloud RuntimeClient、neutral runtime notifications、fenced command lease/ack、atomic state/event writes、outbox replay 和真实 replacement 测试已落地 |
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
-| Wave 14 | 进行中 | RuntimeScope + ToolCatalog 第一刀已接到 Subagent；Agent 退回 wiring 仍待做 |
+| Wave 14 | 进行中 | RuntimeScope + ToolCatalog + Subagent `DefaultToolExecutor`；Agent 退回 wiring / ChatBackend→ModelExecutor 仍待做 |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
 | Wave 16 | 已完成 command 对齐 | Cloud RuntimeCommand 含 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；仍不依赖 `zene-runtime` |
 
@@ -1455,3 +1455,9 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 - 新增 `zene_tools::RuntimeScope`：Subagent 经 scope 注入 profile / depth / max_depth / tool catalog。
 - 新增 `ToolCatalog` trait；`ToolRegistry` 实现该 trait。Subagent `PreparedContext.tools` 经 catalog 取定义。
 - 保留 `SubagentRunner` facade。不搬 Agent actor。不做 Cloud 改动。
+
+### 2026-08-13 — Wave 14 Subagent DefaultToolExecutor
+
+- Subagent 工具批次经 `execute_subagent_tool_batch` 走与主 Agent 相同的 `DefaultToolExecutor`（permission / scheduler / output bound / dedup）。
+- 删除并行的 `run_subagent_tools` 顺序执行路径。无 permission 时仍 bypass。
+- 不替换 Subagent `ChatBackend`。不搬 Agent actor。不做 Cloud 改动。

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -101,7 +101,7 @@ RuntimeHandle → Agent → TurnEngine
 | Session | `crates/session` | `SessionRecord` + `SessionStore`；events 优先，messages 为 materialized cache |
 | Context | `crates/context` | observe/commit/project；`SessionView` 驱动 event-backed projection |
 | Permission | `crates/permission` | `evaluate` 纯判定；`Ask` 走 `ApprovalBroker`。Runtime 挂 waiter，transport 发 `RuntimeCommand::Approval` |
-| Subagent | `crates/core/src/subagent.rs` | 直接实现 `TurnEnginePorts`；仍用独立 `ChatBackend` 和内存消息，尚未 `RuntimeScope` |
+| Subagent | `crates/core/src/subagent.rs` | 经 `RuntimeScope` 注入工具目录；工具执行走 `DefaultToolExecutor`；仍用独立 `ChatBackend` 与内存消息 |
 | Runtime | `crates/runtime` + `crates/core/src/agent_runtime.rs` | 公共 command/event 在 `zene-runtime`；Agent actor 仍在 core |
 | ACP | `apps/cli/src/acp/server.rs` | transport adapter；创建/加载 session，并把请求接入 `RuntimeHandle` |
 | Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；API→worker `WorkerCommand` 为 Prompt/Cancel；审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；ACP `optionId` 只在 adapter 内映射 |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#96 给 Subagent 接上 `RuntimeScope` / `ToolCatalog` 之后，工具执行仍走独立的 `run_subagent_tools` 顺序循环。本 PR 继续 Wave 14：让 Subagent 工具批次与主 Agent 共用 `DefaultToolExecutor`。

新增 `execute_subagent_tool_batch`：经 scope 持有的工具集走 permission / scheduler / output bound / dedup。删除并行的 `run_subagent_tools`。无 permission 时仍 bypass。保留 `SubagentRunner` facade 与内存会话。

不替换 Subagent `ChatBackend`。不搬 Agent actor。不做 Cloud 改动。

`cargo test -p zene-core --locked --lib` 已通过。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

