### PR TITLE
feat: Wave 14 抽出主 Agent prepare-step 编排

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context, Result};
 use parking_lot::Mutex;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::info;
 use zene_config::ZeneConfig;
 use zene_context::{ContextDeps, ContextEngine, PrefireClientFactory};
 use zene_llm::{ChatClient, Message, TokenUsage, ToolCall};
@@ -32,6 +32,7 @@ mod context_hooks;
 mod events;
 mod model_step;
 mod plan_mode;
+mod prepare_step;
 mod runtime;
 mod subagent;
 mod tool_dedup;
@@ -621,22 +622,6 @@ impl Agent {
         }))
     }
 
-    fn warn_if_near_context_limit(&self, estimated_tokens: usize) {
-        let window = self.config.compaction.context_window_tokens as f32;
-        if window <= 0.0 {
-            return;
-        }
-        let ratio = estimated_tokens as f32 / window;
-        if ratio >= 0.9 {
-            warn!(
-                estimated_context_tokens = estimated_tokens,
-                context_window_tokens = self.config.compaction.context_window_tokens,
-                usage_ratio = ratio,
-                "context estimate exceeds 90% of model window"
-            );
-        }
-    }
-
     /// Replace the permission gate (e.g. TUI custom prompter).
     ///
     /// Re-applies sandbox `auto_allow_bash` and config permission rules so a TUI
@@ -831,89 +816,25 @@ impl Agent {
         options: &PromptOptions,
         cancel: Option<&CancellationToken>,
     ) -> Result<zene_turn::PreparedContext> {
-        if Self::check_cancelled(cancel)? {
-            return Err(zene_turn::aborted_error());
-        }
-
-        self.sync_todos_to_session();
-        let tools = self.tool_definitions_for_llm();
-        let estimator = self.token_estimator();
-        let background_tasks = self.background.lock().list();
-        let hooks = context_hooks::ZeneContextHooks::new(
-            &self.session,
-            &background_tasks,
-            self.is_plan_mode_active(),
-        );
-        let compaction_config = context_config::context_compaction_config(&self.config.compaction);
-        let mut handler = context_events::AgentContextHandler::new(
-            self.context_model.as_ref(),
-            &self.config.model,
-            self.sandbox.workdir(),
-        );
-        let prefire_factory = self.prefire_client_factory();
-        let mut deps = make_context_deps(
-            &mut self.session,
-            &compaction_config,
-            &self.config.model,
-            self.context_model.as_ref(),
-            Some(&hooks),
-            &self.system_prompt,
-            &estimator,
-            &mut handler,
-            prefire_factory,
-        );
-        let prepared = self.context.prepare_step(&mut deps, &tools).await?;
-        if let Some(result) = &prepared.compaction {
-            self.record_compaction(result)?;
-        }
-        emit_event(
-            &options.event_handler,
-            AgentEvent::ProjectionReady {
-                source_message_count: prepared.explain.source_message_count,
-                projected_message_count: prepared.explain.projected_message_count,
-                source_event_count: prepared.explain.source_event_count,
-                active_event_count: prepared.explain.active_event_count,
-                cache_drift_detected: prepared.explain.cache_drift_detected,
-                used_materialized_fallback: prepared.explain.used_materialized_fallback,
-                fallback_reason: prepared.explain.fallback_reason.clone(),
-                active_branch_id: prepared.explain.active_branch_id.clone(),
-                active_path_start_sequence: prepared.explain.active_path_start_sequence,
-                injected: prepared.explain.injected.clone(),
-                retained_message_count: prepared.explain.retained_message_count,
-                retained_turn_count: prepared.explain.retained_turn_count,
-                dropped_event_count: prepared.explain.dropped_event_count,
-                truncated_message_count: prepared.explain.truncated_message_count,
-                compaction_event_ids: prepared.explain.compaction_event_ids.clone(),
-                tool_output_provenance: prepared.explain.tool_output_provenance.clone(),
-                retained_turn_ids: prepared.explain.retained_turn_ids.clone(),
-                injected_sources: prepared.explain.injected_sources.clone(),
-                delivery: prepared.explain.delivery.as_str().to_string(),
-                delivery_tail_start: prepared.explain.delivery_tail_start,
-                estimate_tokens: prepared.explain.estimate_tokens,
-                context_epoch: prepared.explain.context_epoch,
-                prefix_cache: prepared.explain.prefix_cache.clone(),
+        let plan_mode_active = self.is_plan_mode_active();
+        prepare_step::prepare_step_context(
+            prepare_step::PrepareStepDeps {
+                config: &self.config,
+                context_model: self.context_model.as_ref(),
+                context: &mut self.context,
+                session: &mut self.session,
+                system_prompt: &self.system_prompt,
+                workdir: self.sandbox.workdir(),
+                tools: self.tools.as_ref(),
+                background: &self.background,
+                todos: &self.todos,
+                plan_mode_active,
+                record_writer: &self.record_writer,
             },
-        );
-        let step = prepared.step;
-        debug!(
-            estimated_context_tokens = step.estimate_tokens,
-            effective_tokens = self.context.water().effective_tokens(),
-            usage_percent = self.context.water().usage_percent(),
-            message_count = step.messages.len(),
-            tool_count = tools.len(),
-            context_epoch = step.metadata.context_epoch,
-            source_event_count = prepared.explain.source_event_count,
-            projection_fallback = prepared.explain.used_materialized_fallback,
-            "llm request context water level"
-        );
-        self.warn_if_near_context_limit(step.estimate_tokens as usize);
-        Ok(zene_turn::PreparedContext {
-            messages: step.messages,
-            tools,
-            context_epoch: Some(step.metadata.context_epoch),
-            metadata: Some(step.metadata),
-            estimate_tokens: Some(step.estimate_tokens),
-        })
+            options,
+            cancel,
+        )
+        .await
     }
 
     pub(crate) async fn invoke_model(
@@ -942,10 +863,6 @@ impl Agent {
             cancel,
         )
         .await
-    }
-
-    fn check_cancelled(cancel: Option<&CancellationToken>) -> Result<bool> {
-        Ok(zene_turn::is_cancelled(cancel))
     }
 
     async fn run_tools(

--- a/crates/core/src/prepare_step.rs
+++ b/crates/core/src/prepare_step.rs
@@ -1,0 +1,214 @@
+//! Main-agent context prepare-step extracted from [`crate::Agent`].
+//!
+//! Wave 14: `ContextAssemblerPort` still enters via Agent wiring, but todos
+//! sync → ContextEngine prepare → ProjectionReady / water logging lives here
+//! (parallel to [`crate::model_step`] for the model path).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+use zene_config::ZeneConfig;
+use zene_context::{
+    ContextEngine, ContextModel, EstimateProvider, PrefireClientFactory, TokenEstimator,
+};
+use zene_llm::{ChatClient, ToolDefinition};
+use zene_session::{AgentRecordWriter, RecordEntry, SessionRecord};
+use zene_tools::{SharedBackgroundTasks, SharedTodoStore, ToolCatalog, ToolRegistry};
+use zene_turn::PreparedContext;
+
+use crate::context_config;
+use crate::context_events::AgentContextHandler;
+use crate::context_hooks::ZeneContextHooks;
+use crate::events::{emit_event, AgentEvent};
+use crate::plan_mode::tool_visible_in_definitions;
+use crate::PromptOptions;
+
+/// Mutable Agent pieces needed to assemble one step's [`PreparedContext`].
+pub(crate) struct PrepareStepDeps<'a> {
+    pub config: &'a ZeneConfig,
+    pub context_model: &'a dyn ContextModel,
+    pub context: &'a mut ContextEngine,
+    pub session: &'a mut SessionRecord,
+    pub system_prompt: &'a str,
+    pub workdir: &'a Path,
+    pub tools: &'a ToolRegistry,
+    pub background: &'a SharedBackgroundTasks,
+    pub todos: &'a SharedTodoStore,
+    pub plan_mode_active: bool,
+    pub record_writer: &'a AgentRecordWriter,
+}
+
+/// Assemble the next model-facing context (catalog defs + ContextEngine prepare).
+pub(crate) async fn prepare_step_context(
+    deps: PrepareStepDeps<'_>,
+    options: &PromptOptions,
+    cancel: Option<&CancellationToken>,
+) -> Result<PreparedContext> {
+    if check_cancelled(cancel)? {
+        return Err(zene_turn::aborted_error());
+    }
+
+    sync_todos_to_session(deps.todos, deps.session);
+    let tools = tool_definitions_for_llm(deps.tools, deps.plan_mode_active);
+    let estimator = token_estimator(deps.config);
+    let background_tasks = deps.background.lock().list();
+    let hooks = ZeneContextHooks::new(deps.session, &background_tasks, deps.plan_mode_active);
+    let compaction_config = context_config::context_compaction_config(&deps.config.compaction);
+    let mut handler =
+        AgentContextHandler::new(deps.context_model, &deps.config.model, deps.workdir);
+    let prefire_factory = prefire_client_factory(deps.config);
+    let mut context_deps = crate::make_context_deps(
+        deps.session,
+        &compaction_config,
+        &deps.config.model,
+        deps.context_model,
+        Some(&hooks),
+        deps.system_prompt,
+        &estimator,
+        &mut handler,
+        prefire_factory,
+    );
+    let prepared = deps.context.prepare_step(&mut context_deps, &tools).await?;
+    if let Some(result) = &prepared.compaction {
+        record_compaction(deps.record_writer, result)?;
+    }
+    emit_event(
+        &options.event_handler,
+        AgentEvent::ProjectionReady {
+            source_message_count: prepared.explain.source_message_count,
+            projected_message_count: prepared.explain.projected_message_count,
+            source_event_count: prepared.explain.source_event_count,
+            active_event_count: prepared.explain.active_event_count,
+            cache_drift_detected: prepared.explain.cache_drift_detected,
+            used_materialized_fallback: prepared.explain.used_materialized_fallback,
+            fallback_reason: prepared.explain.fallback_reason.clone(),
+            active_branch_id: prepared.explain.active_branch_id.clone(),
+            active_path_start_sequence: prepared.explain.active_path_start_sequence,
+            injected: prepared.explain.injected.clone(),
+            retained_message_count: prepared.explain.retained_message_count,
+            retained_turn_count: prepared.explain.retained_turn_count,
+            dropped_event_count: prepared.explain.dropped_event_count,
+            truncated_message_count: prepared.explain.truncated_message_count,
+            compaction_event_ids: prepared.explain.compaction_event_ids.clone(),
+            tool_output_provenance: prepared.explain.tool_output_provenance.clone(),
+            retained_turn_ids: prepared.explain.retained_turn_ids.clone(),
+            injected_sources: prepared.explain.injected_sources.clone(),
+            delivery: prepared.explain.delivery.as_str().to_string(),
+            delivery_tail_start: prepared.explain.delivery_tail_start,
+            estimate_tokens: prepared.explain.estimate_tokens,
+            context_epoch: prepared.explain.context_epoch,
+            prefix_cache: prepared.explain.prefix_cache.clone(),
+        },
+    );
+    let step = prepared.step;
+    debug!(
+        estimated_context_tokens = step.estimate_tokens,
+        effective_tokens = deps.context.water().effective_tokens(),
+        usage_percent = deps.context.water().usage_percent(),
+        message_count = step.messages.len(),
+        tool_count = tools.len(),
+        context_epoch = step.metadata.context_epoch,
+        source_event_count = prepared.explain.source_event_count,
+        projection_fallback = prepared.explain.used_materialized_fallback,
+        "llm request context water level"
+    );
+    warn_if_near_context_limit(deps.config, step.estimate_tokens as usize);
+    Ok(PreparedContext {
+        messages: step.messages,
+        tools,
+        context_epoch: Some(step.metadata.context_epoch),
+        metadata: Some(step.metadata),
+        estimate_tokens: Some(step.estimate_tokens),
+    })
+}
+
+fn tool_definitions_for_llm(tools: &ToolRegistry, plan_mode_active: bool) -> Vec<ToolDefinition> {
+    ToolCatalog::definitions(tools)
+        .into_iter()
+        .filter(|def| tool_visible_in_definitions(&def.name, plan_mode_active))
+        .collect()
+}
+
+fn sync_todos_to_session(todos: &SharedTodoStore, session: &mut SessionRecord) {
+    let store = todos.lock();
+    session.todos = store.to_items();
+}
+
+fn token_estimator(config: &ZeneConfig) -> TokenEstimator {
+    TokenEstimator::for_provider(
+        EstimateProvider::from_name(&config.provider),
+        &config.model,
+        config.chars_per_token_for_model(),
+    )
+}
+
+fn prefire_client_factory(config: &ZeneConfig) -> Option<PrefireClientFactory> {
+    let config = config.clone();
+    Some(Arc::new(move || {
+        let config = config.clone();
+        Box::pin(async move {
+            let client = ChatClient::from_config(&config).await?;
+            Ok(Arc::new(client) as Arc<dyn ContextModel>)
+        })
+    }))
+}
+
+fn record_compaction(
+    record_writer: &AgentRecordWriter,
+    result: &zene_context::CompactionResult,
+) -> Result<()> {
+    record_writer.append(&RecordEntry::Compaction {
+        reason: result.reason.clone(),
+        compacted_count: result.compacted_count,
+        tokens_before: Some(result.stats.tokens_before),
+        tokens_after: Some(result.stats.tokens_after),
+        ts: chrono::Utc::now(),
+    })
+}
+
+fn warn_if_near_context_limit(config: &ZeneConfig, estimated_tokens: usize) {
+    let window = config.compaction.context_window_tokens as f32;
+    if window <= 0.0 {
+        return;
+    }
+    let ratio = estimated_tokens as f32 / window;
+    if ratio >= 0.9 {
+        warn!(
+            estimated_context_tokens = estimated_tokens,
+            context_window_tokens = config.compaction.context_window_tokens,
+            usage_ratio = ratio,
+            "context estimate exceeds 90% of model window"
+        );
+    }
+}
+
+fn check_cancelled(cancel: Option<&CancellationToken>) -> Result<bool> {
+    Ok(zene_turn::is_cancelled(cancel))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zene_tools::default_builtin_tools;
+
+    #[test]
+    fn plan_mode_hides_write_tools_from_catalog_defs() {
+        let tools = default_builtin_tools();
+        let active = tool_definitions_for_llm(&tools, true);
+        let names: Vec<_> = active.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"Read"));
+        assert!(!names.iter().any(|n| *n == "Write" || *n == "Edit" || *n == "Bash"));
+    }
+
+    #[test]
+    fn inactive_plan_mode_keeps_write_tools() {
+        let tools = default_builtin_tools();
+        let defs = tool_definitions_for_llm(&tools, false);
+        let names: Vec<_> = defs.iter().map(|t| t.name.as_str()).collect();
+        assert!(names.contains(&"Write"));
+        assert!(names.contains(&"Bash"));
+    }
+}

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `150d0d5`（PR #99 已合并）。**
+> **进度快照：2026-08-13，基线 `2e0c32d`（PR #100 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（主 Agent / Subagent 经 RuntimeScope；Subagent 已走 DefaultToolExecutor + ModelExecutor；主 Agent model-step 已抽出）。
+> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（主 Agent prepare/model-step 已抽出；Subagent 经 RuntimeScope + DefaultToolExecutor + ModelExecutor）。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -1097,7 +1097,7 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 | Wave 11 | 已完成第一阶段 | ModelExecutor、ContextModel、usage boundary、runtime protocol 和 lifecycle publisher 已落地；Agent-specific actor 尚在 core |
 | Wave 12 | 已完成第一阶段 | safe resume、Cloud RuntimeClient、neutral runtime notifications、fenced command lease/ack、atomic state/event writes、outbox replay 和真实 replacement 测试已落地 |
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
-| Wave 14 | 进行中 | RuntimeScope + ToolCatalog（主 Agent + Subagent）+ Subagent DefaultToolExecutor/ModelExecutor + 主 Agent model-step 抽出；完全退回 composition root / ToolPolicy 仍待做 |
+| Wave 14 | 进行中 | RuntimeScope + ToolCatalog + Subagent executors + 主 Agent prepare/model-step 抽出；tool writeback / ToolPolicy / 完全退回 composition root 仍待做 |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
 | Wave 16 | 已完成 command 对齐 | Cloud RuntimeCommand 含 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；仍不依赖 `zene-runtime` |
 
@@ -1132,7 +1132,7 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 
 4. **仍明确未自动完成的项目**
    - pending tool / approval 的任意副作用自动 replay：继续采用 inspection/manual intervention，避免重复写操作。
-   - `Agent` 从 step orchestrator 完全退回 composition root（catalog / model-step 已抽出；prepare_context 与 tool writeback 仍在 Agent）。
+   - `Agent` 从 step orchestrator 完全退回 composition root（catalog / prepare_step / model-step 已抽出；tool writeback 仍在 Agent）。
    - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor` / `ModelExecutor`（已落地）；仍用内存消息。
    - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；API→worker 仍是 Prompt/Cancel；不依赖 `zene-runtime`）。`GetMode` / `ResumeSafeTurn` 仍仅本地。未识别 Cloud 帧仍为 ACP JSON。
    - Agent-specific actor 从 `zene-core` 移入独立 runtime implementation crate（应在 ports/审批稳定之后）。
@@ -1479,3 +1479,9 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 - 新增 `crates/core/src/model_step.rs`：overflow-retry / stream assembly 经 `ModelStepDeps` + `run_model_step`（对齐 `DefaultToolExecutor` 对工具的抽出）。
 - `Agent::invoke_model` 退回 wiring；请求类型仍是 `ChatRequest`。
 - 不搬 Agent actor。不抽 prepare_context / tool writeback。不做 Cloud 改动。不引入中性 `ModelRequest`。
+
+### 2026-08-13 — Wave 14 主 Agent prepare-step 抽出
+
+- 新增 `crates/core/src/prepare_step.rs`：todos sync → ContextEngine prepare → ProjectionReady / water 日志经 `PrepareStepDeps`。
+- `Agent::prepare_step_context` 退回 wiring；`record_step_started` 仍留在 Agent/ports。
+- 不搬 Agent actor。不抽 tool writeback。不做 Cloud 改动。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wave 14：把主 Agent 的 prepare-step（todos sync → ContextEngine prepare → ProjectionReady / water）从 `Agent` 抽到 `prepare_step::prepare_step_context`，与 #100 的 model-step 抽出对称。`Agent::prepare_step_context` 只做 wiring。

## Changes

- 新增 `crates/core/src/prepare_step.rs`（`PrepareStepDeps` + plan-mode catalog 过滤）
- `Agent::prepare_step_context` 退回依赖注入入口；`record_step_started` 仍留在 Agent/ports
- 文档更新 Wave 14 进度

## Out of scope

- 不搬 Agent actor
- 不抽 tool writeback / checkpoint 持久化
- 不做 ToolPolicy / SessionPolicy
- 不做 Cloud 改动
- 不引入中性 `ModelRequest`

## Test plan

- [x] `cargo test -p zene-core --locked --lib`（含 prepare_step plan-mode 过滤测试）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

