### PR TITLE
feat: Wave 14 抽出主 Agent model-step 编排

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,13 +1,11 @@
 use anyhow::{bail, Context, Result};
-use futures::StreamExt;
 use parking_lot::Mutex;
-use std::io::{self, Write};
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use zene_config::ZeneConfig;
-use zene_context::{ContextDeps, ContextEngine, PrefireClientFactory, StepContext};
-use zene_llm::{ChatClient, ChatRequest, Message, StreamEvent, TokenUsage, ToolCall};
+use zene_context::{ContextDeps, ContextEngine, PrefireClientFactory};
+use zene_llm::{ChatClient, Message, TokenUsage, ToolCall};
 
 use zene_mcp::McpManager;
 use zene_model_executor::ModelExecutor;
@@ -32,6 +30,7 @@ pub use zene_model_executor as model_executor;
 mod context_events;
 mod context_hooks;
 mod events;
+mod model_step;
 mod plan_mode;
 mod runtime;
 mod subagent;
@@ -74,7 +73,7 @@ pub use zene_turn::{
 };
 pub use zene_workspace::{build_system_prompt, FsWorkspaceProvider, WorkspaceProvider};
 
-fn make_context_deps<'a>(
+pub(crate) fn make_context_deps<'a>(
     session: &'a mut SessionRecord,
     compaction_config: &'a zene_context::CompactionConfig,
     model: &'a str,
@@ -923,196 +922,30 @@ impl Agent {
         options: &PromptOptions,
         cancel: Option<&CancellationToken>,
     ) -> Result<zene_turn::StepResult> {
-        let tools = context.tools.clone();
-        let step = StepContext {
-            estimate_tokens: context.estimate_tokens.unwrap_or(0),
-            metadata: context.metadata.unwrap_or_default(),
-            messages: context.messages,
-        };
-        let (assistant_message, usage) = self
-            .run_llm_step(&step, &tools, options, cancel)
-            .await
-            .context("llm step")?;
-        let had_tool_calls = assistant_message
-            .tool_calls
-            .as_ref()
-            .is_some_and(|calls| !calls.is_empty());
-        Ok(zene_turn::StepResult {
-            message: assistant_message,
-            usage,
-            had_tool_calls,
-        })
-    }
-
-    async fn run_llm_step(
-        &mut self,
-        step: &StepContext,
-        tools: &[zene_llm::ToolDefinition],
-        options: &PromptOptions,
-        cancel: Option<&CancellationToken>,
-    ) -> Result<(Message, Option<TokenUsage>)> {
-        let mut overflow_state = model_executor::OverflowRetryState::default();
-        let mut messages = step.messages.clone();
-        let mut metadata = step.metadata.clone();
-
-        loop {
-            if Self::check_cancelled(cancel)? {
-                return Err(zene_turn::aborted_error());
-            }
-
-            debug!(
-                estimated_context_tokens = step.estimate_tokens,
-                message_count = messages.len(),
-                "llm step context estimate"
-            );
-
-            let request = model_executor::build_request(
-                &self.config.model,
-                messages.clone(),
-                tools.to_vec(),
-                options.stream,
-                Some(metadata.clone()),
-            );
-
-            let result = if options.stream {
-                self.run_streaming_step(self.model_executor.as_ref(), request, options, cancel)
-                    .await
-            } else {
-                self.model_executor
-                    .complete(request)
-                    .await
-                    .map(|response| (response.message, response.usage))
-            };
-
-            match result {
-                Ok(value) => return Ok(value),
-                Err(err) if ContextEngine::is_context_overflow_error(&err) => {
-                    if let Some(refreshed) =
-                        self.recover_overflow(tools, &mut overflow_state).await?
-                    {
-                        messages = refreshed.messages;
-                        metadata = refreshed.metadata;
-                        continue;
-                    }
-                    return Err(err);
-                }
-                Err(err) => return Err(err),
-            }
-        }
-    }
-
-    async fn recover_overflow(
-        &mut self,
-        tools: &[zene_llm::ToolDefinition],
-        overflow_state: &mut model_executor::OverflowRetryState,
-    ) -> Result<Option<StepContext>> {
-        self.sync_todos_to_session();
-        let estimator = self.token_estimator();
-        let background_tasks = self.background.lock().list();
-        let hooks = context_hooks::ZeneContextHooks::new(
-            &self.session,
-            &background_tasks,
-            self.is_plan_mode_active(),
-        );
-        let compaction_config = context_config::context_compaction_config(&self.config.compaction);
-        let mut handler = context_events::AgentContextHandler::new(
-            self.context_model.as_ref(),
-            &self.config.model,
-            self.sandbox.workdir(),
-        );
-        let prefire_factory = self.prefire_client_factory();
-        let (mut overflow_truncated, mut overflow_summarized) = overflow_state.flags();
-        let overflow = {
-            let mut deps = make_context_deps(
-                &mut self.session,
-                &compaction_config,
-                &self.config.model,
-                self.context_model.as_ref(),
-                Some(&hooks),
-                &self.system_prompt,
-                &estimator,
-                &mut handler,
-                prefire_factory,
-            );
-            self.context
-                .handle_overflow(
-                    &mut deps,
-                    tools,
-                    &mut overflow_truncated,
-                    &mut overflow_summarized,
-                )
-                .await?
-        };
-        overflow_state.set_flags(overflow_truncated, overflow_summarized);
-        if let Some(result) = &overflow.compaction {
-            self.record_compaction(result)?;
-        }
-        overflow
-            .retry
-            .then(|| {
-                self.context
-                    .try_assemble_step(&self.session, tools, &estimator)
-            })
-            .transpose()
+        let plan_mode_active = self.is_plan_mode_active();
+        model_step::run_model_step(
+            model_step::ModelStepDeps {
+                config: &self.config,
+                model_executor: self.model_executor.as_ref(),
+                context_model: self.context_model.as_ref(),
+                context: &mut self.context,
+                session: &mut self.session,
+                system_prompt: &self.system_prompt,
+                workdir: self.sandbox.workdir(),
+                background: &self.background,
+                todos: &self.todos,
+                plan_mode_active,
+                record_writer: &self.record_writer,
+            },
+            context,
+            options,
+            cancel,
+        )
+        .await
     }
 
     fn check_cancelled(cancel: Option<&CancellationToken>) -> Result<bool> {
         Ok(zene_turn::is_cancelled(cancel))
-    }
-
-    async fn run_streaming_step(
-        &self,
-        executor: &dyn zene_model_executor::ModelExecutor,
-        request: ChatRequest,
-        options: &PromptOptions,
-        cancel: Option<&CancellationToken>,
-    ) -> Result<(Message, Option<TokenUsage>)> {
-        if Self::check_cancelled(cancel)? {
-            return Err(zene_turn::aborted_error());
-        }
-
-        let mut stream = executor.stream(request).await?;
-        let mut accumulator = model_executor::StreamAccumulator::default();
-
-        while let Some(event) = stream.next().await {
-            if Self::check_cancelled(cancel)? {
-                return Err(zene_turn::aborted_error());
-            }
-            let event = event.context("stream event")?;
-            match &event {
-                StreamEvent::TextDelta(delta) => {
-                    emit_event(
-                        &options.event_handler,
-                        AgentEvent::TextDelta {
-                            delta: delta.clone(),
-                        },
-                    );
-                    if !options.quiet {
-                        print!("{delta}");
-                        let _ = io::stdout().flush();
-                    }
-                }
-                StreamEvent::ThoughtDelta(delta) => {
-                    emit_event(
-                        &options.event_handler,
-                        AgentEvent::ThoughtDelta {
-                            delta: delta.clone(),
-                        },
-                    );
-                }
-                StreamEvent::ToolCallDelta { .. } => {}
-                StreamEvent::Done { .. } => {}
-            }
-            if accumulator.apply(&event) {
-                break;
-            }
-        }
-
-        if accumulator.has_text() && !options.quiet {
-            println!();
-        }
-
-        Ok(accumulator.finish())
     }
 
     async fn run_tools(

--- a/crates/core/src/model_step.rs
+++ b/crates/core/src/model_step.rs
@@ -1,0 +1,315 @@
+//! Main-agent model-step orchestration extracted from [`crate::Agent`].
+//!
+//! Wave 14: the default turn path still enters via Agent wiring, but the
+//! overflow-retry / stream assembly loop lives here (parallel to
+//! [`crate::tool_executor::DefaultToolExecutor`] for tools). Request type
+//! remains [`zene_llm::ChatRequest`] — no neutral `ModelRequest` yet.
+
+use std::io::{self, Write};
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use futures::StreamExt;
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+use zene_config::ZeneConfig;
+use zene_context::{
+    ContextEngine, ContextModel, EstimateProvider, PrefireClientFactory, StepContext, TokenEstimator,
+};
+use zene_llm::{ChatClient, ChatRequest, Message, StreamEvent, TokenUsage, ToolDefinition};
+use zene_model_executor::ModelExecutor;
+use zene_session::{AgentRecordWriter, RecordEntry, SessionRecord};
+use zene_tools::{SharedBackgroundTasks, SharedTodoStore};
+use zene_turn::PreparedContext;
+
+use crate::context_config;
+use crate::context_events::AgentContextHandler;
+use crate::context_hooks::ZeneContextHooks;
+use crate::events::{emit_event, AgentEvent};
+use crate::model_executor;
+use crate::PromptOptions;
+
+/// Mutable Agent pieces needed to run one model step (including overflow recovery).
+pub(crate) struct ModelStepDeps<'a> {
+    pub config: &'a ZeneConfig,
+    pub model_executor: &'a dyn ModelExecutor,
+    pub context_model: &'a dyn ContextModel,
+    pub context: &'a mut ContextEngine,
+    pub session: &'a mut SessionRecord,
+    pub system_prompt: &'a str,
+    pub workdir: &'a Path,
+    pub background: &'a SharedBackgroundTasks,
+    pub todos: &'a SharedTodoStore,
+    pub plan_mode_active: bool,
+    pub record_writer: &'a AgentRecordWriter,
+}
+
+/// Run a prepared model step: overflow-retry loop + stream/complete via [`ModelExecutor`].
+pub(crate) async fn run_model_step(
+    deps: ModelStepDeps<'_>,
+    context: PreparedContext,
+    options: &PromptOptions,
+    cancel: Option<&CancellationToken>,
+) -> Result<zene_turn::StepResult> {
+    let tools = context.tools.clone();
+    let step = StepContext {
+        estimate_tokens: context.estimate_tokens.unwrap_or(0),
+        metadata: context.metadata.unwrap_or_default(),
+        messages: context.messages,
+    };
+    let (assistant_message, usage) = run_llm_step(deps, &step, &tools, options, cancel)
+        .await
+        .context("llm step")?;
+    let had_tool_calls = assistant_message
+        .tool_calls
+        .as_ref()
+        .is_some_and(|calls| !calls.is_empty());
+    Ok(zene_turn::StepResult {
+        message: assistant_message,
+        usage,
+        had_tool_calls,
+    })
+}
+
+async fn run_llm_step(
+    mut deps: ModelStepDeps<'_>,
+    step: &StepContext,
+    tools: &[ToolDefinition],
+    options: &PromptOptions,
+    cancel: Option<&CancellationToken>,
+) -> Result<(Message, Option<TokenUsage>)> {
+    let mut overflow_state = model_executor::OverflowRetryState::default();
+    let mut messages = step.messages.clone();
+    let mut metadata = step.metadata.clone();
+
+    loop {
+        if check_cancelled(cancel)? {
+            return Err(zene_turn::aborted_error());
+        }
+
+        debug!(
+            estimated_context_tokens = step.estimate_tokens,
+            message_count = messages.len(),
+            "llm step context estimate"
+        );
+
+        let request = model_executor::build_request(
+            &deps.config.model,
+            messages.clone(),
+            tools.to_vec(),
+            options.stream,
+            Some(metadata.clone()),
+        );
+
+        let result = if options.stream {
+            run_streaming_step(deps.model_executor, request, options, cancel).await
+        } else {
+            deps.model_executor
+                .complete(request)
+                .await
+                .map(|response| (response.message, response.usage))
+        };
+
+        match result {
+            Ok(value) => return Ok(value),
+            Err(err) if ContextEngine::is_context_overflow_error(&err) => {
+                if let Some(refreshed) =
+                    recover_overflow(&mut deps, tools, &mut overflow_state).await?
+                {
+                    messages = refreshed.messages;
+                    metadata = refreshed.metadata;
+                    continue;
+                }
+                return Err(err);
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+async fn recover_overflow(
+    deps: &mut ModelStepDeps<'_>,
+    tools: &[ToolDefinition],
+    overflow_state: &mut model_executor::OverflowRetryState,
+) -> Result<Option<StepContext>> {
+    sync_todos_to_session(deps.todos, deps.session);
+    let estimator = token_estimator(deps.config);
+    let background_tasks = deps.background.lock().list();
+    let hooks = ZeneContextHooks::new(deps.session, &background_tasks, deps.plan_mode_active);
+    let compaction_config = context_config::context_compaction_config(&deps.config.compaction);
+    let mut handler =
+        AgentContextHandler::new(deps.context_model, &deps.config.model, deps.workdir);
+    let prefire_factory = prefire_client_factory(deps.config);
+    let (mut overflow_truncated, mut overflow_summarized) = overflow_state.flags();
+    let overflow = {
+        let mut context_deps = crate::make_context_deps(
+            deps.session,
+            &compaction_config,
+            &deps.config.model,
+            deps.context_model,
+            Some(&hooks),
+            deps.system_prompt,
+            &estimator,
+            &mut handler,
+            prefire_factory,
+        );
+        deps.context
+            .handle_overflow(
+                &mut context_deps,
+                tools,
+                &mut overflow_truncated,
+                &mut overflow_summarized,
+            )
+            .await?
+    };
+    overflow_state.set_flags(overflow_truncated, overflow_summarized);
+    if let Some(result) = &overflow.compaction {
+        record_compaction(deps.record_writer, result)?;
+    }
+    overflow
+        .retry
+        .then(|| {
+            deps.context
+                .try_assemble_step(deps.session, tools, &estimator)
+        })
+        .transpose()
+}
+
+pub(crate) async fn run_streaming_step(
+    executor: &dyn ModelExecutor,
+    request: ChatRequest,
+    options: &PromptOptions,
+    cancel: Option<&CancellationToken>,
+) -> Result<(Message, Option<TokenUsage>)> {
+    if check_cancelled(cancel)? {
+        return Err(zene_turn::aborted_error());
+    }
+
+    let mut stream = executor.stream(request).await?;
+    let mut accumulator = model_executor::StreamAccumulator::default();
+
+    while let Some(event) = stream.next().await {
+        if check_cancelled(cancel)? {
+            return Err(zene_turn::aborted_error());
+        }
+        let event = event.context("stream event")?;
+        match &event {
+            StreamEvent::TextDelta(delta) => {
+                emit_event(
+                    &options.event_handler,
+                    AgentEvent::TextDelta {
+                        delta: delta.clone(),
+                    },
+                );
+                if !options.quiet {
+                    print!("{delta}");
+                    let _ = io::stdout().flush();
+                }
+            }
+            StreamEvent::ThoughtDelta(delta) => {
+                emit_event(
+                    &options.event_handler,
+                    AgentEvent::ThoughtDelta {
+                        delta: delta.clone(),
+                    },
+                );
+            }
+            StreamEvent::ToolCallDelta { .. } => {}
+            StreamEvent::Done { .. } => {}
+        }
+        if accumulator.apply(&event) {
+            break;
+        }
+    }
+
+    if accumulator.has_text() && !options.quiet {
+        println!();
+    }
+
+    Ok(accumulator.finish())
+}
+
+fn sync_todos_to_session(todos: &SharedTodoStore, session: &mut SessionRecord) {
+    let store = todos.lock();
+    session.todos = store.to_items();
+}
+
+fn token_estimator(config: &ZeneConfig) -> TokenEstimator {
+    TokenEstimator::for_provider(
+        EstimateProvider::from_name(&config.provider),
+        &config.model,
+        config.chars_per_token_for_model(),
+    )
+}
+
+fn prefire_client_factory(config: &ZeneConfig) -> Option<PrefireClientFactory> {
+    let config = config.clone();
+    Some(Arc::new(move || {
+        let config = config.clone();
+        Box::pin(async move {
+            let client = ChatClient::from_config(&config).await?;
+            Ok(Arc::new(client) as Arc<dyn ContextModel>)
+        })
+    }))
+}
+
+fn record_compaction(
+    record_writer: &AgentRecordWriter,
+    result: &zene_context::CompactionResult,
+) -> Result<()> {
+    record_writer.append(&RecordEntry::Compaction {
+        reason: result.reason.clone(),
+        compacted_count: result.compacted_count,
+        tokens_before: Some(result.stats.tokens_before),
+        tokens_after: Some(result.stats.tokens_after),
+        ts: chrono::Utc::now(),
+    })
+}
+
+fn check_cancelled(cancel: Option<&CancellationToken>) -> Result<bool> {
+    Ok(zene_turn::is_cancelled(cancel))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use zene_model_executor::ModelStream;
+
+    struct TextThenDone;
+
+    #[async_trait]
+    impl ModelExecutor for TextThenDone {
+        async fn complete(&self, _request: ChatRequest) -> Result<zene_llm::ChatResponse> {
+            unreachable!("complete not used")
+        }
+
+        async fn stream(&self, _request: ChatRequest) -> Result<ModelStream> {
+            Ok(Box::pin(futures::stream::iter(vec![
+                Ok(StreamEvent::TextDelta("hi".into())),
+                Ok(StreamEvent::Done { usage: None }),
+            ])))
+        }
+    }
+
+    #[tokio::test]
+    async fn streaming_step_assembles_text_deltas() {
+        let options = PromptOptions {
+            stream: true,
+            quiet: true,
+            ..PromptOptions::default()
+        };
+        let request = ChatRequest {
+            model: "test".into(),
+            messages: vec![],
+            tools: vec![],
+            stream: true,
+            context: None,
+        };
+        let (message, _) = run_streaming_step(&TextThenDone, request, &options, None)
+            .await
+            .expect("stream");
+        assert_eq!(message.content.as_deref(), Some("hi"));
+    }
+}

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `0c21e4d`（PR #98 已合并）。**
+> **进度快照：2026-08-13，基线 `150d0d5`（PR #99 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（主 Agent / Subagent 经 RuntimeScope + ToolCatalog；Subagent 已走 DefaultToolExecutor + ModelExecutor）。
+> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（主 Agent / Subagent 经 RuntimeScope；Subagent 已走 DefaultToolExecutor + ModelExecutor；主 Agent model-step 已抽出）。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -1097,7 +1097,7 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 | Wave 11 | 已完成第一阶段 | ModelExecutor、ContextModel、usage boundary、runtime protocol 和 lifecycle publisher 已落地；Agent-specific actor 尚在 core |
 | Wave 12 | 已完成第一阶段 | safe resume、Cloud RuntimeClient、neutral runtime notifications、fenced command lease/ack、atomic state/event writes、outbox replay 和真实 replacement 测试已落地 |
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
-| Wave 14 | 进行中 | RuntimeScope + ToolCatalog（主 Agent + Subagent）+ Subagent DefaultToolExecutor/ModelExecutor；完全退回 composition root 仍待做 |
+| Wave 14 | 进行中 | RuntimeScope + ToolCatalog（主 Agent + Subagent）+ Subagent DefaultToolExecutor/ModelExecutor + 主 Agent model-step 抽出；完全退回 composition root / ToolPolicy 仍待做 |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
 | Wave 16 | 已完成 command 对齐 | Cloud RuntimeCommand 含 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；仍不依赖 `zene-runtime` |
 
@@ -1132,7 +1132,7 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 
 4. **仍明确未自动完成的项目**
    - pending tool / approval 的任意副作用自动 replay：继续采用 inspection/manual intervention，避免重复写操作。
-   - `Agent` 从 step orchestrator 完全退回 composition root（catalog 已经 `RuntimeScope` 接线；step 编排仍在 Agent）。
+   - `Agent` 从 step orchestrator 完全退回 composition root（catalog / model-step 已抽出；prepare_context 与 tool writeback 仍在 Agent）。
    - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor` / `ModelExecutor`（已落地）；仍用内存消息。
    - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；API→worker 仍是 Prompt/Cancel；不依赖 `zene-runtime`）。`GetMode` / `ResumeSafeTurn` 仍仅本地。未识别 Cloud 帧仍为 ACP JSON。
    - Agent-specific actor 从 `zene-core` 移入独立 runtime implementation crate（应在 ports/审批稳定之后）。
@@ -1473,3 +1473,9 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 - 新增 `RuntimeScope::agent(AgentProfile, WebSearchConfig)`（depth 0，经 `agent_tools` 建 catalog）。
 - `AgentBuilder` 默认工具路径与父级 `SubagentEnv` 经 root scope 注入；LLM 定义经 `ToolCatalog` 再套 plan-mode 过滤。
 - 不搬 Agent actor。不做 ToolPolicy/SessionPolicy。不做 Cloud 改动。
+
+### 2026-08-13 — Wave 14 主 Agent model-step 抽出
+
+- 新增 `crates/core/src/model_step.rs`：overflow-retry / stream assembly 经 `ModelStepDeps` + `run_model_step`（对齐 `DefaultToolExecutor` 对工具的抽出）。
+- `Agent::invoke_model` 退回 wiring；请求类型仍是 `ChatRequest`。
+- 不搬 Agent actor。不抽 prepare_context / tool writeback。不做 Cloud 改动。不引入中性 `ModelRequest`。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wave 14：把主 Agent 的 model-step 编排（overflow-retry / stream assembly）从 `Agent` 抽到 `model_step::run_model_step`，对齐工具侧的 `DefaultToolExecutor`。`Agent::invoke_model` 只做 wiring。

## Changes

- 新增 `crates/core/src/model_step.rs`（`ModelStepDeps` + `run_model_step` / `run_streaming_step`）
- `Agent::invoke_model` 退回依赖注入入口
- 文档更新 Wave 14 进度

## Out of scope

- 不搬 Agent actor
- 不抽 `prepare_context` / tool writeback
- 不引入中性 `ModelRequest`
- 不做 ToolPolicy / SessionPolicy
- 不做 Cloud 改动

## Test plan

- [x] `cargo test -p zene-core --locked --lib`（含 `model_step::tests::streaming_step_assembles_text_deltas`）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

