### PR TITLE
feat: Wave 14 主 Agent 经 RuntimeScope 接线

### DIFF
--- a/crates/core/src/agent_builder.rs
+++ b/crates/core/src/agent_builder.rs
@@ -16,7 +16,8 @@ use zene_sandbox::{LocalSandbox, Sandbox};
 use zene_session::{AgentRecordWriter, FileSessionStore, SessionRecord, SessionStore};
 use zene_tools::{
     default_ask_user_prompter, shared_background_tasks, shared_plan_mode, shared_todo_store_from,
-    SharedAskUserPrompter, SharedBackgroundTasks, SharedPlanMode, SharedTodoStore, ToolRegistry,
+    RuntimeScope, SharedAskUserPrompter, SharedBackgroundTasks, SharedPlanMode, SharedTodoStore,
+    ToolRegistry,
 };
 
 use crate::plan_mode::{default_plan_approval_prompter, PlanApprovalPrompter};
@@ -108,7 +109,7 @@ impl AgentBuilder {
         self
     }
 
-    /// Replace default `agent_tools` registry (MCP tools are not merged unless [`Self::mcp_auto`]).
+    /// Replace default `RuntimeScope::agent` registry (MCP tools are not merged unless [`Self::mcp_auto`]).
     pub fn tools(mut self, tools: ToolRegistry) -> Self {
         self.tools = Some(tools);
         self
@@ -255,11 +256,11 @@ impl AgentBuilder {
             None => AgentRecordWriter::for_session(&self.session.meta.id)?,
         };
 
+        let runtime_scope =
+            RuntimeScope::agent(self.config.agent_profile, self.config.web_search.clone());
         let mut tools = match self.tools {
             Some(tools) => tools,
-            None => {
-                zene_tools::agent_tools(self.config.agent_profile, self.config.web_search.clone())
-            }
+            None => runtime_scope.tools(),
         };
 
         let mcp = match self.mcp {
@@ -331,6 +332,7 @@ impl AgentBuilder {
                 )))
             }),
             context_model: client,
+            runtime_scope,
             tools: Arc::new(tools),
             sandbox,
             session: self.session,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,8 +19,8 @@ use zene_session::{
 pub use zene_session::{RecoveryDisposition, RecoveryExecution, RecoverySnapshot};
 pub use zene_tools::AskUserOption;
 use zene_tools::{
-    shared_todo_store_from, SharedAskUserPrompter, SharedBackgroundTasks, SharedPlanMode,
-    SharedTodoStore, SubagentEnv, ToolRegistry, DEFAULT_SUBAGENT_MAX_DEPTH,
+    shared_todo_store_from, RuntimeScope, SharedAskUserPrompter, SharedBackgroundTasks,
+    SharedPlanMode, SharedTodoStore, ToolCatalog, ToolRegistry,
 };
 
 mod agent_builder;
@@ -103,6 +103,8 @@ pub struct Agent {
     config: ZeneConfig,
     context_model: Arc<dyn zene_context::ContextModel>,
     model_executor: Arc<dyn ModelExecutor>,
+    /// Root capability scope (depth 0). Tools may be overridden after scope build.
+    runtime_scope: RuntimeScope,
     tools: Arc<ToolRegistry>,
     sandbox: Arc<dyn Sandbox>,
     session: SessionRecord,
@@ -255,8 +257,10 @@ impl Agent {
 
     fn tool_definitions_for_llm(&self) -> Vec<zene_llm::ToolDefinition> {
         let active = self.is_plan_mode_active();
-        self.tools
-            .filter_definitions(|name| tool_visible_in_definitions(name, active))
+        ToolCatalog::definitions(self.tools.as_ref())
+            .into_iter()
+            .filter(|def| tool_visible_in_definitions(&def.name, active))
+            .collect()
     }
 
     pub(crate) fn execution_record_writer(&self) -> AgentRecordWriter {
@@ -1164,11 +1168,7 @@ impl Agent {
                 todos: Arc::clone(&self.todos),
                 ask_user: Arc::clone(&self.ask_user),
                 background: Arc::clone(&self.background),
-                subagent: Some(SubagentEnv {
-                    depth: 0,
-                    max_depth: DEFAULT_SUBAGENT_MAX_DEPTH,
-                    runner: subagent_runner,
-                }),
+                subagent: Some(self.runtime_scope.env(subagent_runner)),
                 hooks: &self.hooks,
             });
             executor

--- a/crates/core/src/subagent.rs
+++ b/crates/core/src/subagent.rs
@@ -179,7 +179,10 @@ impl<'a> SubagentTurnRuntime<'a> {
         permission: Option<SharedToolPermission>,
         broker: Option<zene_permission::SharedApprovalBroker>,
     ) -> Self {
-        let system_prompt = subagent_system_prompt(scope.profile, sandbox.workdir());
+        let profile = scope
+            .subagent_profile()
+            .expect("SubagentTurnRuntime requires a subagent RuntimeScope");
+        let system_prompt = subagent_system_prompt(profile, sandbox.workdir());
         let tools = Arc::new(scope.tools());
         Self {
             sandbox,

--- a/crates/tools/src/scope.rs
+++ b/crates/tools/src/scope.rs
@@ -1,24 +1,50 @@
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
+use zene_config::{AgentProfile, WebSearchConfig};
 
-use crate::builtin::tools_for_profile;
+use crate::builtin::{agent_tools, tools_for_profile};
 use crate::registry::ToolRegistry;
 use crate::subagent::{SubagentEnv, SubagentProfile, SubagentRunner, DEFAULT_SUBAGENT_MAX_DEPTH};
 
-/// Capability boundary for a child/runtime turn.
+/// Capability boundary for a main-agent or child runtime turn.
 ///
-/// Wave 14 first slice: Subagent construction goes through a scope so profile,
-/// nesting depth, and tool catalog stay one injection point. Full-agent scopes
-/// and ToolPolicy/SessionPolicy land in later slices.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Wave 14: construction goes through a scope so profile, nesting depth, and
+/// tool catalog stay one injection point. ToolPolicy/SessionPolicy land later.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeScope {
-    pub profile: SubagentProfile,
+    kind: RuntimeKind,
     pub depth: u32,
     pub max_depth: u32,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum RuntimeKind {
+    Agent {
+        profile: AgentProfile,
+        web_search: WebSearchConfig,
+    },
+    Subagent {
+        profile: SubagentProfile,
+    },
+}
+
 impl RuntimeScope {
+    /// Root scope for the main Agent (depth `0`).
+    ///
+    /// Uses [`agent_tools`] — Explore/Coder agent boxes differ from Subagent
+    /// profile boxes (collaboration / plan / Task).
+    pub fn agent(profile: AgentProfile, web_search: WebSearchConfig) -> Self {
+        Self {
+            kind: RuntimeKind::Agent {
+                profile,
+                web_search,
+            },
+            depth: 0,
+            max_depth: DEFAULT_SUBAGENT_MAX_DEPTH,
+        }
+    }
+
     /// Build a child scope under `parent_depth`. Depth `0` is the main agent.
     pub fn subagent(profile: SubagentProfile, parent_depth: u32) -> Result<Self> {
         let depth = parent_depth.saturating_add(1);
@@ -26,14 +52,28 @@ impl RuntimeScope {
             bail!("Subagent nesting limit reached (max depth {DEFAULT_SUBAGENT_MAX_DEPTH})");
         }
         Ok(Self {
-            profile,
+            kind: RuntimeKind::Subagent { profile },
             depth,
             max_depth: DEFAULT_SUBAGENT_MAX_DEPTH,
         })
     }
 
+    /// Subagent profile when this scope was built via [`Self::subagent`].
+    pub fn subagent_profile(&self) -> Option<SubagentProfile> {
+        match self.kind {
+            RuntimeKind::Subagent { profile } => Some(profile),
+            RuntimeKind::Agent { .. } => None,
+        }
+    }
+
     pub fn tools(&self) -> ToolRegistry {
-        tools_for_profile(self.profile)
+        match &self.kind {
+            RuntimeKind::Agent {
+                profile,
+                web_search,
+            } => agent_tools(*profile, web_search.clone()),
+            RuntimeKind::Subagent { profile } => tools_for_profile(*profile),
+        }
     }
 
     pub fn catalog(&self) -> ToolRegistry {
@@ -88,5 +128,34 @@ mod tests {
         let err = RuntimeScope::subagent(SubagentProfile::Explore, DEFAULT_SUBAGENT_MAX_DEPTH)
             .expect_err("over max");
         assert!(err.to_string().contains("nesting limit"));
+    }
+
+    #[test]
+    fn agent_scope_is_root_depth_and_uses_agent_tool_boxes() {
+        let scope = RuntimeScope::agent(AgentProfile::Explore, WebSearchConfig::default());
+        assert_eq!(scope.depth, 0);
+        assert!(scope.subagent_profile().is_none());
+        let names: Vec<_> = scope
+            .definitions()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect();
+        assert!(names.contains(&"Read".into()));
+        assert!(names.contains(&"AskUserQuestion".into()));
+        assert!(!names.iter().any(|name| name == "Write" || name == "Edit" || name == "Bash"));
+        // Agent Explore includes plan/collaboration; Subagent Explore does not include Task.
+        assert!(!names.iter().any(|name| name == "Task"));
+    }
+
+    #[test]
+    fn agent_coder_scope_includes_task() {
+        let scope = RuntimeScope::agent(AgentProfile::Coder, WebSearchConfig::default());
+        let names: Vec<_> = scope
+            .definitions()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect();
+        assert!(names.contains(&"Write".into()));
+        assert!(names.contains(&"Task".into()));
     }
 }

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -4,7 +4,7 @@
 >
 > **进度快照：2026-08-13，基线 `fa5a1dd`（PR #96 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（Subagent 已走 RuntimeScope + DefaultToolExecutor）。
+> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（主 Agent / Subagent 经 RuntimeScope + ToolCatalog；Subagent 已走 DefaultToolExecutor）。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -33,7 +33,7 @@
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者，但 Agent-specific actor 仍在 `zene-core`，ACP 仍保留 transport 层 session bookkeeping。
 6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 与 option 列表只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`，并带 `ApprovalKind` / `ApprovalRisk`。已分类 Cloud payload 与审批表 payload 已是产品字段；未识别帧仍为 ACP JSON。API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举。
-7. `ToolRegistry` 仍同时承担目录与执行；`ToolCatalog` 已抽出定义端口，Subagent 经 `RuntimeScope` 注入。主 Agent 仍直接持有 registry。
+7. `ToolRegistry` 仍同时承担目录与执行；`ToolCatalog` 已抽出定义端口；主 Agent / Subagent 均经 `RuntimeScope` 注入 catalog。Agent 仍持有 registry 执行面，尚未完全退回 composition root。
 
 本文目标不是立刻重写 runtime，而是建立一个可以渐进落地的目标架构：
 
@@ -1097,7 +1097,7 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 | Wave 11 | 已完成第一阶段 | ModelExecutor、ContextModel、usage boundary、runtime protocol 和 lifecycle publisher 已落地；Agent-specific actor 尚在 core |
 | Wave 12 | 已完成第一阶段 | safe resume、Cloud RuntimeClient、neutral runtime notifications、fenced command lease/ack、atomic state/event writes、outbox replay 和真实 replacement 测试已落地 |
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
-| Wave 14 | 进行中 | RuntimeScope + ToolCatalog + Subagent `DefaultToolExecutor`；Agent 退回 wiring / ChatBackend→ModelExecutor 仍待做 |
+| Wave 14 | 进行中 | RuntimeScope + ToolCatalog（主 Agent + Subagent）+ Subagent `DefaultToolExecutor`；ChatBackend→ModelExecutor / 完全退回 composition root 仍待做 |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
 | Wave 16 | 已完成 command 对齐 | Cloud RuntimeCommand 含 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；仍不依赖 `zene-runtime` |
 
@@ -1132,8 +1132,8 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 
 4. **仍明确未自动完成的项目**
    - pending tool / approval 的任意副作用自动 replay：继续采用 inspection/manual intervention，避免重复写操作。
-   - `Agent` 从 step orchestrator 完全退回 composition root。
-   - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor` / ModelExecutor，而不是并行 `ChatBackend`。
+   - `Agent` 从 step orchestrator 完全退回 composition root（catalog 已经 `RuntimeScope` 接线；step 编排仍在 Agent）。
+   - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor`；ChatBackend→ModelExecutor 仍待做；仍用内存消息。
    - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；API→worker 仍是 Prompt/Cancel；不依赖 `zene-runtime`）。`GetMode` / `ResumeSafeTurn` 仍仅本地。未识别 Cloud 帧仍为 ACP JSON。
    - Agent-specific actor 从 `zene-core` 移入独立 runtime implementation crate（应在 ports/审批稳定之后）。
    - 跨 VM outbox 的共享持久化实现；当前部署文档要求共享 POSIX volume 或后续 DB/object spool。
@@ -1461,3 +1461,9 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 - Subagent 工具批次经 `execute_subagent_tool_batch` 走与主 Agent 相同的 `DefaultToolExecutor`（permission / scheduler / output bound / dedup）。
 - 删除并行的 `run_subagent_tools` 顺序执行路径。无 permission 时仍 bypass。
 - 不替换 Subagent `ChatBackend`。不搬 Agent actor。不做 Cloud 改动。
+
+### 2026-08-13 — Wave 14 主 Agent RuntimeScope 接线
+
+- 新增 `RuntimeScope::agent(AgentProfile, WebSearchConfig)`（depth 0，经 `agent_tools` 建 catalog）。
+- `AgentBuilder` 默认工具路径与父级 `SubagentEnv` 经 root scope 注入；LLM 定义经 `ToolCatalog` 再套 plan-mode 过滤。
+- 不搬 Agent actor。不做 ToolPolicy/SessionPolicy。不做 Cloud 改动。不替换 Subagent `ChatBackend`。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wave 14 下一刀：主 Agent 与 Subagent 共用 `RuntimeScope` 作为 profile → catalog → depth 的注入点。新增 `RuntimeScope::agent`，`AgentBuilder` 默认工具与父级 `SubagentEnv` 经 root scope 接线；LLM 定义经 `ToolCatalog` 再套 plan-mode 过滤。

已 rebase/merge `#98`（Subagent ModelExecutor）并解决文档冲突。

## Changes

- `RuntimeScope::agent(AgentProfile, WebSearchConfig)`（depth 0，走 `agent_tools`，与 Subagent 小工具箱区分）
- `Agent` 持有 `runtime_scope`；`run_tools` 用 `scope.env(runner)` 替代硬编码 depth 0
- `tool_definitions_for_llm` 经 `ToolCatalog::definitions`
- 文档更新 Wave 14 进度（与 #98 changelog 并存）

## Out of scope

- 不搬 Agent actor
- 不做 ToolPolicy / SessionPolicy
- 不做 Cloud 改动
- 不把 Agent 的 step 编排一次性抽空

## Test plan

- [x] `cargo test -p zene-tools -p zene-core --locked --lib`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

