### PR TITLE
feat: Wave 14 抽出主 Agent tool-batch writeback

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -35,6 +35,7 @@ mod plan_mode;
 mod prepare_step;
 mod runtime;
 mod subagent;
+mod tool_batch;
 mod tool_dedup;
 mod tool_executor;
 pub mod tool_scheduler;
@@ -48,7 +49,6 @@ pub use zene_context::{
 };
 
 use crate::agent_turn::AgentTurnPorts;
-use crate::tool_executor::{DefaultToolExecutor, ToolExecutorDeps};
 pub use agent_builder::AgentBuilder;
 pub use events::{emit_event, runtime_event_handler, AgentEvent, EventHandler};
 pub use plan_mode::PlanApprovalPrompter;
@@ -871,44 +871,19 @@ impl Agent {
         options: &PromptOptions,
         cancel: Option<&CancellationToken>,
     ) -> Result<zene_turn::ToolBatchOutcome> {
-        let scope = self.active_turn.as_ref().map(|turn| {
-            (
-                turn.turn_id.to_string(),
-                turn.step_id.map(|step_id| step_id.to_string()),
-            )
-        });
-        for call in tool_calls {
-            let turn_id = scope.as_ref().map(|(turn_id, _)| turn_id.as_str());
-            let step_id = scope.as_ref().and_then(|(_, step_id)| step_id.as_deref());
-            let idempotency_key = append_tool_execution_checkpoint(
-                &self.record_writer,
-                turn_id,
-                step_id,
-                &call.id,
-                ExecutionCheckpointState::ToolStarted,
-            )?;
-            let tool_event = self
-                .session
-                .record_tool_call(turn_id, step_id, &call.id, &call.name, &call.arguments);
-            self.session.record_checkpoint(
-                turn_id,
-                step_id,
-                Some(&call.id),
-                "tool_started",
-                &idempotency_key,
-            );
-            self.record_writer.append_execution_link(
-                &idempotency_key,
-                &tool_event.id,
-                tool_event.sequence,
-            )?;
-        }
-
-        let subagent_runner = Arc::new(
-            CoreSubagentRunner::new(self.config.clone()).with_broker(self.approval_broker.clone()),
-        );
-        let result = {
-            let executor = DefaultToolExecutor::new(ToolExecutorDeps {
+        let (turn_id, step_id) = self
+            .active_turn
+            .as_ref()
+            .map(|turn| {
+                (
+                    Some(turn.turn_id.to_string()),
+                    turn.step_id.map(|step_id| step_id.to_string()),
+                )
+            })
+            .unwrap_or((None, None));
+        tool_batch::run_tool_batch(
+            tool_batch::ToolBatchDeps {
+                config: &self.config,
                 tools: Arc::clone(&self.tools),
                 sandbox: Arc::clone(&self.sandbox),
                 permission: Arc::clone(&self.permission),
@@ -918,75 +893,19 @@ impl Agent {
                 todos: Arc::clone(&self.todos),
                 ask_user: Arc::clone(&self.ask_user),
                 background: Arc::clone(&self.background),
-                subagent: Some(self.runtime_scope.env(subagent_runner)),
+                runtime_scope: &self.runtime_scope,
                 hooks: &self.hooks,
-            });
-            executor
-                .execute(
-                    tool_calls,
-                    options,
-                    cancel,
-                    &self.session.meta.id,
-                    self.sandbox.workdir(),
-                    &mut self.tool_dedup,
-                )
-                .await?
-        };
-
-        if !result.mode_changes.is_empty() {
-            for mode_id in &result.mode_changes {
-                self.session.record_mode_changed(mode_id);
-            }
-        }
-        for decision in &result.permission_decisions {
-            self.session.record_permission_decision(
-                scope.as_ref().map(|(turn_id, _)| turn_id.as_str()),
-                scope.as_ref().and_then(|(_, step_id)| step_id.as_deref()),
-                &decision.tool_call_id,
-                &decision.tool_name,
-                decision.allowed,
-            );
-        }
-        for message in result.messages {
-            let content = message.content;
-            let turn_id = scope.as_ref().map(|(turn_id, _)| turn_id.as_str());
-            let step_id = scope.as_ref().and_then(|(_, step_id)| step_id.as_deref());
-            let idempotency_key = append_tool_execution_checkpoint(
-                &self.record_writer,
+                session: &mut self.session,
+                record_writer: &self.record_writer,
+                tool_dedup: &mut self.tool_dedup,
                 turn_id,
                 step_id,
-                &message.call.id,
-                ExecutionCheckpointState::ToolCompleted,
-            )?;
-            let result_event = self.session.record_tool_result(
-                turn_id,
-                step_id,
-                &message.call.id,
-                &message.call.name,
-                &content,
-                message.is_error,
-                message.duration_ms,
-            );
-            self.session.record_checkpoint(
-                turn_id,
-                step_id,
-                Some(&message.call.id),
-                "tool_completed",
-                &idempotency_key,
-            );
-            self.record_writer.append_execution_link(
-                &idempotency_key,
-                &result_event.id,
-                result_event.sequence,
-            )?;
-            self.session.push_message(Message::tool_result_with_error(
-                &message.call.id,
-                &message.call.name,
-                content,
-                message.is_error,
-            ));
-        }
-        Ok(result.outcome)
+            },
+            tool_calls,
+            options,
+            cancel,
+        )
+        .await
     }
 
     fn record_compaction(&self, result: &CompactionResult) -> Result<()> {
@@ -998,36 +917,6 @@ impl Agent {
             ts: chrono::Utc::now(),
         })
     }
-}
-
-fn append_tool_execution_checkpoint(
-    record_writer: &AgentRecordWriter,
-    turn_id: Option<&str>,
-    step_id: Option<&str>,
-    tool_call_id: &str,
-    state: ExecutionCheckpointState,
-) -> Result<String> {
-    let state_name = match &state {
-        ExecutionCheckpointState::ToolStarted => "started",
-        ExecutionCheckpointState::ToolCompleted => "completed",
-        _ => bail!("invalid tool execution checkpoint state"),
-    };
-    let idempotency_key = format!(
-        "tool/{}/{}/{tool_call_id}/{state_name}",
-        turn_id.unwrap_or("unknown"),
-        step_id.unwrap_or("unknown"),
-    );
-    record_writer.append_execution_checkpoint(&RecordEntry::ExecutionCheckpoint {
-        turn_id: turn_id.unwrap_or("unknown").to_string(),
-        step_id: step_id.map(str::to_string),
-        tool_call_id: Some(tool_call_id.to_string()),
-        state,
-        idempotency_key: idempotency_key.clone(),
-        context_epoch: None,
-        model_request_hash: None,
-        ts: chrono::Utc::now(),
-    })?;
-    Ok(idempotency_key)
 }
 
 fn merge_event_handler(
@@ -1310,7 +1199,7 @@ mod execution_checkpoint_tests {
         // mandatory append fails before the side-effect closure is reached.
         let writer = AgentRecordWriter::from_path(record_dir.path()).expect("writer");
         let mut executed = false;
-        let execution = append_tool_execution_checkpoint(
+        let execution = tool_batch::append_tool_execution_checkpoint(
             &writer,
             Some("turn-1"),
             Some("step-1"),

--- a/crates/core/src/tool_batch.rs
+++ b/crates/core/src/tool_batch.rs
@@ -1,0 +1,216 @@
+//! Main-agent tool-batch orchestration extracted from [`crate::Agent`].
+//!
+//! Wave 14: execution still goes through [`DefaultToolExecutor`]; this module
+//! owns ToolStarted/Completed checkpoints, session event writeback, and
+//! mode/permission recording so `Agent::run_tools` stays wiring-only.
+
+use std::sync::Arc;
+
+use anyhow::{bail, Result};
+use tokio_util::sync::CancellationToken;
+use zene_config::ZeneConfig;
+use zene_llm::{Message, ToolCall};
+use zene_permission::SharedApprovalBroker;
+use zene_sandbox::Sandbox;
+use zene_session::{AgentRecordWriter, ExecutionCheckpointState, RecordEntry, SessionRecord};
+use zene_tools::{
+    RuntimeScope, SharedAskUserPrompter, SharedBackgroundTasks, SharedPlanMode, SharedTodoStore,
+    SharedToolPermission, ToolRegistry,
+};
+use zene_turn::ToolBatchOutcome;
+use zene_hooks::HookRunner;
+
+use crate::plan_mode::PlanApprovalPrompter;
+use crate::subagent::CoreSubagentRunner;
+use crate::tool_dedup::ToolDedup;
+use crate::tool_executor::{DefaultToolExecutor, ToolExecutorDeps};
+use crate::PromptOptions;
+
+/// Mutable Agent pieces needed to run and persist one tool batch.
+pub(crate) struct ToolBatchDeps<'a> {
+    pub config: &'a ZeneConfig,
+    pub tools: Arc<ToolRegistry>,
+    pub sandbox: Arc<dyn Sandbox>,
+    pub permission: SharedToolPermission,
+    pub approval_broker: Option<SharedApprovalBroker>,
+    pub plan_mode: SharedPlanMode,
+    pub plan_approval: &'a PlanApprovalPrompter,
+    pub todos: SharedTodoStore,
+    pub ask_user: SharedAskUserPrompter,
+    pub background: SharedBackgroundTasks,
+    pub runtime_scope: &'a RuntimeScope,
+    pub hooks: &'a HookRunner,
+    pub session: &'a mut SessionRecord,
+    pub record_writer: &'a AgentRecordWriter,
+    pub tool_dedup: &'a mut ToolDedup,
+    pub turn_id: Option<String>,
+    pub step_id: Option<String>,
+}
+
+/// Record ToolStarted, execute via [`DefaultToolExecutor`], then write results back.
+pub(crate) async fn run_tool_batch(
+    deps: ToolBatchDeps<'_>,
+    tool_calls: &[ToolCall],
+    options: &PromptOptions,
+    cancel: Option<&CancellationToken>,
+) -> Result<ToolBatchOutcome> {
+    let turn_id = deps.turn_id.as_deref();
+    let step_id = deps.step_id.as_deref();
+
+    for call in tool_calls {
+        let idempotency_key = append_tool_execution_checkpoint(
+            deps.record_writer,
+            turn_id,
+            step_id,
+            &call.id,
+            ExecutionCheckpointState::ToolStarted,
+        )?;
+        let tool_event =
+            deps.session
+                .record_tool_call(turn_id, step_id, &call.id, &call.name, &call.arguments);
+        deps.session.record_checkpoint(
+            turn_id,
+            step_id,
+            Some(&call.id),
+            "tool_started",
+            &idempotency_key,
+        );
+        deps.record_writer.append_execution_link(
+            &idempotency_key,
+            &tool_event.id,
+            tool_event.sequence,
+        )?;
+    }
+
+    let subagent_runner = Arc::new(
+        CoreSubagentRunner::new(deps.config.clone()).with_broker(deps.approval_broker.clone()),
+    );
+    let result = {
+        let executor = DefaultToolExecutor::new(ToolExecutorDeps {
+            tools: Arc::clone(&deps.tools),
+            sandbox: Arc::clone(&deps.sandbox),
+            permission: Arc::clone(&deps.permission),
+            approval_broker: deps.approval_broker.clone(),
+            plan_mode: Arc::clone(&deps.plan_mode),
+            plan_approval: deps.plan_approval,
+            todos: Arc::clone(&deps.todos),
+            ask_user: Arc::clone(&deps.ask_user),
+            background: Arc::clone(&deps.background),
+            subagent: Some(deps.runtime_scope.env(subagent_runner)),
+            hooks: deps.hooks,
+        });
+        executor
+            .execute(
+                tool_calls,
+                options,
+                cancel,
+                &deps.session.meta.id,
+                deps.sandbox.workdir(),
+                deps.tool_dedup,
+            )
+            .await?
+    };
+
+    if !result.mode_changes.is_empty() {
+        for mode_id in &result.mode_changes {
+            deps.session.record_mode_changed(mode_id);
+        }
+    }
+    for decision in &result.permission_decisions {
+        deps.session.record_permission_decision(
+            turn_id,
+            step_id,
+            &decision.tool_call_id,
+            &decision.tool_name,
+            decision.allowed,
+        );
+    }
+    for message in result.messages {
+        let content = message.content;
+        let idempotency_key = append_tool_execution_checkpoint(
+            deps.record_writer,
+            turn_id,
+            step_id,
+            &message.call.id,
+            ExecutionCheckpointState::ToolCompleted,
+        )?;
+        let result_event = deps.session.record_tool_result(
+            turn_id,
+            step_id,
+            &message.call.id,
+            &message.call.name,
+            &content,
+            message.is_error,
+            message.duration_ms,
+        );
+        deps.session.record_checkpoint(
+            turn_id,
+            step_id,
+            Some(&message.call.id),
+            "tool_completed",
+            &idempotency_key,
+        );
+        deps.record_writer.append_execution_link(
+            &idempotency_key,
+            &result_event.id,
+            result_event.sequence,
+        )?;
+        deps.session.push_message(Message::tool_result_with_error(
+            &message.call.id,
+            &message.call.name,
+            content,
+            message.is_error,
+        ));
+    }
+    Ok(result.outcome)
+}
+
+pub(crate) fn append_tool_execution_checkpoint(
+    record_writer: &AgentRecordWriter,
+    turn_id: Option<&str>,
+    step_id: Option<&str>,
+    tool_call_id: &str,
+    state: ExecutionCheckpointState,
+) -> Result<String> {
+    let state_name = match &state {
+        ExecutionCheckpointState::ToolStarted => "started",
+        ExecutionCheckpointState::ToolCompleted => "completed",
+        _ => bail!("invalid tool execution checkpoint state"),
+    };
+    let idempotency_key = format!(
+        "tool/{}/{}/{tool_call_id}/{state_name}",
+        turn_id.unwrap_or("unknown"),
+        step_id.unwrap_or("unknown"),
+    );
+    record_writer.append_execution_checkpoint(&RecordEntry::ExecutionCheckpoint {
+        turn_id: turn_id.unwrap_or("unknown").to_string(),
+        step_id: step_id.map(str::to_string),
+        tool_call_id: Some(tool_call_id.to_string()),
+        state,
+        idempotency_key: idempotency_key.clone(),
+        context_epoch: None,
+        model_request_hash: None,
+        ts: chrono::Utc::now(),
+    })?;
+    Ok(idempotency_key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_checkpoint_key_includes_ids_and_state() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let writer = AgentRecordWriter::from_path(dir.path().join("record.jsonl")).expect("writer");
+        let key = append_tool_execution_checkpoint(
+            &writer,
+            Some("turn-1"),
+            Some("step-2"),
+            "call-3",
+            ExecutionCheckpointState::ToolStarted,
+        )
+        .expect("checkpoint");
+        assert_eq!(key, "tool/turn-1/step-2/call-3/started");
+    }
+}

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `2e0c32d`（PR #100 已合并）。**
+> **进度快照：2026-08-13，基线 `0eb889c`（PR #101 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（主 Agent prepare/model-step 已抽出；Subagent 经 RuntimeScope + DefaultToolExecutor + ModelExecutor）。
+> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（主 Agent prepare/model/tool-batch 已抽出；Subagent 经 RuntimeScope + DefaultToolExecutor + ModelExecutor）。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wave 14：把主 Agent 的 tool-batch writeback（ToolStarted/Completed checkpoint、session event、mode/permission 写回）从 `Agent` 抽到 `tool_batch::run_tool_batch`。执行仍走 `DefaultToolExecutor`；`Agent::run_tools` 只做 wiring。

## Changes

- 新增 `crates/core/src/tool_batch.rs`（`ToolBatchDeps` + checkpoint helper）
- `Agent::run_tools` 退回依赖注入入口
- 文档更新 Wave 14 进度

## Out of scope

- 不搬 Agent actor
- 不做 ToolPolicy / SessionPolicy
- 不做 Cloud 改动
- 不引入中性 `ModelRequest`

## Test plan

- [x] `cargo test -p zene-core --locked --lib`（含 checkpoint key 测试与原 persistence gate 测试）

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

