### PR TITLE
docs: close runtime control-plane line and record next goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ cd cloud && ./scripts/dev.sh
 
 See [`cloud/README.md`](cloud/README.md) for env vars and demo path. Production: [https://zene.run](https://zene.run) — deploy notes in [`cloud/deploy/README.md`](cloud/deploy/README.md).
 
+Control-plane / event productization line is closed; wrap-up and optional next goals: [`docs/agent-runtime-next-goals.md`](docs/agent-runtime-next-goals.md).
+
 ## Install `zene` (ACP binary)
 
 Needed for Cloud workers / editors. From the repo:

--- a/docs/ENGINE.md
+++ b/docs/ENGINE.md
@@ -1,6 +1,6 @@
 # Zene Engine Notes
 
-Core agent loop lives in `crates/core`. This document tracks engine-level behaviors (turn flow, context, permissions) beyond the milestone checklist in [ROADMAP.md](./ROADMAP.md). For the Session-vs-Context architecture model, see [session-as-source-of-truth.md](./session-as-source-of-truth.md). For Context Engine (projection, prefix cache, epoch/delta, **index vs Select**), see [context-engine.md](./context-engine.md). For AgentRuntime / Turn / ports and merged implementation waves, see [agent-runtime-optimization.md](./agent-runtime-optimization.md). For Pi agent-harness comparisons, see [pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md).
+Core agent loop lives in `crates/core`. This document tracks engine-level behaviors (turn flow, context, permissions) beyond the milestone checklist in [ROADMAP.md](./ROADMAP.md). For the Session-vs-Context architecture model, see [session-as-source-of-truth.md](./session-as-source-of-truth.md). For Context Engine (projection, prefix cache, epoch/delta, **index vs Select**), see [context-engine.md](./context-engine.md). For AgentRuntime / Turn / ports and merged implementation waves, see [agent-runtime-optimization.md](./agent-runtime-optimization.md) (control-plane line closed). Wrap-up and optional next goals: [agent-runtime-next-goals.md](./agent-runtime-next-goals.md). For Pi agent-harness comparisons, see [pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md).
 
 ## Turn flow & steer
 

--- a/docs/agent-components.md
+++ b/docs/agent-components.md
@@ -2,7 +2,7 @@
 
 目标：把 Zene 拆成**可独立发布、按需组合**的 crate，第三方 runtime 不必 fork `zene-core` 也能复用 compaction、tools、sandbox 等能力。
 
-相关文档：[context-engine.md](./context-engine.md)、[agent-inference-context.md](./agent-inference-context.md)、[session-as-source-of-truth.md](./session-as-source-of-truth.md)（Session 事实 vs Context 投影）、[agent-runtime-optimization.md](./agent-runtime-optimization.md)（Runtime / Turn / ports）、[pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md)（Pi Harness 启发）。索引 / Repo Map 走工具侧，契约见 [context-engine.md §5](./context-engine.md#5-代码索引与-select)，不进 `zene-context`。
+相关文档：[context-engine.md](./context-engine.md)、[agent-inference-context.md](./agent-inference-context.md)、[session-as-source-of-truth.md](./session-as-source-of-truth.md)（Session 事实 vs Context 投影）、[agent-runtime-optimization.md](./agent-runtime-optimization.md)（Runtime / Turn / ports，**本线已收口**）、[agent-runtime-next-goals.md](./agent-runtime-next-goals.md)（结项与后续可选目标）、[pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md)（Pi Harness 启发）。索引 / Repo Map 走工具侧，契约见 [context-engine.md §5](./context-engine.md#5-代码索引与-select)，不进 `zene-context`。
 
 ---
 

--- a/docs/agent-runtime-next-goals.md
+++ b/docs/agent-runtime-next-goals.md
@@ -1,0 +1,117 @@
+# Agent Runtime — 本线收尾与后续目标
+
+> 状态：**控制面 / 事件产品化主线已收口**（截至 PR #113，基线 `8c56fd2`）。
+>
+> 本文记录结项结论、刻意不做的边界，以及下一批**可选**产品目标。
+> 详细设计与 Wave 历程仍以 [agent-runtime-optimization.md](./agent-runtime-optimization.md) 为准。
+
+## 1. 本线结项（已完成）
+
+本线主攻 **控制面**（谁在跑、怎么被控制、状态归谁）与 **Cloud 事件产品化**，不是 Console chrome 重做。
+
+已落地（摘要）：
+
+- Turn 默认路径走 ports；主 Agent / Subagent 共用 `TurnEngine` 语义。
+- Wave 14：`RuntimeScope`（ToolPolicy / SessionPolicy）+ Agent facade（prepare / model / tool_batch / turn_session）。
+- Actor 迁入 `zene-agent-runtime`；协议在 `zene-runtime`；**Cloud 不依赖二者**。
+- `ModelExecutor` / `ContextModel` 共用中性 `ModelRequest` / `ModelResponse`；provider 仍用 `ChatRequest`。
+- Cloud `RuntimeCommand` 与本地共享变体字段对齐（Prompt/Steer/Cancel/Approval/SetMode/Shutdown）。
+- Cloud 事件：timeline 类产品字段 + `initialized` / `unsupported_request` / turn·step·error；未知 update 为 residual。
+- `session_started` 携带 modes + recovery（inspect-only；mock 同形）。
+- **Cloud session mode（`default` / `plan`）以推送为真相源**（`session_started` + `current_mode_update`→`state_changed`）；**明确不做 Cloud GetMode**。
+- `zene-core` 不再 re-export runtime protocol / turn `RuntimeEvent` 类型。
+
+本线 **停线**。勿再为 GetMode / reply-shaped 读 mode 开碎片 PR。
+
+## 2. 刻意保持的非目标
+
+下列项 **不是遗漏**，本线明确不做或继续维持边界：
+
+| 项 | 态度 |
+| --- | --- |
+| pending tool / approval 自动 replay | 继续 inspection / 人工介入，避免重复副作用 |
+| Cloud `GetMode` / `session/get_mode` | 已否决；mode 用推送 SoT |
+| Cloud 依赖 `zene-runtime` / `zene-agent-runtime` | 禁止 |
+| 合并本地与 Cloud `RuntimeEvent` 信封 | 不做强行统一 |
+| 完整 Event Sourcing / 历史 `acp` 行迁移 | 不做 |
+| Console chrome / 时间线视觉大改 | 不做（本线事件多数不进时间线） |
+
+## 3. 后续新目标（可选，另开产品线）
+
+下列目标需要 **单独产品决策与排期**，不要当作本线未完成勾选：
+
+### 3.1 Durable Subagent session
+
+- 现状：Subagent 使用 `SessionPersistence::Ephemeral`（内存消息）。
+- 目标：子 Agent 可落盘 / 恢复，与主 session lineage 可解释关联。
+- 依赖：持久化模型、fork/rewind 边界、是否进 Cloud Run 投影。
+
+### 3.2 跨 VM EventOutbox
+
+- 现状：本地 durable outbox；跨 VM 需共享 POSIX 卷或 DB/object spool（见 Cloud deploy 文档）。
+- 目标：replacement worker 跨机器仍可可靠投递 / ACK。
+- 依赖：部署拓扑选型（共享盘 vs DB spool），不是再改一层 adapter 能替代的。
+
+### 3.3 Cloud `ResumeSafeTurn`（若需要）
+
+- 现状：仅本地；Cloud 已有 session resume + inspect-only recovery 元数据。
+- 目标：仅当产品要求 **安全 model-boundary 自动续跑** 且有明确调用方时再做。
+- 约束：仍禁止 pending tool 自动 replay；与 reply-shaped 控制面设计绑定。
+
+### 3.4 Agent composition-root 继续退回 wiring
+
+- 现状：step 算法已抽出；`Agent` 仍持有 model/tools/sandbox/permission/hooks/MCP 等。
+- 目标：进一步模块化 holdings，降低 God-object 感。
+- 杠杆：结构清理，低于有调用方的产品能力。
+
+### 3.5 Provider 面 `ChatRequest`（可选长期）
+
+- 现状：Turn / ContextModel 已中性；`ChatClient` / provider 仍 `ChatRequest`。
+- 目标：仅当要替换 provider 栈或共享跨语言边界时再推。
+- 态度：保持 provider 边界即可，不必为对称而改。
+
+### 3.6 新的 Cloud 控制能力（非读 mode）
+
+- 仅当出现 **真实调用方**（JobRunner / API / Console）时，再设计 reply-shaped 或新命令。
+- 读 mode 已关闭；其他读/写控制另立 RFC，勿挂在本线 changelog 下碎片推进。
+
+## 4. 如何本地体验（验证本线结果）
+
+产品可跑；本线改动多为边界与事件形态，Console 外观不会大变。
+
+### 4.1 一键起 Cloud Console
+
+```bash
+cd cloud && ./scripts/dev.sh
+# 浏览器打开 http://127.0.0.1:8788/
+```
+
+推荐路径：注册 → **Settings** 配置 LLM（BYOK）→ Connect GitHub → **New Agent** → 发消息跑一轮。
+
+可选：先 `./scripts/install.sh`（或让 `dev.sh` 自行构建）确保有仓库根 `zene` ACP 二进制。
+
+### 4.2 UI 热更新（可选）
+
+```bash
+cd cloud && ZENE_CLOUD_SKIP_WEB_BUILD=1 ./scripts/dev.sh
+# 另开终端：
+cd cloud/apps/web && npm run dev
+# 打开 http://127.0.0.1:8787/（/api/* 代理到 8788）
+```
+
+### 4.3 建议观察点
+
+- 正常对话、工具审批、取消、follow-up（忙时 Steer / 闲时 Prompt）。
+- 切换 session mode（`default` / `plan`）：应走推送（`session_started` / `state_changed`），无 GetMode 拉取。
+- 事件时间线仍以 text / thought / user / tool 为主；turn/step/error、initialized、projection 等为产品字段但不进时间线 chrome。
+
+细则见 [cloud/README.md](../cloud/README.md) 与根 [README.md](../README.md)。
+
+## 相关文档
+
+- [agent-runtime-optimization.md](./agent-runtime-optimization.md) — 目标架构与 Wave 全记录
+- [session-as-source-of-truth.md](./session-as-source-of-truth.md) — 数据面 Session SoT
+- [context-engine.md](./context-engine.md) — Context 投影
+- [agent-components.md](./agent-components.md) — 可组装 crate 栈
+- [ENGINE.md](./ENGINE.md) — turn / compaction 行为
+- [ROADMAP.md](./ROADMAP.md) — 历史 CLI 里程碑清单

--- a/docs/agent-runtime-optimization.md
+++ b/docs/agent-runtime-optimization.md
@@ -1,12 +1,12 @@
 # Agent Runtime 架构优化设计
 
-> 状态：持续演进。Wave 0–12 把控制面/数据面的 **接口边界** 建起来了；Wave 13 起让默认执行路径真正走这些边界。
+> 状态：**控制面 / 事件产品化主线已收口**（结项说明与后续目标见 [agent-runtime-next-goals.md](./agent-runtime-next-goals.md)）。
 >
-> **进度快照：2026-08-14，基线 `4a3443d`（PR #112 已合并）。**
-> 本文同时记录目标架构、已实现能力和剩余工作。
+> **进度快照：2026-08-14，基线 `8c56fd2`（PR #113 已合并）。**
+> 本文同时记录目标架构、已实现能力和本线历程。
 > Wave 16 的 Steer/SetMode 已对齐；**Wave 14 已完成**；Agent-specific actor 已迁至 `zene-agent-runtime`（协议仍在 `zene-runtime`；Cloud 不依赖二者）；Turn 与 ContextModel 共用中性 `ModelRequest`。Cloud/本地共享 `RuntimeCommand` 变体已评估为字段对齐。**Cloud session mode（`default`/`plan`）以推送为准**：`session_started` + `current_mode_update`→`state_changed`；**不做 Cloud GetMode**。`ResumeSafeTurn` 仍仅本地。ACP `initialize` / unsupported / turn/step/error 已产品化；`session_started` 携带 modes + recovery（inspect-only；mock 路径同形）；未知 `session/update` 存 residual 产品字段。`zene-core` 不再 re-export turn/runtime protocol 类型。
 >
-> **停线点：** 非协议控制/事件产品化与 ownership 收缩已收口。Cloud mode 真相源已定为事件推送，GetMode 不再是本线下一步。后续高杠杆项（若有）需新的产品目标，不要为 GetMode 碎片化。
+> **停线点：** 本线已结项。后续可选目标见 [agent-runtime-next-goals.md](./agent-runtime-next-goals.md)；不要为 GetMode 碎片化。
 >
 > 本文基于当前 zene runtime 实现，描述如何将 `Agent`、`Turn`、`Step`、`Session`、Cloud `Run` 和 ACP transport 拉开，并给出渐进式迁移方案。
 >
@@ -1240,7 +1240,7 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 | 结构清理 | （已完成）core protocol / turn event re-export 收缩 | protocol 在 `zene-runtime`/`zene-agent-runtime`；事件在 `zene-turn` |
 | 可选后续 | Agent holdings 继续退回 wiring | Wave 14 step 算法已抽出；剩余 composition-root 持有 |
 
-推荐组合：**控制/事件产品化主线已收口**。Cloud session mode 以事件推送为真相源；本地保留 GetMode，Cloud 不引入。后续勿为 GetMode / reply-shaped 控制碎片化，除非出现新的产品调用方需求（且不是读 mode）。
+推荐组合：**控制/事件产品化主线已收口**（结项与后续目标：[agent-runtime-next-goals.md](./agent-runtime-next-goals.md)）。Cloud session mode 以事件推送为真相源；本地保留 GetMode，Cloud 不引入。
 
 **不要一上来做** actor 全量重写、完整 Event Sourcing、或再抽一层没有调用方的 crate。
 
@@ -1264,6 +1264,7 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 
 ## 相关文档
 
+- [agent-runtime-next-goals.md](./agent-runtime-next-goals.md) — **本线结项与后续可选目标**
 - [session-as-source-of-truth.md](./session-as-source-of-truth.md) — Session 事实 vs Context 投影
 - [context-engine.md](./context-engine.md) — ContextEngine（投影、prefix cache、epoch/delta、索引 Select）
 - [pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md) — Pi Harness 对照
@@ -1569,3 +1570,8 @@ Wave 16  统一 transport command/event  ← 已完成（含 Steer/SetMode）
 - **明确不做**：Cloud `GetMode`、ACP `session/get_mode`、为读 mode 引入 reply-shaped `RuntimeClient` API。本地 `GetMode` 仍供 ACP session new/load/resume 填 `modes` 使用。
 - JobRunner 继续用 `pending_mode_id` + idle `SetMode` + 本地 `turn_busy`；不依赖拉取校验。
 - 不改 Console。不自动 replay pending tools。
+
+### 2026-08-14 — Runtime optimization line wrap-up
+
+- 新增 [agent-runtime-next-goals.md](./agent-runtime-next-goals.md)：本线结项、刻意非目标、后续可选产品线（durable subagent、跨 VM outbox、ResumeSafeTurn、Agent wiring 等）。
+- 本文标记控制面/事件产品化主线 **已收口**；体验路径见 next-goals §4。

--- a/docs/session-as-source-of-truth.md
+++ b/docs/session-as-source-of-truth.md
@@ -5,7 +5,7 @@
 > 两者相关，但不是同一件事；也绝不能反过来让 Context 变成事实来源。
 
 本文是架构心智模型，不是实现清单。对照实现见 [ENGINE.md](./ENGINE.md)、[context-engine.md](./context-engine.md)、[agent-inference-context.md](./agent-inference-context.md)、[agent-components.md](./agent-components.md)。  
-控制面（谁在跑、命令与状态归谁）见 [agent-runtime-optimization.md](./agent-runtime-optimization.md)；Context 投影落地见 [context-engine.md](./context-engine.md)。  
+控制面（谁在跑、命令与状态归谁）见 [agent-runtime-optimization.md](./agent-runtime-optimization.md)（已收口）；结项与后续目标见 [agent-runtime-next-goals.md](./agent-runtime-next-goals.md)。Context 投影落地见 [context-engine.md](./context-engine.md)。  
 灵感来源：Pi Session Tree（JSONL event tree + `buildSessionContext` 投影）；Zene 不必照搬其格式。更完整的 Pi→Zene 对照见 [pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md)。
 
 ---
@@ -369,7 +369,8 @@ Wave 12    Safe resume 与 Cloud RuntimeClient                 已完成 reconne
 
 - [ENGINE.md](./ENGINE.md) — turn / steer / compaction 行为
 - [context-engine.md](./context-engine.md) — ContextEngine 边界、投影、prefix cache、索引 Select
-- [agent-runtime-optimization.md](./agent-runtime-optimization.md) — AgentRuntime / Turn / ports（控制面）
+- [agent-runtime-optimization.md](./agent-runtime-optimization.md) — AgentRuntime / Turn / ports（控制面，已收口）
+- [agent-runtime-next-goals.md](./agent-runtime-next-goals.md) — 本线结项与后续可选目标
 - [agent-inference-context.md](./agent-inference-context.md) — 推理上下文装配
 - [agent-components.md](./agent-components.md) — 可组装组件栈
 - [pi-agent-harness-lessons.md](./pi-agent-harness-lessons.md) — Pi Agent Harness 对照与启发总览


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

控制面 / 事件产品化主线文档收尾：标记 `agent-runtime-optimization` 已收口，新增结项与后续可选目标文档，并交叉更新相关 docs / README。

## Changes

- Add `docs/agent-runtime-next-goals.md`（结项结论、刻意非目标、后续可选产品线、本地体验步骤）
- Mark `docs/agent-runtime-optimization.md` 本线已收口并链到 next-goals
- Cross-link `agent-components` / `session-as-source-of-truth` / `ENGINE.md` / root `README.md`

## Experience

见 `docs/agent-runtime-next-goals.md` §4：`cd cloud && ./scripts/dev.sh` → http://127.0.0.1:8788/
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea05728-0337-437a-ab35-88705f3c65cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea05728-0337-437a-ab35-88705f3c65cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

