### PR TITLE
feat: 收口 Wave 14（ToolPolicy/SessionPolicy + Agent facade）

### DIFF
--- a/crates/core/src/agent_turn.rs
+++ b/crates/core/src/agent_turn.rs
@@ -2,13 +2,14 @@
 
 use async_trait::async_trait;
 use tokio_util::sync::CancellationToken;
-use zene_llm::{Message, TokenUsage, ToolCall};
+use zene_llm::{TokenUsage, ToolCall};
 use zene_turn::{
-    max_turns_notice, ContextAssemblerPort, EventSinkPort, ModelExecutorPort, PreparedContext,
-    StepResult, ToolBatchOutcome, ToolExecutorPort, TurnEnginePorts, TurnRuntime, TurnSessionPort,
+    ContextAssemblerPort, EventSinkPort, ModelExecutorPort, PreparedContext, StepResult,
+    ToolBatchOutcome, ToolExecutorPort, TurnEnginePorts, TurnRuntime, TurnSessionPort,
 };
 
 use crate::events::{emit_event, AgentEvent};
+use crate::turn_session;
 use crate::Agent;
 
 /// Native turn-engine ports for the primary agent runtime.
@@ -48,7 +49,7 @@ impl TurnSessionPort<crate::PromptOptions> for AgentTurnPorts<'_> {
         <Agent as TurnRuntime>::inject_steer(self.agent, options)
     }
 
-    fn push_assistant(&mut self, message: Message) {
+    fn push_assistant(&mut self, message: zene_llm::Message) {
         <Agent as TurnRuntime>::push_assistant(self.agent, message);
     }
 
@@ -152,14 +153,16 @@ impl TurnRuntime for Agent {
     }
 
     async fn prepare_turn(&mut self, user_input: &str) -> Result<(), anyhow::Error> {
-        self.usage_accumulator.reset();
-        self.tool_dedup.reset();
-        self.session.ensure_system_message(&self.system_prompt);
-        if !self.resume_existing_turn {
-            self.session.set_title_from_prompt(user_input);
-            self.session.push_message(Message::user(user_input));
-        }
-        self.resume_existing_turn = false;
+        turn_session::prepare_turn(
+            turn_session::PrepareTurnDeps {
+                session: &mut self.session,
+                system_prompt: &self.system_prompt,
+                usage_accumulator: &mut self.usage_accumulator,
+                tool_dedup: &mut self.tool_dedup,
+                resume_existing_turn: &mut self.resume_existing_turn,
+            },
+            user_input,
+        );
         Ok(())
     }
 
@@ -178,35 +181,20 @@ impl TurnRuntime for Agent {
         usage: &TokenUsage,
         options: &Self::Options,
     ) -> Result<(), anyhow::Error> {
-        self.usage_accumulator.record(usage);
-        let tools = self.tool_definitions_for_llm();
-        let estimator = self.token_estimator();
-        let compaction_config =
-            crate::context_config::context_compaction_config(&self.config.compaction);
-        let context_usage = self.context.record_step_usage(
-            usage,
-            &mut self.session,
-            &tools,
-            &estimator,
-            &compaction_config,
-        )?;
-        let snapshot = self.usage_accumulator.snapshot(
-            context_usage.context_tokens,
-            context_usage.context_window,
-            context_usage.context_percent,
-            self.context.epoch(),
-        );
-        emit_event(
-            &options.event_handler,
-            AgentEvent::UsageUpdate {
-                usage: snapshot.usage,
-                context_tokens: snapshot.context_tokens,
-                context_window: snapshot.context_window,
-                context_percent: snapshot.context_percent,
-                context_epoch: snapshot.context_epoch,
+        let plan_mode_active = self.is_plan_mode_active();
+        turn_session::record_step_usage(
+            turn_session::StepUsageDeps {
+                config: &self.config,
+                context: &mut self.context,
+                session: &mut self.session,
+                tools: self.tools.as_ref(),
+                tool_policy: self.runtime_scope.tool_policy,
+                plan_mode_active,
+                usage_accumulator: &mut self.usage_accumulator,
             },
-        );
-        Ok(())
+            usage,
+            options,
+        )
     }
 
     async fn run_tools(
@@ -222,7 +210,7 @@ impl TurnRuntime for Agent {
         self.inject_pending_steer(options)
     }
 
-    fn push_assistant(&mut self, message: Message) {
+    fn push_assistant(&mut self, message: zene_llm::Message) {
         self.session.push_message(message);
     }
 
@@ -232,20 +220,7 @@ impl TurnRuntime for Agent {
         final_text: &mut String,
         options: &Self::Options,
     ) -> Result<(), anyhow::Error> {
-        let notice = max_turns_notice(max_steps);
-        let delta = if final_text.trim().is_empty() {
-            format!("\n{notice}\n")
-        } else {
-            format!("\n\n{notice}")
-        };
-        *final_text = if final_text.trim().is_empty() {
-            notice
-        } else {
-            format!("{final_text}\n\n{notice}")
-        };
-        self.session
-            .push_message(Message::assistant(final_text.clone()));
-        emit_event(&options.event_handler, AgentEvent::TextDelta { delta });
+        turn_session::on_incomplete_turn(&mut self.session, max_steps, final_text, options);
         Ok(())
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,7 +5,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::info;
 use zene_config::ZeneConfig;
 use zene_context::{ContextDeps, ContextEngine, PrefireClientFactory};
-use zene_llm::{ChatClient, Message, TokenUsage, ToolCall};
+use zene_llm::{ChatClient, TokenUsage, ToolCall};
 
 use zene_mcp::McpManager;
 use zene_model_executor::ModelExecutor;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -39,6 +39,7 @@ mod tool_batch;
 mod tool_dedup;
 mod tool_executor;
 pub mod tool_scheduler;
+mod turn_session;
 mod usage;
 mod worktree;
 
@@ -769,46 +770,20 @@ impl Agent {
     }
 
     fn inject_pending_steer(&mut self, options: &PromptOptions) -> Result<bool> {
-        let messages = self.steer_buffer.lock().take_all();
-        if messages.is_empty() {
-            return Ok(false);
-        }
-        for text in messages {
-            info!(steer_chars = text.len(), "steer_injected");
-            emit_event(
-                &options.event_handler,
-                AgentEvent::SteerInput { text: text.clone() },
-            );
-            self.session.push_message(Message::user(text));
-        }
-        Ok(true)
+        Ok(turn_session::inject_pending_steer(
+            self.runtime_scope.session_policy.steer,
+            &self.steer_buffer,
+            &mut self.session,
+            options,
+        ))
     }
 
     pub(crate) fn record_step_started(&mut self) -> Result<()> {
-        let Some(turn) = self.active_turn.as_ref() else {
-            return Ok(());
-        };
-        let Some(step_id) = turn.step_id else {
-            return Ok(());
-        };
-        let turn_id = turn.turn_id.to_string();
-        let step_id = step_id.to_string();
-        self.session
-            .record_step_started(&turn_id, &step_id, turn.step);
-        let idempotency_key = format!("{turn_id}/{step_id}/started");
-        let step_event = self.session.record_checkpoint(
-            Some(&turn_id),
-            Some(&step_id),
-            None,
-            "step_started",
-            &idempotency_key,
-        );
-        self.record_writer.append_execution_link(
-            &idempotency_key,
-            &step_event.id,
-            step_event.sequence,
-        )?;
-        Ok(())
+        turn_session::record_step_started(
+            &mut self.session,
+            &self.record_writer,
+            self.active_turn.as_ref(),
+        )
     }
 
     pub(crate) async fn prepare_step_context(
@@ -828,6 +803,7 @@ impl Agent {
                 tools: self.tools.as_ref(),
                 background: &self.background,
                 todos: &self.todos,
+                tool_policy: self.runtime_scope.tool_policy,
                 plan_mode_active,
                 record_writer: &self.record_writer,
             },

--- a/crates/core/src/prepare_step.rs
+++ b/crates/core/src/prepare_step.rs
@@ -16,7 +16,9 @@ use zene_context::{
 };
 use zene_llm::{ChatClient, ToolDefinition};
 use zene_session::{AgentRecordWriter, RecordEntry, SessionRecord};
-use zene_tools::{SharedBackgroundTasks, SharedTodoStore, ToolCatalog, ToolRegistry};
+use zene_tools::{
+    SharedBackgroundTasks, SharedTodoStore, ToolCatalog, ToolPolicy, ToolRegistry,
+};
 use zene_turn::PreparedContext;
 
 use crate::context_config;
@@ -37,6 +39,7 @@ pub(crate) struct PrepareStepDeps<'a> {
     pub tools: &'a ToolRegistry,
     pub background: &'a SharedBackgroundTasks,
     pub todos: &'a SharedTodoStore,
+    pub tool_policy: ToolPolicy,
     pub plan_mode_active: bool,
     pub record_writer: &'a AgentRecordWriter,
 }
@@ -52,10 +55,11 @@ pub(crate) async fn prepare_step_context(
     }
 
     sync_todos_to_session(deps.todos, deps.session);
-    let tools = tool_definitions_for_llm(deps.tools, deps.plan_mode_active);
+    let plan_filter = deps.tool_policy.plan_mode && deps.plan_mode_active;
+    let tools = tool_definitions_for_llm(deps.tools, plan_filter);
     let estimator = token_estimator(deps.config);
     let background_tasks = deps.background.lock().list();
-    let hooks = ZeneContextHooks::new(deps.session, &background_tasks, deps.plan_mode_active);
+    let hooks = ZeneContextHooks::new(deps.session, &background_tasks, plan_filter);
     let compaction_config = context_config::context_compaction_config(&deps.config.compaction);
     let mut handler =
         AgentContextHandler::new(deps.context_model, &deps.config.model, deps.workdir);
@@ -210,5 +214,15 @@ mod tests {
         let names: Vec<_> = defs.iter().map(|t| t.name.as_str()).collect();
         assert!(names.contains(&"Write"));
         assert!(names.contains(&"Bash"));
+    }
+
+    #[test]
+    fn tool_policy_without_plan_mode_skips_filter_even_when_active_flag_set() {
+        // Mirrors prepare_step: plan_filter = tool_policy.plan_mode && plan_mode_active
+        let tools = default_builtin_tools();
+        let policy = ToolPolicy::subagent();
+        let plan_filter = policy.plan_mode && true;
+        let defs = tool_definitions_for_llm(&tools, plan_filter);
+        assert!(defs.iter().any(|t| t.name == "Write"));
     }
 }

--- a/crates/core/src/subagent.rs
+++ b/crates/core/src/subagent.rs
@@ -153,8 +153,6 @@ struct SubagentTurnRuntime<'a> {
     sandbox: Arc<dyn Sandbox>,
     config: &'a ZeneConfig,
     model_executor: Arc<dyn ModelExecutor>,
-    /// Retained for later ToolPolicy / SessionPolicy injection.
-    #[allow(dead_code)]
     scope: RuntimeScope,
     subagent_env: SubagentEnv,
     permission: Option<SharedToolPermission>,
@@ -234,6 +232,7 @@ impl<'a> SubagentTurnRuntime<'a> {
             self.subagent_env.clone(),
             self.permission.clone(),
             self.broker.clone(),
+            self.scope.tool_policy,
         )
         .await?;
         for message in batch.messages {
@@ -300,7 +299,8 @@ impl TurnSessionPort<()> for SubagentTurnRuntime<'_> {
     }
 
     fn inject_steer(&mut self, _options: &()) -> Result<bool> {
-        Ok(false)
+        // Ephemeral child scopes disable steer via SessionPolicy.
+        Ok(self.scope.session_policy.steer)
     }
 
     fn push_assistant(&mut self, message: Message) {
@@ -436,7 +436,7 @@ impl TurnRuntime for SubagentTurnRuntime<'_> {
     }
 
     fn inject_steer(&mut self, _options: &Self::Options) -> Result<bool> {
-        Ok(false)
+        Ok(self.scope.session_policy.steer)
     }
 
     fn push_assistant(&mut self, message: Message) {

--- a/crates/core/src/tool_batch.rs
+++ b/crates/core/src/tool_batch.rs
@@ -54,6 +54,17 @@ pub(crate) async fn run_tool_batch(
     options: &PromptOptions,
     cancel: Option<&CancellationToken>,
 ) -> Result<ToolBatchOutcome> {
+    debug_assert_eq!(
+        deps.runtime_scope.session_policy.persistence,
+        zene_tools::SessionPersistence::Durable,
+        "main-agent tool batch expects durable SessionPolicy"
+    );
+    debug_assert!(
+        deps.runtime_scope.tool_policy.plan_mode
+            && deps.runtime_scope.tool_policy.ask_user
+            && deps.runtime_scope.tool_policy.hooks,
+        "main-agent tool batch expects ToolPolicy::agent()"
+    );
     let turn_id = deps.turn_id.as_deref();
     let step_id = deps.step_id.as_deref();
 

--- a/crates/core/src/tool_executor.rs
+++ b/crates/core/src/tool_executor.rs
@@ -344,9 +344,11 @@ impl<'a> DefaultToolExecutor<'a> {
 
 /// Run one Subagent tool batch through the same executor as the main Agent.
 ///
-/// Plan mode stays inactive; hooks are empty. Missing permission inherits
-/// bypass so Explore/Coder keep prior auto-allow behavior unless a gate is
-/// passed from the parent.
+/// Capability switches come from [`zene_tools::ToolPolicy`]. Subagent scopes
+/// pass [`zene_tools::ToolPolicy::subagent`]: plan mode stays inactive, hooks
+/// stay empty, and ask-user uses the default prompter while the catalog omits
+/// those tools. Missing permission inherits bypass so Explore/Coder keep prior
+/// auto-allow unless a gate is passed from the parent.
 pub(crate) async fn execute_subagent_tool_batch(
     tools: Arc<ToolRegistry>,
     sandbox: Arc<dyn Sandbox>,
@@ -355,7 +357,12 @@ pub(crate) async fn execute_subagent_tool_batch(
     subagent_env: SubagentEnv,
     permission: Option<SharedToolPermission>,
     broker: Option<SharedApprovalBroker>,
+    tool_policy: zene_tools::ToolPolicy,
 ) -> Result<ToolBatchResult> {
+    debug_assert!(
+        !tool_policy.plan_mode && !tool_policy.ask_user && !tool_policy.hooks,
+        "subagent tool batch expects ToolPolicy::subagent()"
+    );
     let permission = permission.unwrap_or_else(|| {
         Arc::new(Mutex::new(PermissionGate::new(
             PermissionMode::BypassPermissions,
@@ -367,6 +374,7 @@ pub(crate) async fn execute_subagent_tool_batch(
     let ask_user = default_ask_user_prompter();
     let background = shared_background_tasks();
     let hooks = HookRunner::with_bash(Vec::new(), sandbox.workdir().to_path_buf());
+    let _ = tool_policy;
     let options = PromptOptions {
         stream: false,
         quiet: true,

--- a/crates/core/src/turn_session.rs
+++ b/crates/core/src/turn_session.rs
@@ -1,0 +1,166 @@
+//! Turn-session side effects extracted from [`crate::Agent`].
+//!
+//! Wave 14 facade: prepare_turn / usage / incomplete-turn / step-started
+//! live here so Agent TurnRuntime methods stay wiring-only.
+
+use anyhow::Result;
+use tracing::info;
+use zene_config::ZeneConfig;
+use zene_context::{ContextEngine, EstimateProvider, TokenEstimator};
+use zene_llm::{Message, TokenUsage};
+use zene_session::{AgentRecordWriter, SessionRecord};
+use zene_tools::{ToolCatalog, ToolPolicy, ToolRegistry};
+use zene_turn::{max_turns_notice, SteerBuffer};
+
+use crate::events::{emit_event, AgentEvent};
+use crate::plan_mode::tool_visible_in_definitions;
+use crate::tool_dedup::ToolDedup;
+use crate::usage::UsageAccumulator;
+use crate::PromptOptions;
+use parking_lot::Mutex;
+use std::sync::Arc;
+use zene_turn::TurnState;
+
+pub(crate) struct PrepareTurnDeps<'a> {
+    pub session: &'a mut SessionRecord,
+    pub system_prompt: &'a str,
+    pub usage_accumulator: &'a mut UsageAccumulator,
+    pub tool_dedup: &'a mut ToolDedup,
+    pub resume_existing_turn: &'a mut bool,
+}
+
+pub(crate) fn prepare_turn(deps: PrepareTurnDeps<'_>, user_input: &str) {
+    deps.usage_accumulator.reset();
+    deps.tool_dedup.reset();
+    deps.session.ensure_system_message(deps.system_prompt);
+    if !*deps.resume_existing_turn {
+        deps.session.set_title_from_prompt(user_input);
+        deps.session.push_message(Message::user(user_input));
+    }
+    *deps.resume_existing_turn = false;
+}
+
+pub(crate) struct StepUsageDeps<'a> {
+    pub config: &'a ZeneConfig,
+    pub context: &'a mut ContextEngine,
+    pub session: &'a mut SessionRecord,
+    pub tools: &'a ToolRegistry,
+    pub tool_policy: ToolPolicy,
+    pub plan_mode_active: bool,
+    pub usage_accumulator: &'a mut UsageAccumulator,
+}
+
+pub(crate) fn record_step_usage(
+    deps: StepUsageDeps<'_>,
+    usage: &TokenUsage,
+    options: &PromptOptions,
+) -> Result<()> {
+    deps.usage_accumulator.record(usage);
+    let plan_filter = deps.tool_policy.plan_mode && deps.plan_mode_active;
+    let tools: Vec<_> = ToolCatalog::definitions(deps.tools)
+        .into_iter()
+        .filter(|def| tool_visible_in_definitions(&def.name, plan_filter))
+        .collect();
+    let estimator = TokenEstimator::for_provider(
+        EstimateProvider::from_name(&deps.config.provider),
+        &deps.config.model,
+        deps.config.chars_per_token_for_model(),
+    );
+    let compaction_config =
+        crate::context_config::context_compaction_config(&deps.config.compaction);
+    let context_usage = deps.context.record_step_usage(
+        usage,
+        deps.session,
+        &tools,
+        &estimator,
+        &compaction_config,
+    )?;
+    let snapshot = deps.usage_accumulator.snapshot(
+        context_usage.context_tokens,
+        context_usage.context_window,
+        context_usage.context_percent,
+        deps.context.epoch(),
+    );
+    emit_event(
+        &options.event_handler,
+        AgentEvent::UsageUpdate {
+            usage: snapshot.usage,
+            context_tokens: snapshot.context_tokens,
+            context_window: snapshot.context_window,
+            context_percent: snapshot.context_percent,
+            context_epoch: snapshot.context_epoch,
+        },
+    );
+    Ok(())
+}
+
+pub(crate) fn record_step_started(
+    session: &mut SessionRecord,
+    record_writer: &AgentRecordWriter,
+    active_turn: Option<&TurnState>,
+) -> Result<()> {
+    let Some(turn) = active_turn else {
+        return Ok(());
+    };
+    let Some(step_id) = turn.step_id else {
+        return Ok(());
+    };
+    let turn_id = turn.turn_id.to_string();
+    let step_id = step_id.to_string();
+    session.record_step_started(&turn_id, &step_id, turn.step);
+    let idempotency_key = format!("{turn_id}/{step_id}/started");
+    let step_event = session.record_checkpoint(
+        Some(&turn_id),
+        Some(&step_id),
+        None,
+        "step_started",
+        &idempotency_key,
+    );
+    record_writer.append_execution_link(&idempotency_key, &step_event.id, step_event.sequence)?;
+    Ok(())
+}
+
+pub(crate) fn inject_pending_steer(
+    steer_enabled: bool,
+    steer_buffer: &Arc<Mutex<SteerBuffer>>,
+    session: &mut SessionRecord,
+    options: &PromptOptions,
+) -> bool {
+    if !steer_enabled {
+        return false;
+    }
+    let messages = steer_buffer.lock().take_all();
+    if messages.is_empty() {
+        return false;
+    }
+    for text in messages {
+        info!(steer_chars = text.len(), "steer_injected");
+        emit_event(
+            &options.event_handler,
+            AgentEvent::SteerInput { text: text.clone() },
+        );
+        session.push_message(Message::user(text));
+    }
+    true
+}
+
+pub(crate) fn on_incomplete_turn(
+    session: &mut SessionRecord,
+    max_steps: u32,
+    final_text: &mut String,
+    options: &PromptOptions,
+) {
+    let notice = max_turns_notice(max_steps);
+    let delta = if final_text.trim().is_empty() {
+        format!("\n{notice}\n")
+    } else {
+        format!("\n\n{notice}")
+    };
+    *final_text = if final_text.trim().is_empty() {
+        notice
+    } else {
+        format!("{final_text}\n\n{notice}")
+    };
+    session.push_message(Message::assistant(final_text.clone()));
+    emit_event(&options.event_handler, AgentEvent::TextDelta { delta });
+}

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -30,7 +30,7 @@ pub use background::{
 };
 pub use builtin::{agent_tools, builtin_tools, default_builtin_tools, tools_for_profile};
 pub use todo_store::{shared_todo_store, shared_todo_store_from, SharedTodoStore, TodoItem, TodoStatus, TodoStore};
-pub use scope::RuntimeScope;
+pub use scope::{RuntimeScope, SessionPersistence, SessionPolicy, ToolPolicy};
 pub use subagent::{
     SubagentEnv, SubagentProfile, SubagentRunner, DEFAULT_SUBAGENT_MAX_DEPTH,
 };

--- a/crates/tools/src/scope.rs
+++ b/crates/tools/src/scope.rs
@@ -7,15 +7,83 @@ use crate::builtin::{agent_tools, tools_for_profile};
 use crate::registry::ToolRegistry;
 use crate::subagent::{SubagentEnv, SubagentProfile, SubagentRunner, DEFAULT_SUBAGENT_MAX_DEPTH};
 
+/// Tool capability switches for a runtime scope.
+///
+/// Catalog selection already limits which tools exist; these flags control
+/// execute-time / prepare-time behavior that previously branched on
+/// Agent-vs-Subagent hardcoding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToolPolicy {
+    /// Enter/Exit plan mode tooling and plan-mode definition filtering.
+    pub plan_mode: bool,
+    /// AskUserQuestion prompter wiring (catalog still gates the tool).
+    pub ask_user: bool,
+    /// Whether HookRunner from config should run for tool batches.
+    pub hooks: bool,
+}
+
+impl ToolPolicy {
+    pub const fn agent() -> Self {
+        Self {
+            plan_mode: true,
+            ask_user: true,
+            hooks: true,
+        }
+    }
+
+    pub const fn subagent() -> Self {
+        Self {
+            plan_mode: false,
+            ask_user: false,
+            hooks: false,
+        }
+    }
+}
+
+/// How conversation / execution state is retained for a scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionPersistence {
+    /// SessionRecord + execution checkpoints + session_store writeback.
+    Durable,
+    /// In-memory messages only; no parent events/checkpoints.
+    Ephemeral,
+}
+
+/// Session / control-plane capability switches for a runtime scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SessionPolicy {
+    pub persistence: SessionPersistence,
+    /// Mid-turn steer buffer injection.
+    pub steer: bool,
+}
+
+impl SessionPolicy {
+    pub const fn agent() -> Self {
+        Self {
+            persistence: SessionPersistence::Durable,
+            steer: true,
+        }
+    }
+
+    pub const fn subagent() -> Self {
+        Self {
+            persistence: SessionPersistence::Ephemeral,
+            steer: false,
+        }
+    }
+}
+
 /// Capability boundary for a main-agent or child runtime turn.
 ///
-/// Wave 14: construction goes through a scope so profile, nesting depth, and
-/// tool catalog stay one injection point. ToolPolicy/SessionPolicy land later.
+/// Wave 14: construction goes through a scope so profile, nesting depth, tool
+/// catalog, and ToolPolicy/SessionPolicy stay one injection point.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeScope {
     kind: RuntimeKind,
     pub depth: u32,
     pub max_depth: u32,
+    pub tool_policy: ToolPolicy,
+    pub session_policy: SessionPolicy,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -42,6 +110,8 @@ impl RuntimeScope {
             },
             depth: 0,
             max_depth: DEFAULT_SUBAGENT_MAX_DEPTH,
+            tool_policy: ToolPolicy::agent(),
+            session_policy: SessionPolicy::agent(),
         }
     }
 
@@ -55,6 +125,8 @@ impl RuntimeScope {
             kind: RuntimeKind::Subagent { profile },
             depth,
             max_depth: DEFAULT_SUBAGENT_MAX_DEPTH,
+            tool_policy: ToolPolicy::subagent(),
+            session_policy: SessionPolicy::subagent(),
         })
     }
 
@@ -101,6 +173,8 @@ mod tests {
     fn explore_scope_exposes_read_only_catalog() {
         let scope = RuntimeScope::subagent(SubagentProfile::Explore, 0).expect("scope");
         assert_eq!(scope.depth, 1);
+        assert_eq!(scope.tool_policy, ToolPolicy::subagent());
+        assert_eq!(scope.session_policy, SessionPolicy::subagent());
         let names: Vec<_> = scope
             .definitions()
             .into_iter()
@@ -135,6 +209,12 @@ mod tests {
         let scope = RuntimeScope::agent(AgentProfile::Explore, WebSearchConfig::default());
         assert_eq!(scope.depth, 0);
         assert!(scope.subagent_profile().is_none());
+        assert_eq!(scope.tool_policy, ToolPolicy::agent());
+        assert_eq!(scope.session_policy, SessionPolicy::agent());
+        assert_eq!(
+            scope.session_policy.persistence,
+            SessionPersistence::Durable
+        );
         let names: Vec<_> = scope
             .definitions()
             .into_iter()
@@ -157,5 +237,18 @@ mod tests {
             .collect();
         assert!(names.contains(&"Write".into()));
         assert!(names.contains(&"Task".into()));
+    }
+
+    #[test]
+    fn subagent_scope_is_ephemeral_without_steer() {
+        let scope = RuntimeScope::subagent(SubagentProfile::Explore, 0).expect("scope");
+        assert_eq!(
+            scope.session_policy.persistence,
+            SessionPersistence::Ephemeral
+        );
+        assert!(!scope.session_policy.steer);
+        assert!(!scope.tool_policy.plan_mode);
+        assert!(!scope.tool_policy.ask_user);
+        assert!(!scope.tool_policy.hooks);
     }
 }

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `0eb889c`（PR #101 已合并）。**
+> **进度快照：2026-08-13，基线 `d2184e5`（PR #102 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 的 Steer/SetMode 已对齐；Wave 14 进行中（主 Agent prepare/model/tool-batch 已抽出；Subagent 经 RuntimeScope + DefaultToolExecutor + ModelExecutor）。
+> Wave 16 的 Steer/SetMode 已对齐；**Wave 14 已完成**（RuntimeScope + ToolPolicy/SessionPolicy + ToolCatalog；Subagent/主 Agent 共用 executors；Agent 退回 composition-root facade；actor 仍在 core）。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -33,7 +33,7 @@
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者，但 Agent-specific actor 仍在 `zene-core`，ACP 仍保留 transport 层 session bookkeeping。
 6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 与 option 列表只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`，并带 `ApprovalKind` / `ApprovalRisk`。已分类 Cloud payload 与审批表 payload 已是产品字段；未识别帧仍为 ACP JSON。API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举。
-7. `ToolRegistry` 仍同时承担目录与执行；`ToolCatalog` 已抽出定义端口；主 Agent / Subagent 均经 `RuntimeScope` 注入 catalog。Agent 仍持有 registry 执行面，尚未完全退回 composition root。
+7. `ToolRegistry` 仍同时承担目录与执行；`ToolCatalog` 已抽出定义端口；主 Agent / Subagent 均经 `RuntimeScope`（含 `ToolPolicy` / `SessionPolicy`）注入。Agent 为 composition-root facade，step 算法在 prepare/model/tool-batch/turn_session 模块。
 
 本文目标不是立刻重写 runtime，而是建立一个可以渐进落地的目标架构：
 
@@ -101,7 +101,7 @@ RuntimeHandle → Agent → TurnEngine
 | Session | `crates/session` | `SessionRecord` + `SessionStore`；events 优先，messages 为 materialized cache |
 | Context | `crates/context` | observe/commit/project；`SessionView` 驱动 event-backed projection |
 | Permission | `crates/permission` | `evaluate` 纯判定；`Ask` 走 `ApprovalBroker`。Runtime 挂 waiter，transport 发 `RuntimeCommand::Approval` |
-| Subagent | `crates/core/src/subagent.rs` | 经 `RuntimeScope` 注入工具目录；工具执行走 `DefaultToolExecutor`；模型走 `ModelExecutor`；仍用内存消息 |
+| Subagent | `crates/core/src/subagent.rs` | 经 `RuntimeScope`（含 ToolPolicy/SessionPolicy）注入；工具走 `DefaultToolExecutor`；模型走 `ModelExecutor`；`SessionPersistence::Ephemeral` |
 | Runtime | `crates/runtime` + `crates/core/src/agent_runtime.rs` | 公共 command/event 在 `zene-runtime`；Agent actor 仍在 core |
 | ACP | `apps/cli/src/acp/server.rs` | transport adapter；创建/加载 session，并把请求接入 `RuntimeHandle` |
 | Cloud Job | `cloud/apps/worker` + `cloud/crates/runtime-client` | Job 经 `RuntimeClient::send` 发 Prompt/Cancel/Approval/Shutdown；API→worker `WorkerCommand` 为 Prompt/Cancel；审批产品面（决策/kind/risk）从 DB 到 Console 到 RuntimeCommand 共用 domain 类型；ACP `optionId` 只在 adapter 内映射 |
@@ -1097,7 +1097,7 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 | Wave 11 | 已完成第一阶段 | ModelExecutor、ContextModel、usage boundary、runtime protocol 和 lifecycle publisher 已落地；Agent-specific actor 尚在 core |
 | Wave 12 | 已完成第一阶段 | safe resume、Cloud RuntimeClient、neutral runtime notifications、fenced command lease/ack、atomic state/event writes、outbox replay 和真实 replacement 测试已落地 |
 | Wave 13 | 已完成 | 默认 Agent/Subagent 路径消费 `PreparedContext`；PR #60 |
-| Wave 14 | 进行中 | RuntimeScope + ToolCatalog + Subagent executors + 主 Agent prepare/model-step 抽出；tool writeback / ToolPolicy / 完全退回 composition root 仍待做 |
+| Wave 14 | 已完成 | RuntimeScope + ToolCatalog + ToolPolicy/SessionPolicy；Subagent DefaultToolExecutor/ModelExecutor；主 Agent prepare/model/tool-batch/turn_session facade；actor 仍在 core |
 | Wave 15 | 已完成 | `evaluate` + `ApprovalBroker` + runtime-owned waiter；PR #61 / #62 |
 | Wave 16 | 已完成 command 对齐 | Cloud RuntimeCommand 含 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；仍不依赖 `zene-runtime` |
 
@@ -1132,11 +1132,11 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 
 4. **仍明确未自动完成的项目**
    - pending tool / approval 的任意副作用自动 replay：继续采用 inspection/manual intervention，避免重复写操作。
-   - `Agent` 从 step orchestrator 完全退回 composition root（catalog / prepare_step / model-step 已抽出；tool writeback 仍在 Agent）。
-   - Subagent 通过 `RuntimeScope` 复用 `DefaultToolExecutor` / `ModelExecutor`（已落地）；仍用内存消息。
+   - Subagent 仍用内存消息（`SessionPersistence::Ephemeral`）；未做 durable child session。
    - 本地与 Cloud 共用同一套 `RuntimeCommand` / `RuntimeEvent`（Cloud 已有 Prompt/Steer/Cancel/Approval/SetMode/Shutdown；API→worker 仍是 Prompt/Cancel；不依赖 `zene-runtime`）。`GetMode` / `ResumeSafeTurn` 仍仅本地。未识别 Cloud 帧仍为 ACP JSON。
-   - Agent-specific actor 从 `zene-core` 移入独立 runtime implementation crate（应在 ports/审批稳定之后）。
+   - Agent-specific actor 从 `zene-core` 移入独立 runtime implementation crate（应在 ports/审批稳定之后；Wave 14 明确不搬）。
    - 跨 VM outbox 的共享持久化实现；当前部署文档要求共享 POSIX volume 或后续 DB/object spool。
+   - Turn 侧中性 `ModelRequest`（仍吃 `ChatRequest`）。
 
 以上未完成项不是本轮测试覆盖的小修复；在没有明确协议、存储和迁移策略前，不应声称已经完成。
 
@@ -1234,11 +1234,11 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | **Wave 14** | RuntimeScope、ToolCatalog 拆分、Agent 退回 wiring |
-| 结构清理 | Wave 14 | command 面已稳定，可开始能力注入 |
+| 当前最大杠杆 | actor 搬迁 / ModelRequest | Wave 14 已完成；下一步是 runtime crate 边界或中性模型请求 |
+| 结构清理 | actor 出 core | ports/审批已稳定，可评估搬迁 |
 | 可选后续 | 整型 crate / GetMode | Cloud 仍不引入 `zene-runtime`；本地 GetMode/ResumeSafeTurn 仍仅本地 |
 
-推荐组合：**Steer/SetMode 已对齐**。下一步做 Wave 14 的 `RuntimeScope` + `ToolCatalog` 第一刀，不要先搬 Agent actor。
+推荐组合：**Wave 14 已收口**。下一步不要碎片化；若继续做结构清理，优先评估 Agent actor 出 core，或 Turn 侧 `ModelRequest`，不要先动 Console。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1485,3 +1485,16 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 - 新增 `crates/core/src/prepare_step.rs`：todos sync → ContextEngine prepare → ProjectionReady / water 日志经 `PrepareStepDeps`。
 - `Agent::prepare_step_context` 退回 wiring；`record_step_started` 仍留在 Agent/ports。
 - 不搬 Agent actor。不抽 tool writeback。不做 Cloud 改动。
+
+### 2026-08-13 — Wave 14 主 Agent tool-batch writeback 抽出
+
+- 新增 `crates/core/src/tool_batch.rs`：ToolStarted/Completed checkpoint、session event、mode/permission 写回经 `run_tool_batch`；执行仍走 `DefaultToolExecutor`。
+- `Agent::run_tools` 退回 wiring。
+- 不搬 Agent actor。不做 Cloud 改动。
+
+### 2026-08-13 — Wave 14 收口（ToolPolicy / SessionPolicy + facade）
+
+- `RuntimeScope` 携带 `ToolPolicy`（plan_mode / ask_user / hooks）与 `SessionPolicy`（Durable|Ephemeral、steer）。
+- Agent / Subagent 构造器写入预设；prepare / tool-batch / Subagent 执行经 policy 接线。
+- 新增 `turn_session.rs`：prepare_turn / step usage / steer / incomplete-turn / step-started 抽出；`Agent` + `AgentTurnPorts` 为 composition-root facade。
+- **Wave 14 标记完成**。不搬 Agent actor。不做 Cloud。不引入 `ModelRequest`。不做 pending tool 自动 replay。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

一次收口 **Wave 14**：在 `#96`–`#102` 已落地的 RuntimeScope / ToolCatalog / Subagent executors / prepare·model·tool-batch 抽出之上，补齐 `ToolPolicy` / `SessionPolicy`，并把主 Agent 收成 composition-root facade（`turn_session`）。**本 PR 后 Wave 14 标记完成。**

## Changes

- `RuntimeScope` 携带 `ToolPolicy`（plan_mode / ask_user / hooks）与 `SessionPolicy`（Durable|Ephemeral、steer）；Agent / Subagent 构造器写入预设
- prepare / tool-batch / Subagent 执行经 policy 接线（不再靠 Agent-vs-Subagent 硬编码）
- 新增 `crates/core/src/turn_session.rs`：prepare_turn / step usage / steer / incomplete-turn / step-started
- `Agent` + `AgentTurnPorts` 退回 wiring facade
- 文档：Wave 14 → 已完成

## Out of scope（明确不做）

- 不搬 Agent actor 出 `zene-core`
- 不引入中性 `ModelRequest`
- 不做 Cloud / 不让 Cloud 依赖 `zene-runtime`
- 不做 pending tool 自动 replay
- 不改 Console chrome
- 不做 Subagent durable child session

## Test plan

- [x] `cargo test -p zene-tools -p zene-core --locked --lib`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

