### PR TITLE
feat: 产品化 residual Cloud ACP 帧（initialize / unsupported）

### DIFF
--- a/cloud/apps/web/lib/runtimeEvent.ts
+++ b/cloud/apps/web/lib/runtimeEvent.ts
@@ -37,6 +37,8 @@ const RUN_EVENT_TYPES: readonly RunEventType[] = [
   "available_commands",
   "session_started",
   "approval_requested",
+  "initialized",
+  "unsupported_request",
   "acp",
   "platform",
   "runtime",

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -111,6 +111,8 @@ export type CloudEventKind =
   | "available_commands"
   | "session_started"
   | "approval_requested"
+  | "initialized"
+  | "unsupported_request"
   | "acp";
 
 /** Stored `event_type` written by Cloud. Matches domain `RunEventKind`. */
@@ -155,6 +157,25 @@ export interface ToolResultPayload {
 export interface SessionStartedPayload {
   sessionId?: string;
   resumed?: boolean;
+}
+
+export interface InitializedPayload {
+  protocolVersion?: unknown;
+  agentCapabilities?: unknown;
+  agentInfo?: unknown;
+  authMethods?: unknown;
+  [key: string]: unknown;
+}
+
+export interface UnsupportedRequestPayload {
+  method: string;
+  params?: unknown;
+}
+
+export interface AcpResidualPayload {
+  method?: string;
+  sessionUpdate?: string;
+  update?: unknown;
 }
 
 export interface StateChangedPayload {

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -214,7 +214,8 @@ pub struct UpdateRunRequest {
 }
 
 /// Product `event_type` written by RuntimeClient for classified frames.
-/// Unrecognized ACP frames are `acp`. Platform / legacy `runtime` rows use
+/// Unrecognized ACP frames are `acp` (with a residual product payload when the
+/// frame is a `session/update`). Platform / legacy `runtime` rows use
 /// [`RunEventKind`]; `RunEvent.event_type` stays a string so unknown historical
 /// values still load.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -232,6 +233,10 @@ pub enum CloudEventKind {
     AvailableCommands,
     SessionStarted,
     ApprovalRequested,
+    /// ACP `initialize` handshake result (not a session).
+    Initialized,
+    /// Reverse request that Cloud auto-rejects (no permission mapping).
+    UnsupportedRequest,
     Acp,
 }
 
@@ -250,6 +255,8 @@ impl CloudEventKind {
             Self::AvailableCommands => "available_commands",
             Self::SessionStarted => "session_started",
             Self::ApprovalRequested => "approval_requested",
+            Self::Initialized => "initialized",
+            Self::UnsupportedRequest => "unsupported_request",
             Self::Acp => "acp",
         }
     }
@@ -268,6 +275,8 @@ impl CloudEventKind {
             "available_commands" => Self::AvailableCommands,
             "session_started" => Self::SessionStarted,
             "approval_requested" => Self::ApprovalRequested,
+            "initialized" => Self::Initialized,
+            "unsupported_request" => Self::UnsupportedRequest,
             "acp" => Self::Acp,
             _ => return None,
         })
@@ -292,6 +301,8 @@ pub enum RunEventKind {
     AvailableCommands,
     SessionStarted,
     ApprovalRequested,
+    Initialized,
+    UnsupportedRequest,
     Acp,
     Platform,
     Runtime,
@@ -312,6 +323,8 @@ impl From<CloudEventKind> for RunEventKind {
             CloudEventKind::AvailableCommands => Self::AvailableCommands,
             CloudEventKind::SessionStarted => Self::SessionStarted,
             CloudEventKind::ApprovalRequested => Self::ApprovalRequested,
+            CloudEventKind::Initialized => Self::Initialized,
+            CloudEventKind::UnsupportedRequest => Self::UnsupportedRequest,
             CloudEventKind::Acp => Self::Acp,
         }
     }
@@ -334,6 +347,8 @@ impl RunEventKind {
             Self::AvailableCommands => CloudEventKind::AvailableCommands.as_event_type(),
             Self::SessionStarted => CloudEventKind::SessionStarted.as_event_type(),
             Self::ApprovalRequested => CloudEventKind::ApprovalRequested.as_event_type(),
+            Self::Initialized => CloudEventKind::Initialized.as_event_type(),
+            Self::UnsupportedRequest => CloudEventKind::UnsupportedRequest.as_event_type(),
             Self::Acp => CloudEventKind::Acp.as_event_type(),
         }
     }
@@ -401,6 +416,46 @@ pub struct SessionStartedPayload {
     pub session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resumed: Option<bool>,
+}
+
+/// Product payload for ACP `initialize` results.
+/// Extra result keys are preserved so the write path does not drop fields.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct InitializedPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol_version: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_capabilities: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_info: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_methods: Option<serde_json::Value>,
+    #[serde(default, flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Product payload for reverse requests Cloud auto-rejects.
+/// JSON-RPC `id` stays inside the adapter and is never persisted here.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct UnsupportedRequestPayload {
+    pub method: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
+}
+
+/// Residual product payload for unknown `session/update` frames.
+/// Keeps method / sessionUpdate / update body without the JSON-RPC envelope.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AcpResidualPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub method: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_update: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub update: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -972,6 +1027,8 @@ mod tests {
             CloudEventKind::AvailableCommands,
             CloudEventKind::SessionStarted,
             CloudEventKind::ApprovalRequested,
+            CloudEventKind::Initialized,
+            CloudEventKind::UnsupportedRequest,
             CloudEventKind::Acp,
         ] {
             let encoded = serde_json::to_value(kind).expect("serialize");

--- a/cloud/crates/runtime-client/src/lib.rs
+++ b/cloud/crates/runtime-client/src/lib.rs
@@ -13,9 +13,10 @@ use zene_cloud_acp_bridge::{
 };
 
 pub use zene_cloud_domain::{
-    ApprovalDecision, ApprovalEventPayload, ApprovalKind, AvailableCommandsPayload,
-    CloudEventKind, PlanPayload, ProjectionPayload, SessionStartedPayload, StateChangedPayload,
-    TextEventPayload, ToolCallPayload, ToolResultPayload, UsagePayload,
+    AcpResidualPayload, ApprovalDecision, ApprovalEventPayload, ApprovalKind,
+    AvailableCommandsPayload, CloudEventKind, InitializedPayload, PlanPayload, ProjectionPayload,
+    SessionStartedPayload, StateChangedPayload, TextEventPayload, ToolCallPayload,
+    ToolResultPayload, UnsupportedRequestPayload, UsagePayload,
 };
 
 /// ACP `optionId` mapping stays inside this adapter.
@@ -43,8 +44,15 @@ fn classify_payload(payload: &Value) -> CloudEventKind {
     match payload.get("method").and_then(Value::as_str) {
         Some("session/request_permission") => CloudEventKind::ApprovalRequested,
         Some("session/new") | Some("session/resume") => CloudEventKind::SessionStarted,
+        Some("initialize") => CloudEventKind::Initialized,
+        Some(_) if is_reverse_request_frame(payload) => CloudEventKind::UnsupportedRequest,
         _ => CloudEventKind::Acp,
     }
+}
+
+/// Reverse requests carry a JSON-RPC id and params, without a result.
+fn is_reverse_request_frame(payload: &Value) -> bool {
+    payload.get("id").is_some() && payload.get("result").is_none()
 }
 
 fn map_session_update(update: &str) -> CloudEventKind {
@@ -82,7 +90,7 @@ pub enum RuntimeCommand {
 /// In-memory product payload produced by the adapter.
 ///
 /// Classified kinds keep domain structs until JobRunner serializes at the
-/// HTTP/DB boundary. Unrecognized frames and extraction fallbacks stay
+/// HTTP/DB boundary. Extraction failures and non-session residual frames stay
 /// [`RuntimePayload::Json`].
 #[derive(Debug, Clone, PartialEq)]
 pub enum RuntimePayload {
@@ -96,6 +104,9 @@ pub enum RuntimePayload {
     SessionStarted(SessionStartedPayload),
     ApprovalRequested(ApprovalEventPayload),
     Projection(ProjectionPayload),
+    Initialized(InitializedPayload),
+    UnsupportedRequest(UnsupportedRequestPayload),
+    AcpResidual(AcpResidualPayload),
     Json(Value),
 }
 
@@ -112,6 +123,9 @@ impl RuntimePayload {
             Self::SessionStarted(payload) => to_json(payload),
             Self::ApprovalRequested(payload) => to_json(payload),
             Self::Projection(payload) => to_json(payload),
+            Self::Initialized(payload) => to_json(payload),
+            Self::UnsupportedRequest(payload) => to_json(payload),
+            Self::AcpResidual(payload) => to_json(payload),
             Self::Json(value) => value.clone(),
         }
     }
@@ -126,9 +140,9 @@ impl PartialEq<Value> for RuntimePayload {
 /// A runtime notification with the stable fields persisted by the worker.
 ///
 /// `event_type` is the product kind. Classified kinds store a denormalized
-/// product payload. Unrecognized frames stay `acp` with the original ACP JSON.
-/// Records written before this change still have ACP JSON; Console falls back
-/// to `params.update`.
+/// product payload. Unknown `session/update` frames stay `acp` with a residual
+/// product payload (no JSON-RPC envelope). Records written before productization
+/// still have ACP JSON; Console falls back to `params.update`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RuntimeNotification {
     pub source_event_id: String,
@@ -258,7 +272,9 @@ fn product_payload(kind: CloudEventKind, raw: &Value) -> RuntimePayload {
         CloudEventKind::ProjectionReady => projection_product(raw),
         CloudEventKind::Plan => plan_product(raw),
         CloudEventKind::AvailableCommands => commands_product(raw),
-        _ => RuntimePayload::Json(raw.clone()),
+        CloudEventKind::Initialized => initialized_product(raw),
+        CloudEventKind::UnsupportedRequest => unsupported_request_product(raw),
+        CloudEventKind::Acp => acp_residual_product(raw),
     }
 }
 
@@ -319,6 +335,61 @@ fn session_started_product(raw: &Value) -> RuntimePayload {
         return RuntimePayload::Json(raw.clone());
     }
     RuntimePayload::SessionStarted(payload)
+}
+
+fn initialized_product(raw: &Value) -> RuntimePayload {
+    let Some(result) = raw.get("result").filter(|value| value.is_object()) else {
+        return RuntimePayload::Json(raw.clone());
+    };
+    let mut extra = serde_json::Map::new();
+    let mut protocol_version = None;
+    let mut agent_capabilities = None;
+    let mut agent_info = None;
+    let mut auth_methods = None;
+    if let Some(object) = result.as_object() {
+        for (key, value) in object {
+            match key.as_str() {
+                "protocolVersion" => protocol_version = Some(value.clone()),
+                "agentCapabilities" => agent_capabilities = Some(value.clone()),
+                "agentInfo" => agent_info = Some(value.clone()),
+                "authMethods" => auth_methods = Some(value.clone()),
+                _ => {
+                    extra.insert(key.clone(), value.clone());
+                }
+            }
+        }
+    }
+    RuntimePayload::Initialized(InitializedPayload {
+        protocol_version,
+        agent_capabilities,
+        agent_info,
+        auth_methods,
+        extra,
+    })
+}
+
+fn unsupported_request_product(raw: &Value) -> RuntimePayload {
+    let Some(method) = raw.get("method").and_then(Value::as_str) else {
+        return RuntimePayload::Json(raw.clone());
+    };
+    RuntimePayload::UnsupportedRequest(UnsupportedRequestPayload {
+        method: method.to_string(),
+        params: raw.get("params").cloned(),
+    })
+}
+
+fn acp_residual_product(raw: &Value) -> RuntimePayload {
+    let Some(update) = raw.pointer("/params/update") else {
+        return RuntimePayload::Json(raw.clone());
+    };
+    RuntimePayload::AcpResidual(AcpResidualPayload {
+        method: raw.get("method").and_then(Value::as_str).map(str::to_string),
+        session_update: update
+            .get("sessionUpdate")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        update: Some(update.clone()),
+    })
 }
 
 fn state_product(raw: &Value) -> RuntimePayload {
@@ -1061,18 +1132,75 @@ mod tests {
     }
 
     #[test]
-    fn unclassified_session_updates_keep_original_payload() {
+    fn unclassified_session_updates_store_residual_product_payload() {
         let raw = serde_json::json!({
             "jsonrpc": "2.0",
             "method": "session/update",
             "params": {
                 "sessionId": "session-1",
-                "update": { "sessionUpdate": "unknown_update" }
+                "update": { "sessionUpdate": "unknown_update", "note": "x" }
             }
         });
         let event = runtime_notification(AcpEvent::from_notification(&raw));
         assert_eq!(event.event_type.as_event_type(), "acp");
-        assert_eq!(event.payload, raw);
+        assert_eq!(
+            event.payload,
+            serde_json::json!({
+                "method": "session/update",
+                "sessionUpdate": "unknown_update",
+                "update": { "sessionUpdate": "unknown_update", "note": "x" }
+            })
+        );
+    }
+
+    #[test]
+    fn initialize_stores_product_handshake_fields() {
+        let event = runtime_notification(AcpEvent {
+            source_event_id: "init-1".into(),
+            cursor: None,
+            event_type: "acp".into(),
+            payload: serde_json::json!({
+                "method": "initialize",
+                "result": {
+                    "protocolVersion": 1,
+                    "agentCapabilities": { "loadSession": true },
+                    "agentInfo": { "name": "zene" },
+                    "authMethods": [],
+                    "extraFlag": true
+                }
+            }),
+        });
+        assert_eq!(event.event_type.as_event_type(), "initialized");
+        assert_eq!(
+            event.payload,
+            serde_json::json!({
+                "protocolVersion": 1,
+                "agentCapabilities": { "loadSession": true },
+                "agentInfo": { "name": "zene" },
+                "authMethods": [],
+                "extraFlag": true
+            })
+        );
+    }
+
+    #[test]
+    fn unsupported_reverse_request_stores_method_without_jsonrpc_id() {
+        let event = runtime_notification(AcpEvent::from_reverse_request(
+            &serde_json::json!(7),
+            "fs/read_text_file",
+            &serde_json::json!({ "path": "README.md" }),
+        ));
+        assert_eq!(event.event_type.as_event_type(), "unsupported_request");
+        assert_eq!(
+            event.payload,
+            serde_json::json!({
+                "method": "fs/read_text_file",
+                "params": { "path": "README.md" }
+            })
+        );
+        let value = event.payload.to_value();
+        assert!(value.get("id").is_none());
+        assert!(value.get("jsonrpc").is_none());
     }
 
     #[test]

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `122666a`（PR #106 已合并）。**
+> **进度快照：2026-08-13，基线 `64f403d`（PR #107 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 的 Steer/SetMode 已对齐；**Wave 14 已完成**；Agent-specific actor 已迁至 `zene-agent-runtime`（协议仍在 `zene-runtime`；Cloud 不依赖二者）；Turn 与 ContextModel 共用中性 `ModelRequest`。Cloud/本地共享 `RuntimeCommand` 变体已评估为字段对齐；`GetMode` / `ResumeSafeTurn` 仍仅本地。
+> Wave 16 的 Steer/SetMode 已对齐；**Wave 14 已完成**；Agent-specific actor 已迁至 `zene-agent-runtime`（协议仍在 `zene-runtime`；Cloud 不依赖二者）；Turn 与 ContextModel 共用中性 `ModelRequest`。Cloud/本地共享 `RuntimeCommand` 变体已评估为字段对齐；`GetMode` / `ResumeSafeTurn` 仍仅本地。ACP `initialize` / unsupported reverse request 已产品化；未知 `session/update` 存 residual 产品字段。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -29,7 +29,7 @@
 
 1. `TurnEngine` 已统一主 Agent 和 Subagent 的循环，ports 也已抽出；Wave 13 起默认路径必须真正把 `prepare_context` 的 `PreparedContext` 交给 `run_model`，而不是在 model 步骤里重新组装上下文。
 2. `Provider` / `ChatClient` 仍是 provider 面；Turn/runtime 与 Context compaction/memory 经中性 `ModelRequest` / `ModelResponse`，`ChatClientExecutor` 与 `ContextModel` 对 `ChatClient` 的适配内部映射为 `ChatRequest`。
-3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。Cloud `RuntimeCommand` 已与本地共享变体字段对齐（Prompt/Steer/Cancel/Approval/SetMode/Shutdown），仍不依赖 `zene-runtime`；`GetMode` / `ResumeSafeTurn` 仍仅本地。已分类 Cloud payload 已是产品字段；未识别帧仍为 ACP JSON。
+3. ACP、Cloud event 和 Core `AgentEvent` 仍存在语义转换。Cloud `RuntimeCommand` 已与本地共享变体字段对齐（Prompt/Steer/Cancel/Approval/SetMode/Shutdown），仍不依赖 `zene-runtime`；`GetMode` / `ResumeSafeTurn` 仍仅本地。已分类 Cloud payload 已是产品字段（含 `initialized` / `unsupported_request`；未知 `session/update` 为 residual）。历史 `acp` 行与提取失败仍可能保留原始 JSON。
 4. Session 可以恢复历史并在安全 model-boundary 上自动恢复未完成 execution；pending tool、approval 和 failure 仍必须 inspection/manual intervention。
 5. `RuntimeHandle` 已成为 active turn、prompt queue、cancel 的控制所有者；Agent-specific actor 在 `zene-agent-runtime`，ACP 仍保留 transport 层 session bookkeeping。
 6. 权限已拆成纯 `evaluate` + 异步 `ApprovalBroker`。ACP 监听 `ApprovalRequested` 再发 `RuntimeCommand::Approval`。Cloud JobRunner 经 `RuntimeClient::send(RuntimeCommand::Approval)` 回复；ACP jsonrpc id 与 option 列表只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision`，并带 `ApprovalKind` / `ApprovalRisk`。已分类 Cloud payload 与审批表 payload 已是产品字段；未识别帧仍为 ACP JSON。API→worker `WorkerCommand.kind` 是 `Prompt` / `Cancel` 枚举。
@@ -953,7 +953,7 @@ Wave 0–12 的价值是把 **所有权和语义** 分开：Runtime 控制面、
 3. **模型抽象**：Turn 与 ContextModel 经 `PreparedContext` → `ModelRequest`；provider / `ChatClient` 仍用 `ChatRequest`。
 4. **审批 waiter 已打通（Wave 15）**：`PermissionGate::evaluate` 只做 allow/deny/ask；`Ask` 交给 `ApprovalBroker`。Runtime actor 持有 oneshot waiter，`RuntimeCommand::Approval` 唤醒 in-flight tool。ACP 只做事件适配。
 5. **Cloud 审批 command 已中性化（Wave 16）**：JobRunner 用 `send(RuntimeCommand::Approval { request_id, decision })` 回复审批。ACP jsonrpc id 与 `optionId` 只留在 adapter。Cloud 产品审批类型不再携带 `jsonrpc_id`。API→worker `WorkerCommand.kind` 是 Prompt/Cancel 枚举。存库/API/Console/RuntimeCommand 共用 domain `ApprovalDecision` / `ApprovalKind` / `ApprovalRisk`。Cloud 与本地共享 command 变体已字段对齐，仍不引入 `zene-runtime`；`GetMode` / `ResumeSafeTurn` 仍仅本地。
-6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段。平台事件 payload 是 domain `PlatformEvent`。写入路径 `event_type` 是 `RunEventKind`。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection 等不进时间线。未识别帧仍为 `acp`。
+6. **Cloud 事件产品面已接到 Console（Wave 16）**：domain `CloudEventKind` 是 RuntimeClient 分类结果；已分类 payload 存产品字段（含 `initialized` / `unsupported_request`；未知 update 为 residual）。平台事件 payload 是 domain `PlatformEvent`。写入路径 `event_type` 是 `RunEventKind`。Console 时间线按 `event_type` 渲染 `text_delta` / `thought_delta` / `user_message` / `tool_call` / `tool_result`（含 legacy `params.update` 回放）。plan/usage/projection/initialized 等不进时间线。历史与提取失败仍可能为 `acp` JSON。
 7. **JobRunner 只看见 RuntimeClient 产品类型（Wave 16）**：mock 与真实 ACP 共用 event pump、command poller 与 idle hold；`RuntimeNotification.event_type` 是 `CloudEventKind`；`RuntimeNotification.payload` 是 `RuntimePayload`；`RuntimeRequest::Approval` 携带 `ApprovalKind`、`allowed_decisions` 与 `ApprovalEventPayload`。`CreateApprovalRequest.payload` 同样是 `ApprovalEventPayload`。ACP `MockMsg` / `optionId` 只留在 adapter。
 8. **Worker 内部控制已走 domain 类型（Wave 16）**：claim / heartbeat / commands query / runtime session / push / PR 使用 `WorkerClaimRequest`、`WorkerFence`、`WorkerSessionRequest`、`WorkerPushRequest`、`WorkerPullRequestRequest`。产品 runtime session 仍存在 `acp_session_id` 列。CLI ACP transport session 未动。
 9. **不要再为干净拆 crate**：在审批 waiter 和事件语义统一之前，把 actor 搬到新 crate 只会搬耦合。
@@ -1133,7 +1133,7 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 4. **仍明确未自动完成的项目**
    - pending tool / approval 的任意副作用自动 replay：继续采用 inspection/manual intervention，避免重复写操作。
    - Subagent 仍用内存消息（`SessionPersistence::Ephemeral`）；未做 durable child session。
-   - 本地与 Cloud 共享 `RuntimeCommand` 变体已字段对齐（Prompt/Steer/Cancel/Approval/SetMode/Shutdown；API→worker 仍是 Prompt/Cancel；不依赖 `zene-runtime`）。`GetMode` / `ResumeSafeTurn` 仍仅本地（Cloud `send` 为 fire-and-forget，尚无 reply-shaped 控制面）。未识别 Cloud 帧仍为 ACP JSON。本地与 Cloud 的 `RuntimeEvent` 信封不同（turn 流 vs ACP session adapter），不合并为同一类型。
+   - 本地与 Cloud 共享 `RuntimeCommand` 变体已字段对齐（Prompt/Steer/Cancel/Approval/SetMode/Shutdown；API→worker 仍是 Prompt/Cancel；不依赖 `zene-runtime`）。`GetMode` / `ResumeSafeTurn` 仍仅本地（Cloud `send` 为 fire-and-forget，尚无 reply-shaped 控制面）。ACP `initialize` → `initialized`，unsupported reverse request → `unsupported_request`；未知 `session/update` 仍为 `acp` 但存 residual 产品字段。历史行与提取失败仍可能是原始 JSON。本地与 Cloud 的 `RuntimeEvent` 信封不同（turn 流 vs ACP session adapter），不合并为同一类型。
    - Agent-specific actor 已迁入 `zene-agent-runtime`（协议仍在 `zene-runtime`；Cloud 不依赖）。`zene-core` 不再 re-export runtime protocol；ACP 从 `zene_agent_runtime` / `zene_runtime` 取类型。
    - 跨 VM outbox 的共享持久化实现；当前部署文档要求共享 POSIX volume 或后续 DB/object spool。
    - Provider / `ChatClient` 仍是 `ChatRequest` 面（Turn 与 ContextModel 已用 `ModelRequest`）。
@@ -1234,11 +1234,11 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | 未识别 Cloud 帧产品化 | command 面已评估对齐；事件信封仍分本地/Cloud 两套 |
+| 当前最大杠杆 | GetMode / reply-shaped Cloud 控制（需协议） | residual 帧已产品化；事件信封仍分本地/Cloud 两套 |
 | 结构清理 | （已完成）core protocol re-export 收缩 | protocol 由 `zene-runtime` / `zene-agent-runtime` 拥有 |
-| 可选后续 | GetMode on Cloud | 需 reply-shaped 控制通道；模式今日已由 SetMode + `current_mode_update` 覆盖 |
+| 可选后续 | turn/step/error 一等 Cloud 事件 | 需 ACP 发射与 Cloud 分类两层，勿碎片化 |
 
-推荐组合：**Cloud/本地 RuntimeCommand 对齐已评估**；core 不再 re-export protocol。下一步优先未识别 Cloud 帧的产品化，或有明确协议后再做 GetMode；不要碎片化。
+推荐组合：**residual Cloud 帧产品化已落地**。下一步等有明确协议再做 GetMode，或单独切片做 turn/step 事件；不要碎片化。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1525,3 +1525,11 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 - **评估结论**：Cloud 与本地共享 `RuntimeCommand` 变体（Prompt/Steer/Cancel/Approval/SetMode/Shutdown）字段已对齐；故意保留差异为 `GetMode` / `ResumeSafeTurn`（本地有 `RuntimeResponse`；Cloud `send` 为 fire-and-forget）以及不同的 `RuntimeEvent` 信封。Cloud 继续不依赖 `zene-runtime`。
 - **代码**：`zene-core` 移除对 `ApprovalDecision` / `ExecutionState` / `RuntimeCommand` / `RuntimeLifecycle` / `RuntimeResponse` 的 re-export，并去掉对 `zene-runtime` 的依赖；ACP 从 `zene_agent_runtime` 取 `ApprovalDecision`。
 - 不做 GetMode on Cloud。不合并 RuntimeEvent。不改 Console。不自动 replay pending tools。
+
+### 2026-08-13 — Productize residual Cloud ACP frames
+
+- ACP `initialize` → `initialized` + `InitializedPayload`（无 JSON-RPC 信封）。
+- unsupported reverse request → `unsupported_request` + `UnsupportedRequestPayload`（不存 jsonrpc `id`）。
+- 未知 `session/update` 仍为 `acp`，但写入 `AcpResidualPayload`（method / sessionUpdate / update）。
+- Console 仅扩展 kind 类型镜像；不进时间线，不改 chrome。
+- 不迁移历史 `acp` 行。不做 GetMode。不自动 replay pending tools。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

接 #107：产品化仍落成 ACP JSON 的 residual Cloud 帧。

## Changes

- ACP `initialize` → `initialized` + `InitializedPayload`（保留 protocolVersion / capabilities / agentInfo / authMethods 与额外字段）
- unsupported reverse request → `unsupported_request` + `UnsupportedRequestPayload`（不存 jsonrpc `id`）
- 未知 `session/update` 仍为 `acp`，但写入 `AcpResidualPayload`（method / sessionUpdate / update）
- Console 仅扩展 kind / 类型镜像；**不进时间线**，不改 chrome
- 更新 `docs/agent-runtime-optimization.md`

## Non-goals

- 不迁移历史 `acp` 行
- 不做 GetMode / ResumeSafeTurn on Cloud
- 不合并本地/Cloud `RuntimeEvent` 信封
- 不自动 replay pending tools

## Test

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-runtime-client --locked`
`cd cloud && cargo check -p zene-cloud-worker -p zene-cloud-api --locked`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

