### PR TITLE
feat: ModelExecutor 边界引入中性 ModelRequest

### DIFF
--- a/crates/core/src/model_step.rs
+++ b/crates/core/src/model_step.rs
@@ -3,7 +3,8 @@
 //! Wave 14: the default turn path still enters via Agent wiring, but the
 //! overflow-retry / stream assembly loop lives here (parallel to
 //! [`crate::tool_executor::DefaultToolExecutor`] for tools). Request type
-//! remains [`zene_llm::ChatRequest`] — no neutral `ModelRequest` yet.
+//! remains [`zene_model_executor::ModelRequest`]; providers still see `ChatRequest`
+//! inside [`zene_model_executor::ChatClientExecutor`].
 
 use std::io::{self, Write};
 use std::path::Path;
@@ -17,8 +18,8 @@ use zene_config::ZeneConfig;
 use zene_context::{
     ContextEngine, ContextModel, EstimateProvider, PrefireClientFactory, StepContext, TokenEstimator,
 };
-use zene_llm::{ChatClient, ChatRequest, Message, StreamEvent, TokenUsage, ToolDefinition};
-use zene_model_executor::ModelExecutor;
+use zene_llm::{ChatClient, Message, StreamEvent, TokenUsage, ToolDefinition};
+use zene_model_executor::{ModelExecutor, ModelRequest};
 use zene_session::{AgentRecordWriter, RecordEntry, SessionRecord};
 use zene_tools::{SharedBackgroundTasks, SharedTodoStore};
 use zene_turn::PreparedContext;
@@ -178,7 +179,7 @@ async fn recover_overflow(
 
 pub(crate) async fn run_streaming_step(
     executor: &dyn ModelExecutor,
-    request: ChatRequest,
+    request: ModelRequest,
     options: &PromptOptions,
     cancel: Option<&CancellationToken>,
 ) -> Result<(Message, Option<TokenUsage>)> {
@@ -281,11 +282,11 @@ mod tests {
 
     #[async_trait]
     impl ModelExecutor for TextThenDone {
-        async fn complete(&self, _request: ChatRequest) -> Result<zene_llm::ChatResponse> {
+        async fn complete(&self, _request: ModelRequest) -> Result<zene_model_executor::ModelResponse> {
             unreachable!("complete not used")
         }
 
-        async fn stream(&self, _request: ChatRequest) -> Result<ModelStream> {
+        async fn stream(&self, _request: ModelRequest) -> Result<ModelStream> {
             Ok(Box::pin(futures::stream::iter(vec![
                 Ok(StreamEvent::TextDelta("hi".into())),
                 Ok(StreamEvent::Done { usage: None }),
@@ -300,7 +301,7 @@ mod tests {
             quiet: true,
             ..PromptOptions::default()
         };
-        let request = ChatRequest {
+        let request = ModelRequest {
             model: "test".into(),
             messages: vec![],
             tools: vec![],

--- a/crates/core/src/subagent.rs
+++ b/crates/core/src/subagent.rs
@@ -5,8 +5,8 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use tokio_util::sync::CancellationToken;
 use zene_config::ZeneConfig;
-use zene_llm::{ChatClient, ChatRequest, ChatResponse, Message, TokenUsage, ToolCall};
-use zene_model_executor::{ChatClientExecutor, ModelExecutor, ModelStream};
+use zene_llm::{ChatClient, Message, TokenUsage, ToolCall};
+use zene_model_executor::{ChatClientExecutor, ModelExecutor, ModelRequest, ModelResponse, ModelStream};
 use zene_sandbox::Sandbox;
 use zene_tools::{
     RuntimeScope, SubagentEnv, SubagentProfile, SubagentRunner, ToolCatalog, ToolContext,
@@ -256,7 +256,7 @@ impl<'a> SubagentTurnRuntime<'a> {
         }
         let response = self
             .model_executor
-            .complete(ChatRequest {
+            .complete(ModelRequest {
                 model: self.config.model.clone(),
                 messages: context.messages,
                 tools: context.tools,
@@ -524,7 +524,10 @@ async fn maybe_compact_subagent_messages(
         "subagent_token_threshold",
         &tool_defs,
         &estimator,
-        |request| model_executor.complete(request),
+        |request| {
+            let model_executor = Arc::clone(&model_executor);
+            async move { Ok(model_executor.complete(request.into()).await?.into()) }
+        },
     )
     .await?
     .is_some()
@@ -568,13 +571,13 @@ mod tests {
     }
 
     struct ScriptedBackend {
-        responses: Vec<ChatResponse>,
+        responses: Vec<ModelResponse>,
         calls: AtomicUsize,
-        on_first_call: Option<Box<dyn Fn(&ChatRequest) + Send + Sync>>,
+        on_first_call: Option<Box<dyn Fn(&ModelRequest) + Send + Sync>>,
     }
 
     impl ScriptedBackend {
-        fn new(responses: Vec<ChatResponse>) -> Self {
+        fn new(responses: Vec<ModelResponse>) -> Self {
             Self {
                 responses,
                 calls: AtomicUsize::new(0),
@@ -583,8 +586,8 @@ mod tests {
         }
 
         fn with_first_call_check(
-            responses: Vec<ChatResponse>,
-            check: impl Fn(&ChatRequest) + Send + Sync + 'static,
+            responses: Vec<ModelResponse>,
+            check: impl Fn(&ModelRequest) + Send + Sync + 'static,
         ) -> Self {
             Self {
                 responses,
@@ -596,7 +599,7 @@ mod tests {
 
     #[async_trait]
     impl ModelExecutor for ScriptedBackend {
-        async fn complete(&self, request: ChatRequest) -> Result<ChatResponse> {
+        async fn complete(&self, request: ModelRequest) -> Result<ModelResponse> {
             let idx = self.calls.fetch_add(1, Ordering::SeqCst);
             let response = self
                 .responses
@@ -613,7 +616,7 @@ mod tests {
             Ok(response)
         }
 
-        async fn stream(&self, _request: ChatRequest) -> Result<ModelStream> {
+        async fn stream(&self, _request: ModelRequest) -> Result<ModelStream> {
             Ok(Box::pin(futures::stream::iter([Ok(
                 zene_llm::StreamEvent::Done { usage: None },
             )])))
@@ -676,7 +679,7 @@ mod tests {
 
         let backend = ScriptedBackend::with_first_call_check(
             vec![
-            ChatResponse {
+            ModelResponse {
                 message: Message::assistant_with_tools(
                     None,
                     vec![ToolCall {
@@ -687,7 +690,7 @@ mod tests {
                 ),
                 usage: None,
             },
-            ChatResponse {
+            ModelResponse {
                 message: Message::assistant("Found alpha.txt and beta.txt"),
                 usage: None,
             },
@@ -762,7 +765,7 @@ mod tests {
         let sandbox = zene_sandbox::into_arc(LocalSandbox::new(dir.path()));
         let mut config = ZeneConfig::default();
         config.max_turns = 1;
-        let backend = ScriptedBackend::new(vec![ChatResponse {
+        let backend = ScriptedBackend::new(vec![ModelResponse {
             message: Message::assistant_with_tools(
                 None,
                 vec![ToolCall {
@@ -838,7 +841,7 @@ mod tests {
         let permission = test_permission_deny();
 
         let backend = ScriptedBackend::new(vec![
-            ChatResponse {
+            ModelResponse {
                 message: Message::assistant_with_tools(
                     None,
                     vec![ToolCall {
@@ -849,7 +852,7 @@ mod tests {
                 ),
                 usage: None,
             },
-            ChatResponse {
+            ModelResponse {
                 message: Message::assistant("Write was denied"),
                 usage: None,
             },

--- a/crates/model-executor/src/lib.rs
+++ b/crates/model-executor/src/lib.rs
@@ -5,18 +5,81 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::Stream;
-use zene_llm::{ChatClient, ChatRequest, ChatResponse, Message, StreamEvent, ToolCall};
+use zene_llm::{
+    ChatClient, ChatRequest, ChatResponse, ContextMetadata, Message, StreamEvent, TokenUsage,
+    ToolCall, ToolDefinition,
+};
 
-pub type ModelStream = Pin<Box<dyn Stream<Item = Result<StreamEvent>> + Send>>;
+/// Turn/runtime-facing model request (provider details stay behind adapters).
+#[derive(Debug, Clone)]
+pub struct ModelRequest {
+    pub model: String,
+    pub messages: Vec<Message>,
+    pub tools: Vec<ToolDefinition>,
+    pub stream: bool,
+    pub context: Option<ContextMetadata>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ModelResponse {
+    pub message: Message,
+    pub usage: Option<TokenUsage>,
+}
+
+impl From<ModelRequest> for ChatRequest {
+    fn from(request: ModelRequest) -> Self {
+        ChatRequest {
+            model: request.model,
+            messages: request.messages,
+            tools: request.tools,
+            stream: request.stream,
+            context: request.context,
+        }
+    }
+}
+
+impl From<ChatRequest> for ModelRequest {
+    fn from(request: ChatRequest) -> Self {
+        ModelRequest {
+            model: request.model,
+            messages: request.messages,
+            tools: request.tools,
+            stream: request.stream,
+            context: request.context,
+        }
+    }
+}
+
+impl From<ModelResponse> for ChatResponse {
+    fn from(response: ModelResponse) -> Self {
+        ChatResponse {
+            message: response.message,
+            usage: response.usage,
+        }
+    }
+}
+
+impl From<ChatResponse> for ModelResponse {
+    fn from(response: ChatResponse) -> Self {
+        ModelResponse {
+            message: response.message,
+            usage: response.usage,
+        }
+    }
+}
+
+/// Stream item type at the ModelExecutor boundary (provider `StreamEvent` today).
+pub type ModelEvent = StreamEvent;
+pub type ModelStream = Pin<Box<dyn Stream<Item = Result<ModelEvent>> + Send>>;
 
 pub fn build_request(
     model: &str,
     messages: Vec<Message>,
-    tools: Vec<zene_llm::ToolDefinition>,
+    tools: Vec<ToolDefinition>,
     stream: bool,
-    context: Option<zene_llm::ContextMetadata>,
-) -> ChatRequest {
-    ChatRequest {
+    context: Option<ContextMetadata>,
+) -> ModelRequest {
+    ModelRequest {
         model: model.to_string(),
         messages,
         tools,
@@ -43,8 +106,8 @@ impl OverflowRetryState {
 
 #[async_trait]
 pub trait ModelExecutor: Send + Sync {
-    async fn complete(&self, request: ChatRequest) -> Result<ChatResponse>;
-    async fn stream(&self, request: ChatRequest) -> Result<ModelStream>;
+    async fn complete(&self, request: ModelRequest) -> Result<ModelResponse>;
+    async fn stream(&self, request: ModelRequest) -> Result<ModelStream>;
 }
 
 pub struct ChatClientExecutor {
@@ -59,11 +122,11 @@ impl ChatClientExecutor {
 
 #[async_trait]
 impl ModelExecutor for ChatClientExecutor {
-    async fn complete(&self, request: ChatRequest) -> Result<ChatResponse> {
-        self.client.chat(request).await
+    async fn complete(&self, request: ModelRequest) -> Result<ModelResponse> {
+        Ok(self.client.chat(request.into()).await?.into())
     }
-    async fn stream(&self, request: ChatRequest) -> Result<ModelStream> {
-        self.client.chat_stream(request).await
+    async fn stream(&self, request: ModelRequest) -> Result<ModelStream> {
+        self.client.chat_stream(request.into()).await
     }
 }
 
@@ -179,13 +242,13 @@ mod tests {
     struct FakeExecutor;
     #[async_trait]
     impl ModelExecutor for FakeExecutor {
-        async fn complete(&self, request: ChatRequest) -> Result<ChatResponse> {
-            Ok(ChatResponse {
+        async fn complete(&self, request: ModelRequest) -> Result<ModelResponse> {
+            Ok(ModelResponse {
                 message: Message::assistant(request.messages.len().to_string()),
                 usage: None,
             })
         }
-        async fn stream(&self, _request: ChatRequest) -> Result<ModelStream> {
+        async fn stream(&self, _request: ModelRequest) -> Result<ModelStream> {
             Ok(Box::pin(stream::iter([Ok(StreamEvent::Done {
                 usage: None,
             })])))
@@ -208,6 +271,22 @@ mod tests {
             stream.next().await.unwrap().unwrap(),
             StreamEvent::Done { usage: None }
         ));
+    }
+
+    #[test]
+    fn model_request_round_trips_chat_request() {
+        let model = ModelRequest {
+            model: "m".into(),
+            messages: vec![Message::user("hi")],
+            tools: Vec::new(),
+            stream: true,
+            context: None,
+        };
+        let chat: ChatRequest = model.clone().into();
+        let back: ModelRequest = chat.into();
+        assert_eq!(back.model, "m");
+        assert_eq!(back.messages.len(), 1);
+        assert!(back.stream);
     }
 
     #[test]

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -28,7 +28,7 @@
 但当前 `Agent` 仍同时是 composition root 和 step orchestrator，开放度还不够：
 
 1. `TurnEngine` 已统一主 Agent 和 Subagent 的循环，ports 也已抽出；Wave 13 起默认路径必须真正把 `prepare_context` 的 `PreparedContext` 交给 `run_model`，而不是在 model 步骤里重新组装上下文。
-2. `Provider`、`ChatClient`、`ChatBackend` 仍存在相近但不统一的模型抽象；`zene-model-executor` 已可注入，但请求类型仍是 `zene-llm::ChatRequest`，Turn 还看不到中性 `ModelRequest`。
+2. `Provider` / `ChatClient` 仍是 provider 面；Turn/runtime 经 `ModelExecutor` 看见中性 `ModelRequest` / `ModelResponse`，`ChatClientExecutor` 内部映射为 `ChatRequest`。
 3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。Cloud `RuntimeCommand::Approval` 已与 core 同形（`request_id` + `ApprovalDecision`），但 Cloud 仍无 Steer/SetMode 等变体，也未依赖 `zene-runtime`。已分类 Cloud payload 已是产品字段；未识别帧仍为 ACP JSON。
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者；Agent-specific actor 在 `zene-agent-runtime`，ACP 仍保留 transport 层 session bookkeeping。
@@ -1505,3 +1505,10 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 - `zene-core` 不再持有 actor；ACP 从 `zene_agent_runtime` 导入 `RuntimeHandle`。
 - 协议仍在 `zene-runtime`。Cloud 不依赖 `zene-runtime` / `zene-agent-runtime`。
 - 不引入 `ModelRequest`。不做 pending tool 自动 replay。不改 Console。
+
+### 2026-08-13 — ModelRequest at ModelExecutor boundary
+
+- 新增 `ModelRequest` / `ModelResponse`；`ModelExecutor::complete/stream` 改为吃中性请求。
+- `ChatClientExecutor` 内部映射到 `ChatRequest` / `ChatResponse`；provider / `ContextModel` 不变。
+- 主 Agent `model_step` 与 Subagent 调用面改用 `ModelRequest`。
+- 不做 Cloud。不改 Console。不自动 replay pending tools。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

在 `ModelExecutor` 边界引入中性 **`ModelRequest` / `ModelResponse`**。Turn / Agent / Subagent 经 `PreparedContext` → `ModelRequest` 调模型；`ChatClientExecutor` 内部映射到 `ChatRequest`，provider 与 `ContextModel` 不变。

## Changes

- `zene-model-executor`：新增类型、`From` 双向映射；`ModelExecutor` trait 改签名；`build_request` 返回 `ModelRequest`
- `model_step` / Subagent 调用面改用 `ModelRequest`
- 文档更新

## Out of scope

- 不改 provider / `ContextModel`（仍吃 `ChatRequest`）
- 不做 Cloud / Console
- 不做 pending tool 自动 replay
- 不另起一套 `ModelEvent` 枚举

## Test plan

- [x] `cargo test -p zene-model-executor -p zene-core --locked --offline`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

