### PR TITLE
feat: Wave 14 Subagent 模型调用走 ModelExecutor

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -54,7 +54,7 @@ pub use events::{emit_event, runtime_event_handler, AgentEvent, EventHandler};
 pub use plan_mode::PlanApprovalPrompter;
 use plan_mode::{tool_visible_in_definitions};
 pub use runtime::RuntimeHandle;
-pub use subagent::{run_subagent, ChatBackend, CoreSubagentRunner};
+pub use subagent::{run_subagent, CoreSubagentRunner};
 pub use tool_dedup::{append_reminder, ToolDedup};
 pub use tool_scheduler::{classify_tool_accesses, ToolScheduler};
 pub use zene_hooks::{HookBlock, HookRunner, HookSpec};

--- a/crates/core/src/subagent.rs
+++ b/crates/core/src/subagent.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use tokio_util::sync::CancellationToken;
 use zene_config::ZeneConfig;
 use zene_llm::{ChatClient, ChatRequest, ChatResponse, Message, TokenUsage, ToolCall};
+use zene_model_executor::{ChatClientExecutor, ModelExecutor, ModelStream};
 use zene_sandbox::Sandbox;
 use zene_tools::{
     RuntimeScope, SubagentEnv, SubagentProfile, SubagentRunner, ToolCatalog, ToolContext,
@@ -25,17 +26,6 @@ use zene_turn::{
     TurnRequest, TurnRuntime, TurnSessionPort, TurnState,
 };
 
-#[async_trait]
-pub trait ChatBackend: Send + Sync {
-    async fn chat(&self, request: ChatRequest) -> Result<ChatResponse>;
-}
-
-#[async_trait]
-impl ChatBackend for ChatClient {
-    async fn chat(&self, request: ChatRequest) -> Result<ChatResponse> {
-        ChatClient::chat(self, request).await
-    }
-}
 
 pub struct CoreSubagentRunner {
     config: ZeneConfig,
@@ -56,6 +46,13 @@ impl CoreSubagentRunner {
     }
 }
 
+
+async fn model_executor_from_config(config: &ZeneConfig) -> Result<Arc<dyn ModelExecutor>> {
+    let client = ChatClient::from_config(config).await?;
+    Ok(Arc::new(ChatClientExecutor::new(Arc::new(client))))
+}
+
+
 #[async_trait]
 impl SubagentRunner for CoreSubagentRunner {
     async fn run_subagent(
@@ -65,7 +62,7 @@ impl SubagentRunner for CoreSubagentRunner {
         cwd: Option<&Path>,
         parent_ctx: &ToolContext,
     ) -> Result<String> {
-        let client = ChatClient::from_config(&self.config).await?;
+        let executor = model_executor_from_config(&self.config).await?;
         let sandbox = resolve_subagent_sandbox(&parent_ctx.sandbox, cwd)?;
         let parent_depth = parent_ctx
             .subagent
@@ -78,7 +75,7 @@ impl SubagentRunner for CoreSubagentRunner {
             profile,
             sandbox,
             &self.config,
-            &client,
+            executor,
             parent_ctx.cancel.as_ref(),
             parent_depth,
             parent_ctx.permission.clone(),
@@ -94,7 +91,7 @@ pub async fn run_subagent(
     profile: SubagentProfile,
     sandbox: Arc<dyn Sandbox>,
     config: &ZeneConfig,
-    backend: &dyn ChatBackend,
+    model_executor: Arc<dyn ModelExecutor>,
     cancel: Option<&CancellationToken>,
     parent_depth: u32,
     permission: Option<SharedToolPermission>,
@@ -104,7 +101,7 @@ pub async fn run_subagent(
         profile,
         sandbox,
         config,
-        backend,
+        model_executor,
         cancel,
         parent_depth,
         permission,
@@ -119,7 +116,7 @@ pub(crate) async fn run_subagent_with_runner(
     profile: SubagentProfile,
     sandbox: Arc<dyn Sandbox>,
     config: &ZeneConfig,
-    backend: &dyn ChatBackend,
+    model_executor: Arc<dyn ModelExecutor>,
     cancel: Option<&CancellationToken>,
     parent_depth: u32,
     permission: Option<SharedToolPermission>,
@@ -135,7 +132,7 @@ pub(crate) async fn run_subagent_with_runner(
         scope,
         sandbox,
         config,
-        backend,
+        model_executor,
         subagent_env,
         permission,
         broker,
@@ -151,12 +148,11 @@ pub(crate) async fn run_subagent_with_runner(
 ///
 /// Subagents share the generic turn state machine. Conversation stays in
 /// memory; they do not publish the parent runtime's events or checkpoints.
-/// Tools come from [`RuntimeScope`] so Explore/Coder differ by scope, not a
-/// parallel wiring path.
+/// Tools come from [`RuntimeScope`]; model calls go through [`ModelExecutor`].
 struct SubagentTurnRuntime<'a> {
     sandbox: Arc<dyn Sandbox>,
     config: &'a ZeneConfig,
-    backend: &'a dyn ChatBackend,
+    model_executor: Arc<dyn ModelExecutor>,
     /// Retained for later ToolPolicy / SessionPolicy injection.
     #[allow(dead_code)]
     scope: RuntimeScope,
@@ -174,7 +170,7 @@ impl<'a> SubagentTurnRuntime<'a> {
         scope: RuntimeScope,
         sandbox: Arc<dyn Sandbox>,
         config: &'a ZeneConfig,
-        backend: &'a dyn ChatBackend,
+        model_executor: Arc<dyn ModelExecutor>,
         subagent_env: SubagentEnv,
         permission: Option<SharedToolPermission>,
         broker: Option<zene_permission::SharedApprovalBroker>,
@@ -184,7 +180,7 @@ impl<'a> SubagentTurnRuntime<'a> {
         Self {
             sandbox,
             config,
-            backend,
+            model_executor,
             scope,
             subagent_env,
             permission,
@@ -210,7 +206,7 @@ impl<'a> SubagentTurnRuntime<'a> {
             self.tools.as_ref(),
             &self.compaction_config,
             &self.config.model,
-            self.backend,
+            Arc::clone(&self.model_executor),
         )
         .await?;
         Ok(PreparedContext {
@@ -257,8 +253,8 @@ impl<'a> SubagentTurnRuntime<'a> {
             return Err(aborted_error());
         }
         let response = self
-            .backend
-            .chat(ChatRequest {
+            .model_executor
+            .complete(ChatRequest {
                 model: self.config.model.clone(),
                 messages: context.messages,
                 tools: context.tools,
@@ -509,7 +505,7 @@ async fn maybe_compact_subagent_messages(
     tools: &ToolRegistry,
     compaction_config: &zene_context::CompactionConfig,
     model: &str,
-    backend: &dyn ChatBackend,
+    model_executor: Arc<dyn ModelExecutor>,
 ) -> Result<()> {
     let tool_defs = tools.definitions();
     let estimator = TokenEstimator::default();
@@ -525,7 +521,7 @@ async fn maybe_compact_subagent_messages(
         "subagent_token_threshold",
         &tool_defs,
         &estimator,
-        |request| backend.chat(request),
+        |request| model_executor.complete(request),
     )
     .await?
     .is_some()
@@ -596,8 +592,8 @@ mod tests {
     }
 
     #[async_trait]
-    impl ChatBackend for ScriptedBackend {
-        async fn chat(&self, request: ChatRequest) -> Result<ChatResponse> {
+    impl ModelExecutor for ScriptedBackend {
+        async fn complete(&self, request: ChatRequest) -> Result<ChatResponse> {
             let idx = self.calls.fetch_add(1, Ordering::SeqCst);
             let response = self
                 .responses
@@ -612,6 +608,12 @@ mod tests {
             }
 
             Ok(response)
+        }
+
+        async fn stream(&self, _request: ChatRequest) -> Result<ModelStream> {
+            Ok(Box::pin(futures::stream::iter([Ok(
+                zene_llm::StreamEvent::Done { usage: None },
+            )])))
         }
     }
 
@@ -630,7 +632,7 @@ mod tests {
             parent_ctx: &ToolContext,
         ) -> Result<String> {
             self.calls.fetch_add(1, Ordering::SeqCst);
-            let client = ChatClient::from_config(&self.config).await?;
+            let executor = model_executor_from_config(&self.config).await?;
             let sandbox = resolve_subagent_sandbox(&parent_ctx.sandbox, cwd)?;
             let parent_depth = parent_ctx
                 .subagent
@@ -642,7 +644,7 @@ mod tests {
                 profile,
                 sandbox,
                 &self.config,
-                &client,
+                executor,
                 parent_ctx.cancel.as_ref(),
                 parent_depth,
                 parent_ctx.permission.clone(),
@@ -711,7 +713,7 @@ mod tests {
             SubagentProfile::Explore,
             Arc::clone(&sandbox),
             &config,
-            &backend,
+            Arc::new(backend),
             None,
             0,
             None,
@@ -774,7 +776,7 @@ mod tests {
             SubagentProfile::Explore,
             sandbox,
             &config,
-            &backend,
+            Arc::new(backend),
             None,
             0,
             None,
@@ -855,7 +857,7 @@ mod tests {
             SubagentProfile::Coder,
             Arc::clone(&sandbox),
             &config,
-            &backend,
+            Arc::new(backend),
             None,
             0,
             Some(permission),

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `fa5a1dd`（PR #96 已合并）。**
+> **进度快照：2026-08-13，基线 `fcabddc`（PR #97 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（Subagent 已走 RuntimeScope + DefaultToolExecutor）。
+> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（Subagent 已走 RuntimeScope + DefaultToolExecutor + ModelExecutor）。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -101,7 +101,7 @@ RuntimeHandle → Agent → TurnEngine
 | Session | `crates/session` | `SessionRecord` + `SessionStore`；events 优先，messages 为 materialized cache |
 | Context | `crates/context` | observe/commit/project；`SessionView` 驱动 event-backed projection |
 | Permission | `crates/permission` | `evaluate` 纯判定；`Ask` 走 `ApprovalBroker`。Runtime 挂 waiter，transport 发 `RuntimeCommand::Approval` |
-| Subagent | `crates/core/src/subagent.rs` | 经 `RuntimeScope` 注入工具目录；工具执行走 `DefaultToolExecutor`；仍用独立 `ChatBackend` 与内存消息 |
+| Subagent | `crates/core/src/subagent.rs` | 经 `RuntimeScope` 注入工具目录；工具执行走 `DefaultToolExecutor`；模型走 `ModelExecutor`；仍用内存消息 |
 | Runtime | `crates/runtime` + `crates/core/src/agent_runtime.rs` | 公共 command/event 在 `zene-runtime`；Agent actor 仍在 core |
 | ACP | `apps/cli/src/acp/server.rs` | transport adapter；创建/加载 session，并把请求接入 `RuntimeHandle` |
 | Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；API→worker `WorkerCommand` 为 Prompt/Cancel；审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；ACP `optionId` 只在 adapter 内映射 |
@@ -950,7 +950,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 
 1. **Turn ports 已是真入口（Wave 13，PR #60）**：`AgentTurnPorts.prepare_context` 产出 `PreparedContext`，`run_model` 只消费它；Subagent 直接实现 `TurnEnginePorts`。
 2. **`Agent` 仍是 God Object**：它同时持有 model、tools、sandbox、permission、hooks、MCP、todos、plan mode。下一步是把它变成 wiring，而不是继续实现 step。
-3. **模型抽象仍偏 provider**：`ModelExecutor` 吃 `ChatRequest`；Subagent 另有 `ChatBackend`。目标是 Turn 只看见 `PreparedContext` → `ModelRequest`。
+3. **模型抽象仍偏 provider**：`ModelExecutor` 吃 `ChatRequest`；Subagent 已共用 `ModelExecutor`。目标是 Turn 只看见 `PreparedContext` → `ModelRequest`。
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
 5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision` / `ApprovalKind` / `ApprovalRisk`。Cloud 仍不是 `zene-runtime::RuntimeCommand`（无 Steer/SetMode，不引入该 crate）。
 6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段。平台事件 payload 是 domain `PlatformEvent`。写入路径 `event_type` 是 `RunEventKind`。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection 等不进时间线。未识别帧仍为 `acp`。
@@ -1097,7 +1097,7 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 | Wave 11 | 已完成第一阶段 | ModelExecutor、ContextModel、usage boundary、runtime protocol 和 lifecycle publisher 已落地；Agent-specific actor 尚在 core |
 | Wave 12 | 已完成第一阶段 | safe resume、Cloud RuntimeClient、neutral runtime notifications、fenced command lease/ack、atomic state/event writes、outbox replay 和真实 replacement 测试已落地 |
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
-| Wave 14 | 进行中 | RuntimeScope + ToolCatalog + Subagent `DefaultToolExecutor`；Agent 退回 wiring / ChatBackend→ModelExecutor 仍待做 |
+| Wave 14 | 进行中 | RuntimeScope + ToolCatalog + Subagent DefaultToolExecutor/ModelExecutor；Agent 退回 wiring 仍待做 |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
 | Wave 16 | 已完成 command 对齐 | Cloud RuntimeCommand 含 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；仍不依赖 `zene-runtime` |
 
@@ -1133,7 +1133,7 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 4. **仍明确未自动完成的项目**
    - pending tool / approval 的任意副作用自动 replay：继续采用 inspection/manual intervention，避免重复写操作。
    - `Agent` 从 step orchestrator 完全退回 composition root。
-   - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor` / ModelExecutor，而不是并行 `ChatBackend`。
+   - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor` / `ModelExecutor`（已落地）；仍用内存消息。
    - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；API→worker 仍是 Prompt/Cancel；不依赖 `zene-runtime`）。`GetMode` / `ResumeSafeTurn` 仍仅本地。未识别 Cloud 帧仍为 ACP JSON。
    - Agent-specific actor 从 `zene-core` 移入独立 runtime implementation crate（应在 ports/审批稳定之后）。
    - 跨 VM outbox 的共享持久化实现；当前部署文档要求共享 POSIX volume 或后续 DB/object spool。
@@ -1461,3 +1461,9 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 - Subagent 工具批次经 `execute_subagent_tool_batch` 走与主 Agent 相同的 `DefaultToolExecutor`（permission / scheduler / output bound / dedup）。
 - 删除并行的 `run_subagent_tools` 顺序执行路径。无 permission 时仍 bypass。
 - 不替换 Subagent `ChatBackend`。不搬 Agent actor。不做 Cloud 改动。
+
+### 2026-08-13 — Wave 14 Subagent ModelExecutor
+
+- 删除并行 `ChatBackend`；Subagent 模型调用与 compaction 经 `Arc<dyn ModelExecutor>`（默认 `ChatClientExecutor`）。
+- `run_subagent` / `CoreSubagentRunner` API 对齐主 Agent 的 model executor 注入面。
+- 不搬 Agent actor。不做 Cloud 改动。不引入中性 `ModelRequest`。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wave 14 下一刀：删除并行 `ChatBackend`，Subagent 的 `invoke_model` / compaction 统一经 `Arc<dyn ModelExecutor>`（默认 `ChatClientExecutor`），与主 Agent 模型注入面对齐。

## Changes

- `crates/core/src/subagent.rs`：模型调用改走 `ModelExecutor`
- `run_subagent` / `CoreSubagentRunner` API 对齐主 Agent 注入面
- 文档更新 Wave 14 进度

## Out of scope

- 不搬 Agent actor 出 core
- 不做 Cloud 改动
- 不引入中性 `ModelRequest`
- Agent 退回 composition root / 更完整 RuntimeScope 留后续

## Test plan

- [x] `cargo test -p zene-core --locked --lib`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

