### PR TITLE
feat: Cloud session_started 补齐 modes/recovery

### DIFF
--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -161,6 +161,20 @@ export interface ToolResultPayload {
 export interface SessionStartedPayload {
   sessionId?: string;
   resumed?: boolean;
+  currentModeId?: string;
+  availableModes?: unknown;
+  /** Inspect-only; never used to auto-resume or replay pending tools. */
+  recovery?: SessionRecoveryPayload;
+}
+
+export interface SessionRecoveryPayload {
+  disposition?: string;
+  hasIncompleteExecution?: boolean;
+  activeTurnCount?: number;
+  activeToolCount?: number;
+  safeResumeAllowed?: boolean;
+  automaticResume?: boolean;
+  reason?: string;
 }
 
 export interface InitializedPayload {

--- a/cloud/crates/acp-bridge/src/lib.rs
+++ b/cloud/crates/acp-bridge/src/lib.rs
@@ -244,33 +244,32 @@ impl AcpBridge {
         .await
     }
 
-    pub async fn session_new(&self, cwd: &Path) -> Result<String> {
-        let session = self
-            .request(
-                "session/new",
-                json!({
-                    "cwd": cwd.display().to_string(),
-                    "mcpServers": []
-                }),
-            )
-            .await?;
-        session
-            .get("sessionId")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .context("sessionId missing")
+    pub async fn session_new(&self, cwd: &Path) -> Result<Value> {
+        self.request(
+            "session/new",
+            json!({
+                "cwd": cwd.display().to_string(),
+                "mcpServers": []
+            }),
+        )
+        .await
     }
 
     pub async fn initialize_and_new_session(&self, cwd: &Path) -> Result<(String, Vec<AcpEvent>)> {
         let mut events = self.initialize_events().await?;
-        let session_id = self.session_new(cwd).await?;
+        let result = self.session_new(cwd).await?;
+        let session_id = result
+            .get("sessionId")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .context("sessionId missing")?;
         events.push(AcpEvent {
             source_event_id: format!("session-new-{session_id}"),
             cursor: None,
             event_type: "acp".into(),
             payload: json!({
                 "method": "session/new",
-                "result": { "sessionId": session_id }
+                "result": result
             }),
         });
         Ok((session_id, events))
@@ -282,22 +281,19 @@ impl AcpBridge {
         session_id: &str,
     ) -> Result<(String, Vec<AcpEvent>)> {
         let mut events = self.initialize_events().await?;
-        self.request(
-            "session/resume",
-            json!({
-                "sessionId": session_id,
-                "cwd": cwd.display().to_string(),
-            }),
-        )
-        .await?;
+        let params = json!({
+            "sessionId": session_id,
+            "cwd": cwd.display().to_string(),
+        });
+        let result = self.request("session/resume", params.clone()).await?;
         events.push(AcpEvent {
             source_event_id: format!("session-resume-{session_id}"),
             cursor: None,
             event_type: "acp".into(),
             payload: json!({
                 "method": "session/resume",
-                "params": { "sessionId": session_id, "cwd": cwd.display().to_string() },
-                "result": { "sessionId": session_id }
+                "params": params,
+                "result": result
             }),
         });
         Ok((session_id.to_string(), events))

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -440,6 +440,34 @@ pub struct SessionStartedPayload {
     pub session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resumed: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_mode_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub available_modes: Option<serde_json::Value>,
+    /// Inspect-only recovery snapshot from ACP `_meta.recovery`.
+    /// Never used to auto-resume or auto-replay pending tools.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recovery: Option<SessionRecoveryPayload>,
+}
+
+/// Product recovery fields lifted from ACP session new/load/resume `_meta`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRecoveryPayload {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disposition: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub has_incomplete_execution: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_turn_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_tool_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub safe_resume_allowed: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub automatic_resume: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 /// Product payload for ACP `initialize` results.

--- a/cloud/crates/runtime-client/src/lib.rs
+++ b/cloud/crates/runtime-client/src/lib.rs
@@ -15,9 +15,9 @@ use zene_cloud_acp_bridge::{
 pub use zene_cloud_domain::{
     AcpResidualPayload, ApprovalDecision, ApprovalEventPayload, ApprovalKind,
     AvailableCommandsPayload, CloudEventKind, ErrorPayload, InitializedPayload, PlanPayload,
-    ProjectionPayload, SessionStartedPayload, StateChangedPayload, StepStartedPayload,
-    TextEventPayload, ToolCallPayload, ToolResultPayload, TurnEndedPayload, TurnStartedPayload,
-    UnsupportedRequestPayload, UsagePayload,
+    ProjectionPayload, SessionRecoveryPayload, SessionStartedPayload, StateChangedPayload,
+    StepStartedPayload, TextEventPayload, ToolCallPayload, ToolResultPayload, TurnEndedPayload,
+    TurnStartedPayload, UnsupportedRequestPayload, UsagePayload,
 };
 
 /// ACP `optionId` mapping stays inside this adapter.
@@ -337,21 +337,59 @@ fn approval_product(raw: &Value) -> RuntimePayload {
 }
 
 fn session_started_product(raw: &Value) -> RuntimePayload {
-    let session_id = raw
-        .pointer("/result/sessionId")
+    let result = raw.get("result").unwrap_or(&Value::Null);
+    let session_id = result
+        .get("sessionId")
         .or_else(|| raw.pointer("/params/sessionId"))
         .and_then(Value::as_str)
         .map(str::to_string);
     let resumed = (raw.get("method").and_then(Value::as_str) == Some("session/resume"))
         .then_some(true);
+    let modes = result.get("modes");
+    let recovery = result
+        .pointer("/_meta/recovery")
+        .and_then(session_recovery_payload);
     let payload = SessionStartedPayload {
         session_id,
         resumed,
+        current_mode_id: modes
+            .and_then(|value| value.get("currentModeId"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        available_modes: modes
+            .and_then(|value| value.get("availableModes"))
+            .cloned(),
+        recovery,
     };
-    if payload.session_id.is_none() && payload.resumed.is_none() {
+    if payload.session_id.is_none()
+        && payload.resumed.is_none()
+        && payload.current_mode_id.is_none()
+        && payload.available_modes.is_none()
+        && payload.recovery.is_none()
+    {
         return RuntimePayload::Json(raw.clone());
     }
     RuntimePayload::SessionStarted(payload)
+}
+
+fn session_recovery_payload(raw: &Value) -> Option<SessionRecoveryPayload> {
+    let payload = SessionRecoveryPayload {
+        disposition: raw
+            .get("disposition")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        has_incomplete_execution: raw.get("hasIncompleteExecution").and_then(Value::as_bool),
+        active_turn_count: raw.get("activeTurnCount").and_then(Value::as_u64),
+        active_tool_count: raw.get("activeToolCount").and_then(Value::as_u64),
+        safe_resume_allowed: raw.get("safeResumeAllowed").and_then(Value::as_bool),
+        automatic_resume: raw.get("automaticResume").and_then(Value::as_bool),
+        reason: raw.get("reason").and_then(Value::as_str).map(str::to_string),
+    };
+    if payload == SessionRecoveryPayload::default() {
+        None
+    } else {
+        Some(payload)
+    }
 }
 
 fn initialized_product(raw: &Value) -> RuntimePayload {
@@ -758,6 +796,7 @@ impl MockRuntimeClient {
                 payload: RuntimePayload::SessionStarted(SessionStartedPayload {
                     session_id: Some(session_id.clone()),
                     resumed: None,
+                    ..Default::default()
                 }),
             },
         });
@@ -1324,6 +1363,60 @@ mod tests {
     }
 
     #[test]
+    fn session_started_lifts_modes_and_recovery_meta() {
+        let event = runtime_notification(AcpEvent {
+            source_event_id: "session-new-2".into(),
+            cursor: None,
+            event_type: "acp".into(),
+            payload: serde_json::json!({
+                "method": "session/new",
+                "result": {
+                    "sessionId": "session-2",
+                    "modes": {
+                        "currentModeId": "default",
+                        "availableModes": [
+                            { "id": "default", "name": "Default" },
+                            { "id": "plan", "name": "Plan" }
+                        ]
+                    },
+                    "_meta": {
+                        "recovery": {
+                            "disposition": "clean",
+                            "hasIncompleteExecution": false,
+                            "activeTurnCount": 0,
+                            "activeToolCount": 0,
+                            "safeResumeAllowed": false,
+                            "automaticResume": false,
+                            "reason": "no incomplete execution"
+                        }
+                    }
+                }
+            }),
+        });
+        assert_eq!(event.event_type.as_event_type(), "session_started");
+        assert_eq!(
+            event.payload,
+            serde_json::json!({
+                "sessionId": "session-2",
+                "currentModeId": "default",
+                "availableModes": [
+                    { "id": "default", "name": "Default" },
+                    { "id": "plan", "name": "Plan" }
+                ],
+                "recovery": {
+                    "disposition": "clean",
+                    "hasIncompleteExecution": false,
+                    "activeTurnCount": 0,
+                    "activeToolCount": 0,
+                    "safeResumeAllowed": false,
+                    "automaticResume": false,
+                    "reason": "no incomplete execution"
+                }
+            })
+        );
+    }
+
+    #[test]
     fn session_resume_marks_resumed() {
         let event = runtime_notification(AcpEvent {
             source_event_id: "session-resume-1".into(),
@@ -1332,13 +1425,41 @@ mod tests {
             payload: serde_json::json!({
                 "method": "session/resume",
                 "params": { "sessionId": "session-1", "cwd": "/tmp" },
-                "result": { "sessionId": "session-1" }
+                "result": {
+                    "sessionId": "session-1",
+                    "modes": { "currentModeId": "plan", "availableModes": [] },
+                    "_meta": {
+                        "recovery": {
+                            "disposition": "inspect",
+                            "hasIncompleteExecution": true,
+                            "activeTurnCount": 1,
+                            "activeToolCount": 1,
+                            "safeResumeAllowed": false,
+                            "automaticResume": false,
+                            "reason": "pending tool requires inspection"
+                        }
+                    }
+                }
             }),
         });
         assert_eq!(event.event_type.as_event_type(), "session_started");
         assert_eq!(
             event.payload,
-            serde_json::json!({ "sessionId": "session-1", "resumed": true })
+            serde_json::json!({
+                "sessionId": "session-1",
+                "resumed": true,
+                "currentModeId": "plan",
+                "availableModes": [],
+                "recovery": {
+                    "disposition": "inspect",
+                    "hasIncompleteExecution": true,
+                    "activeTurnCount": 1,
+                    "activeToolCount": 1,
+                    "safeResumeAllowed": false,
+                    "automaticResume": false,
+                    "reason": "pending tool requires inspection"
+                }
+            })
         );
     }
 

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -2,9 +2,9 @@
 
 > 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
 >
-> **进度快照：2026-08-13，基线 `15a41a4`（PR #108 已合并）。**
+> **进度快照：2026-08-13，基线 `e7ea2fb`（PR #109 已合并）。**
 > 本文同时记录目标架构、已实现能力和剩余工作。
-> Wave 16 的 Steer/SetMode 已对齐；**Wave 14 已完成**；Agent-specific actor 已迁至 `zene-agent-runtime`（协议仍在 `zene-runtime`；Cloud 不依赖二者）；Turn 与 ContextModel 共用中性 `ModelRequest`。Cloud/本地共享 `RuntimeCommand` 变体已评估为字段对齐；`GetMode` / `ResumeSafeTurn` 仍仅本地。ACP `initialize` / unsupported / turn/step/error 已产品化；未知 `session/update` 存 residual 产品字段。
+> Wave 16 的 Steer/SetMode 已对齐；**Wave 14 已完成**；Agent-specific actor 已迁至 `zene-agent-runtime`（协议仍在 `zene-runtime`；Cloud 不依赖二者）；Turn 与 ContextModel 共用中性 `ModelRequest`。Cloud/本地共享 `RuntimeCommand` 变体已评估为字段对齐；`GetMode` / `ResumeSafeTurn` 仍仅本地。ACP `initialize` / unsupported / turn/step/error 已产品化；`session_started` 携带 modes + recovery（inspect-only）；未知 `session/update` 存 residual 产品字段。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -1234,11 +1234,11 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 
 | 选择 | Wave | 理由 |
 | --- | --- | --- |
-| 当前最大杠杆 | GetMode / reply-shaped Cloud 控制（需协议） | turn/step/error 已产品化；事件信封仍分本地/Cloud 两套 |
+| 当前最大杠杆 | GetMode / reply-shaped Cloud 控制（需协议） | session_started 已带 modes/recovery；事件信封仍分本地/Cloud 两套 |
 | 结构清理 | （已完成）core protocol re-export 收缩 | protocol 由 `zene-runtime` / `zene-agent-runtime` 拥有 |
 | 可选后续 | Agent holdings 继续退回 wiring | Wave 14 step 算法已抽出；剩余 composition-root 持有 |
 
-推荐组合：**turn/step/error Cloud 事件已落地**。控制/事件产品化主线基本收口；下一步等有明确协议再做 GetMode，或做低杠杆结构清理；不要碎片化。
+推荐组合：**控制/事件产品化主线已收口**（含 session_started modes/recovery）。下一步等有明确协议再做 GetMode；低杠杆结构清理可择机做；不要碎片化。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1540,3 +1540,10 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 - Cloud 分类为对应产品 kind + payload（`turnId` / `step` / `steps` / `message`）。
 - Console 仅扩展 kind 类型镜像；不进时间线，不改 chrome。
 - 不做 GetMode。不迁移历史假 `[error]` text_delta 行。不自动 replay pending tools。
+
+### 2026-08-13 — Enrich Cloud session_started with modes/recovery
+
+- ACP bridge 透传 `session/new` / `session/resume` 完整 result（不再只伪造 `sessionId`）。
+- `SessionStartedPayload` 增加 `currentModeId` / `availableModes` / `recovery`（inspect-only；不触发 auto-resume / pending-tool replay）。
+- Console 仅扩展类型镜像；不改 chrome。
+- 不做 GetMode。不自动 replay pending tools。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

接 #109：补全 Cloud `session_started` 产品字段。ACP 本就返回 `modes` 与 `_meta.recovery`，但 bridge 之前只伪造 `{ sessionId }` 丢掉了它们。

## Changes

- ACP bridge 透传 `session/new` / `session/resume` 完整 result
- `SessionStartedPayload` 增加 `currentModeId` / `availableModes` / `recovery`
- `recovery` 为 **inspect-only**，不触发 auto-resume / pending-tool replay
- Console 仅扩展类型镜像；不改 chrome
- 更新 `docs/agent-runtime-optimization.md`

## Non-goals

- 不做 GetMode / reply-shaped Cloud 控制
- 不自动 resume / 不自动 replay pending tools
- 不改 Console 时间线或布局

## Test

`cd cloud && cargo test -p zene-cloud-domain -p zene-cloud-runtime-client -p zene-cloud-acp-bridge --locked`
`cd cloud && cargo check -p zene-cloud-worker -p zene-cloud-api --locked`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

