### PR TITLE
feat(cloud): landing intro and email magic-link sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Zene is a coding-agent product. The product UI is **Cloud Console** (`cloud/`); 
 ```bash
 cd cloud && ./scripts/dev.sh
 # open http://127.0.0.1:8788/
-# Register → Settings (LLM BYOK) → Connect GitHub → New Agent
+# Email sign-in → Settings (LLM BYOK) → Connect GitHub → New Agent
 ```
 
 `dev.sh` builds or locates the repo-root `zene` binary and starts the API + worker with real ACP.

--- a/cloud/.gitignore
+++ b/cloud/.gitignore
@@ -5,4 +5,5 @@
 .DS_Store
 .env
 github.env
+email.env
 node_modules/

--- a/cloud/Cargo.lock
+++ b/cloud/Cargo.lock
@@ -2948,6 +2948,7 @@ dependencies = [
  "chrono",
  "clap",
  "futures",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",

--- a/cloud/README.md
+++ b/cloud/README.md
@@ -4,7 +4,7 @@
 
 ## 当前能力（可本地完整演示）
 
-- 用户注册 / 登录与组织
+- 邮箱登录链接（Resend）与组织
 - GitHub 集成（默认 **live**；凭证可在 Settings 页面配置，也可用 env 覆盖）
 - Repository 同步 / 选择
 - Run 生命周期：创建、消息、取消、事件
@@ -45,7 +45,7 @@ cd cloud/apps/web && npm run dev
 
 推荐演示路径：
 
-1. 注册账号
+1. 用工作邮箱接收登录链接并进入 Console
 2. **Settings** 配置 LLM（API key + base URL，如 DeepSeek / Custom）
 3. Connect GitHub
 4. New Agent 选择仓库，输入任务并 Start
@@ -66,6 +66,8 @@ cd cloud/apps/web && npm run dev
 | `ZENE_CLOUD_WORKER_MAX_HOLD` | `8` | 同时 waiting_for_user/approval 暖持上限 |
 | `ZENE_CLOUD_WORKER_SCALE_INTERVAL_MS` | `1000` | supervisor 调谐周期 |
 | `ZENE_CLOUD_PUSH_PR` | `1` | 完成后自动 push + draft PR |
+| `RESEND_API_KEY` | — | 邮箱登录邮件（[Resend](https://resend.com)） |
+| `RESEND_FROM` | `Zene <noreply@zene.run>` | 发件人，需在 Resend 验证域名 |
 | `GITHUB_CLIENT_ID/SECRET` | — | live OAuth |
 | `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY_PATH` | — | live App |
 | 用户 Settings LLM / `ZENE_API_KEY` | — | 真实 ACP 需要 LLM（优先 per-user BYOK） |

--- a/cloud/apps/api/Cargo.toml
+++ b/cloud/apps/api/Cargo.toml
@@ -14,6 +14,7 @@ axum.workspace = true
 chrono.workspace = true
 clap.workspace = true
 futures.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/cloud/apps/api/src/email.rs
+++ b/cloud/apps/api/src/email.rs
@@ -1,0 +1,94 @@
+use anyhow::{bail, Context, Result};
+use serde::Serialize;
+
+#[derive(Debug, Clone)]
+pub struct EmailConfig {
+    pub api_key: Option<String>,
+    pub from: String,
+}
+
+impl EmailConfig {
+    pub fn from_env() -> Self {
+        Self {
+            api_key: std::env::var("RESEND_API_KEY")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty()),
+            from: std::env::var("RESEND_FROM")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "Zene <noreply@zene.run>".into()),
+        }
+    }
+
+    pub fn configured(&self) -> bool {
+        self.api_key.is_some()
+    }
+}
+
+#[derive(Serialize)]
+struct ResendEmail<'a> {
+    from: &'a str,
+    to: Vec<&'a str>,
+    subject: &'a str,
+    html: &'a str,
+    text: &'a str,
+}
+
+pub async fn send_signin_email(cfg: &EmailConfig, to: &str, login_url: &str) -> Result<()> {
+    let Some(api_key) = cfg.api_key.as_deref() else {
+        bail!("RESEND_API_KEY is not set");
+    };
+    let html = signin_html(login_url);
+    let text = signin_text(login_url);
+    let client = reqwest::Client::builder()
+        .user_agent("zene-cloud")
+        .build()
+        .context("resend http client")?;
+    let response = client
+        .post("https://api.resend.com/emails")
+        .bearer_auth(api_key)
+        .json(&ResendEmail {
+            from: &cfg.from,
+            to: vec![to],
+            subject: "Sign in to Zene",
+            html: &html,
+            text: &text,
+        })
+        .send()
+        .await
+        .context("send resend request")?;
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        tracing::error!(%status, %body, "resend rejected sign-in email");
+        bail!("failed to send sign-in email");
+    }
+    Ok(())
+}
+
+fn signin_text(login_url: &str) -> String {
+    format!(
+        "Sign in to Zene Cloud Console.\n\n{login_url}\n\nThis link expires in 15 minutes. Ignore this email if you did not request it.\n"
+    )
+}
+
+fn signin_html(login_url: &str) -> String {
+    let href = escape(login_url);
+    format!(
+        r#"<div style="font-family:Inter,ui-sans-serif,sans-serif;color:#2E3436;font-size:14px;line-height:1.5">
+<p>Sign in to Zene Cloud Console.</p>
+<p><a href="{href}" style="color:#3584E4">Open sign-in link</a></p>
+<p style="color:#687174;font-size:12px">This link expires in 15 minutes. Ignore this email if you did not request it.</p>
+</div>"#
+    )
+}
+
+fn escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}

--- a/cloud/apps/api/src/error.rs
+++ b/cloud/apps/api/src/error.rs
@@ -83,6 +83,12 @@ impl From<anyhow::Error> for AppError {
         if msg.contains("invalid credentials") || msg.contains("password") {
             return Self::unauthorized(msg);
         }
+        if msg.contains("invalid or expired sign-in") {
+            return Self::unauthorized(msg);
+        }
+        if msg.contains("wait a moment") || msg.contains("invalid email") {
+            return Self::bad_request(msg);
+        }
         if msg.contains("not found") {
             return Self::not_found(msg);
         }

--- a/cloud/apps/api/src/lib.rs
+++ b/cloud/apps/api/src/lib.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod email;
 mod error;
 pub mod routes;
 pub mod state;

--- a/cloud/apps/api/src/routes.rs
+++ b/cloud/apps/api/src/routes.rs
@@ -12,12 +12,13 @@ use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 use zene_cloud_domain::{
     ClaimedRun, CreateApprovalRequest, CreatePullRequestBody, CreateRepositoryRequest,
-    CreateRunRequest, DecideApprovalRequest, GithubAccountType, GithubBranchSummary,
-    GithubInstallationStatus, GithubMode, GithubProviderConfigView,
-    LlmAuthResponse, LlmSettingsView, LoginRequest, PostMessageRequest, QueueStats, RegisterRequest,
-    MessageRole, RunStatus, SetRunModeRequest, UpdateGithubProviderConfigRequest, UpdateLlmSettingsRequest, UpdateRunRequest,
-    WorkerCommandAckRequest, WorkerCommandsResponse, WorkerEventRequest, WorkerFence,
-    WorkerSessionRequest, WorkerClaimRequest, WorkerPullRequestRequest, WorkerPushRequest,
+    CreateRunRequest, DecideApprovalRequest, EmailLoginRequest, EmailLoginResponse,
+    GithubAccountType, GithubBranchSummary, GithubInstallationStatus, GithubMode,
+    GithubProviderConfigView, LlmAuthResponse, LlmSettingsView, LoginRequest, MessageRole,
+    PostMessageRequest, QueueStats, RegisterRequest, RunStatus, SetRunModeRequest,
+    UpdateGithubProviderConfigRequest, UpdateLlmSettingsRequest, UpdateRunRequest,
+    WorkerClaimRequest, WorkerCommandAckRequest, WorkerCommandsResponse, WorkerEventRequest,
+    WorkerFence, WorkerPullRequestRequest, WorkerPushRequest, WorkerSessionRequest,
     WorkerStatusRequest, WorkerTitleRequest,
 };
 
@@ -31,18 +32,32 @@ pub fn router(state: AppState) -> Router {
         .route("/api/v1/health", get(health))
         .route("/api/v1/auth/register", post(register))
         .route("/api/v1/auth/login", post(login))
+        .route("/api/v1/auth/email", post(request_email_login))
+        .route("/api/v1/auth/email/callback", get(email_login_callback))
         .route("/api/v1/me", get(me))
-        .route("/api/v1/settings/github", get(get_github_settings).put(update_github_settings))
-        .route("/api/v1/settings/llm", get(get_llm_settings).put(update_llm_settings))
+        .route(
+            "/api/v1/settings/github",
+            get(get_github_settings).put(update_github_settings),
+        )
+        .route(
+            "/api/v1/settings/llm",
+            get(get_llm_settings).put(update_llm_settings),
+        )
         .route("/api/v1/github/status", get(github_status))
         .route("/api/v1/github/connect/start", get(github_connect_start))
-        .route("/api/v1/github/install/callback", get(github_install_callback))
+        .route(
+            "/api/v1/github/install/callback",
+            get(github_install_callback),
+        )
         .route("/api/v1/github/oauth/start", get(github_oauth_start))
         .route("/api/v1/github/oauth/callback", get(github_oauth_callback))
         .route("/api/v1/github/mock/connect", post(github_mock_connect))
         .route("/api/v1/github/sync", post(github_sync))
         .route("/api/v1/github/installations", get(list_installations))
-        .route("/api/v1/github/installations/mock", post(github_mock_install))
+        .route(
+            "/api/v1/github/installations/mock",
+            post(github_mock_install),
+        )
         .route(
             "/api/v1/github/installations/{installation_id}/sync",
             post(sync_installation_repos),
@@ -89,8 +104,14 @@ pub fn router(state: AppState) -> Router {
         .route("/internal/v1/runs/claim", post(claim_run))
         .route("/internal/v1/queue/stats", get(queue_stats))
         .route("/internal/v1/runs/{run_id}/heartbeat", post(heartbeat))
-        .route("/internal/v1/runs/{run_id}/runtime-session", post(worker_runtime_session))
-        .route("/internal/v1/runs/{run_id}/acp-session", post(worker_runtime_session))
+        .route(
+            "/internal/v1/runs/{run_id}/runtime-session",
+            post(worker_runtime_session),
+        )
+        .route(
+            "/internal/v1/runs/{run_id}/acp-session",
+            post(worker_runtime_session),
+        )
         .route("/internal/v1/runs/{run_id}/events", post(worker_event))
         .route("/internal/v1/runs/{run_id}/status", post(worker_status))
         .route("/internal/v1/runs/{run_id}/title", post(worker_title))
@@ -100,9 +121,18 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/internal/v1/runs/{run_id}/llm-auth", get(llm_auth))
         .route("/internal/v1/runs/{run_id}/commands", get(worker_commands))
-        .route("/internal/v1/runs/{run_id}/commands/ack", post(worker_command_ack))
-        .route("/internal/v1/runs/{run_id}/mode", post(worker_set_pending_mode))
-        .route("/internal/v1/runs/{run_id}/mode/take", post(worker_take_pending_mode))
+        .route(
+            "/internal/v1/runs/{run_id}/commands/ack",
+            post(worker_command_ack),
+        )
+        .route(
+            "/internal/v1/runs/{run_id}/mode",
+            post(worker_set_pending_mode),
+        )
+        .route(
+            "/internal/v1/runs/{run_id}/mode/take",
+            post(worker_take_pending_mode),
+        )
         .route(
             "/internal/v1/runs/{run_id}/approvals",
             post(create_approval),
@@ -143,12 +173,67 @@ async fn login(
     Ok(Json(state.db.login(req).await?))
 }
 
+async fn request_email_login(
+    State(state): State<AppState>,
+    Json(req): Json<EmailLoginRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let token = state.db.create_email_login_token(&req.email).await?;
+    let login_url = format!(
+        "{}/api/v1/auth/email/callback?token={token}",
+        state.public_base_url.trim_end_matches('/')
+    );
+    let cfg = crate::email::EmailConfig::from_env();
+    if cfg.configured() {
+        if let Err(err) =
+            crate::email::send_signin_email(&cfg, &req.email.trim().to_lowercase(), &login_url)
+                .await
+        {
+            let _ = state.db.invalidate_email_login_tokens(&req.email).await;
+            return Err(AppError::from(err));
+        }
+        return Ok(Json(EmailLoginResponse {
+            ok: true,
+            login_url: None,
+        }));
+    }
+    tracing::warn!(
+        email = %req.email.trim().to_lowercase(),
+        %login_url,
+        "RESEND_API_KEY unset; returning sign-in URL for local use"
+    );
+    Ok(Json(EmailLoginResponse {
+        ok: true,
+        login_url: Some(login_url),
+    }))
+}
+
+#[derive(Deserialize)]
+struct EmailCallbackQuery {
+    token: String,
+}
+
+async fn email_login_callback(
+    State(state): State<AppState>,
+    Query(query): Query<EmailCallbackQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    match state.db.consume_email_login_token(&query.token).await {
+        Ok(auth) => Ok(Redirect::temporary(&format!("/?auth={}", auth.token))),
+        Err(err) => {
+            tracing::warn!(error = %err, "email sign-in callback failed");
+            Ok(Redirect::temporary("/?auth_error=invalid"))
+        }
+    }
+}
+
 async fn me(
     State(state): State<AppState>,
     AuthUser(user): AuthUser,
 ) -> Result<impl IntoResponse, AppError> {
     let org = state.db.primary_org(user.id).await?;
-    state.reload_github_for_org(org.id).await.map_err(AppError::from)?;
+    state
+        .reload_github_for_org(org.id)
+        .await
+        .map_err(AppError::from)?;
     let github = state.github_client().await;
     let gh_account = state.db.get_github_account(user.id).await?;
     Ok(Json(serde_json::json!({
@@ -160,9 +245,7 @@ async fn me(
     })))
 }
 
-fn github_provider_view(
-    github: &zene_cloud_github::GithubClient,
-) -> GithubProviderConfigView {
+fn github_provider_view(github: &zene_cloud_github::GithubClient) -> GithubProviderConfigView {
     let cfg = github.config();
     GithubProviderConfigView {
         mode: cfg.mode,
@@ -170,7 +253,10 @@ fn github_provider_view(
         client_id: cfg.client_id.clone(),
         has_client_secret: cfg.client_secret.as_ref().is_some_and(|s| !s.is_empty()),
         app_id: cfg.app_id.clone(),
-        has_app_private_key: cfg.app_private_key_pem.as_ref().is_some_and(|s| !s.is_empty()),
+        has_app_private_key: cfg
+            .app_private_key_pem
+            .as_ref()
+            .is_some_and(|s| !s.is_empty()),
         app_slug: cfg.app_slug.clone(),
     }
 }
@@ -180,7 +266,10 @@ async fn get_github_settings(
     AuthUser(user): AuthUser,
 ) -> Result<impl IntoResponse, AppError> {
     let org = state.db.primary_org(user.id).await?;
-    state.reload_github_for_org(org.id).await.map_err(AppError::from)?;
+    state
+        .reload_github_for_org(org.id)
+        .await
+        .map_err(AppError::from)?;
     let github = state.github_client().await;
     let account = state.db.get_github_account(user.id).await?;
     let view = github_provider_view(&github);
@@ -200,7 +289,10 @@ async fn update_github_settings(
 ) -> Result<impl IntoResponse, AppError> {
     let org = state.db.primary_org(user.id).await?;
     state.db.upsert_github_provider_config(org.id, req).await?;
-    let github = state.reload_github_for_org(org.id).await.map_err(AppError::from)?;
+    let github = state
+        .reload_github_for_org(org.id)
+        .await
+        .map_err(AppError::from)?;
     let account = state.db.get_github_account(user.id).await?;
     Ok(Json(serde_json::json!({
         "provider": github_provider_view(&github),
@@ -290,7 +382,10 @@ async fn github_status(
     AuthUser(user): AuthUser,
 ) -> Result<impl IntoResponse, AppError> {
     let org = state.db.primary_org(user.id).await?;
-    state.reload_github_for_org(org.id).await.map_err(AppError::from)?;
+    state
+        .reload_github_for_org(org.id)
+        .await
+        .map_err(AppError::from)?;
     let github = state.github_client().await;
     let account = state.db.get_github_account(user.id).await?;
     let installations = state.db.list_installations(org.id).await?;
@@ -306,11 +401,7 @@ async fn github_status(
     let display_login = account
         .as_ref()
         .map(|a| a.login.clone())
-        .or_else(|| {
-            live_installations
-                .first()
-                .map(|i| i.account_login.clone())
-        })
+        .or_else(|| live_installations.first().map(|i| i.account_login.clone()))
         .or_else(|| installations.first().map(|i| i.account_login.clone()));
     Ok(Json(serde_json::json!({
         "mode": github.mode(),
@@ -333,7 +424,10 @@ async fn github_connect_start(
     AuthUser(user): AuthUser,
 ) -> Result<impl IntoResponse, AppError> {
     let org = state.db.primary_org(user.id).await?;
-    state.reload_github_for_org(org.id).await.map_err(AppError::from)?;
+    state
+        .reload_github_for_org(org.id)
+        .await
+        .map_err(AppError::from)?;
     let github = state.github_client().await;
     if github.is_mock() {
         return Ok(Json(serde_json::json!({
@@ -386,7 +480,10 @@ async fn github_install_callback(
         .user_id
         .ok_or_else(|| AppError::unauthorized("install state has no user"))?;
     let org = state.db.primary_org(user_id).await?;
-    state.reload_github_for_org(org.id).await.map_err(AppError::from)?;
+    state
+        .reload_github_for_org(org.id)
+        .await
+        .map_err(AppError::from)?;
     let github = state.github_client().await;
     let remote = github
         .get_installation(&installation_id)
@@ -424,7 +521,10 @@ async fn github_oauth_start(
     AuthUser(user): AuthUser,
 ) -> Result<impl IntoResponse, AppError> {
     let org = state.db.primary_org(user.id).await?;
-    state.reload_github_for_org(org.id).await.map_err(AppError::from)?;
+    state
+        .reload_github_for_org(org.id)
+        .await
+        .map_err(AppError::from)?;
     let github = state.github_client().await;
     if github.is_mock() {
         return Ok(Json(serde_json::json!({
@@ -477,7 +577,10 @@ async fn github_oauth_callback(
         .user_id
         .ok_or_else(|| AppError::unauthorized("oauth state has no user"))?;
     let org = state.db.primary_org(user_id).await?;
-    state.reload_github_for_org(org.id).await.map_err(AppError::from)?;
+    state
+        .reload_github_for_org(org.id)
+        .await
+        .map_err(AppError::from)?;
     let github = state.github_client().await;
     let redirect = format!("{}/api/v1/github/oauth/callback", state.public_base_url);
     let tokens = github
@@ -507,10 +610,15 @@ async fn github_mock_connect(
     AuthUser(user): AuthUser,
 ) -> Result<impl IntoResponse, AppError> {
     let org = state.db.primary_org(user.id).await?;
-    state.reload_github_for_org(org.id).await.map_err(AppError::from)?;
+    state
+        .reload_github_for_org(org.id)
+        .await
+        .map_err(AppError::from)?;
     let github = state.github_client().await;
     if !github.is_mock() {
-        return Err(AppError::conflict("mock connect only available in mock mode"));
+        return Err(AppError::conflict(
+            "mock connect only available in mock mode",
+        ));
     }
     let tokens = github
         .exchange_oauth_code("mock-code", None)
@@ -558,7 +666,10 @@ async fn github_sync(
     AuthUser(user): AuthUser,
 ) -> Result<impl IntoResponse, AppError> {
     let org = state.db.primary_org(user.id).await?;
-    state.reload_github_for_org(org.id).await.map_err(AppError::from)?;
+    state
+        .reload_github_for_org(org.id)
+        .await
+        .map_err(AppError::from)?;
     let github = state.github_client().await;
     if github.is_mock() {
         let tokens = github
@@ -582,7 +693,13 @@ async fn github_sync(
             .await?;
         let installation = state
             .db
-            .upsert_installation(org.id, "10001", "mock-org", GithubAccountType::Organization, GithubInstallationStatus::Active)
+            .upsert_installation(
+                org.id,
+                "10001",
+                "mock-org",
+                GithubAccountType::Organization,
+                GithubInstallationStatus::Active,
+            )
             .await?;
         let listed = github
             .list_installation_repos("10001")
@@ -655,7 +772,13 @@ async fn github_mock_install(
     let org = state.db.primary_org(user.id).await?;
     let installation = state
         .db
-        .upsert_installation(org.id, "10001", "mock-org", GithubAccountType::Organization, GithubInstallationStatus::Active)
+        .upsert_installation(
+            org.id,
+            "10001",
+            "mock-org",
+            GithubAccountType::Organization,
+            GithubInstallationStatus::Active,
+        )
         .await?;
     Ok(Json(installation))
 }
@@ -674,7 +797,10 @@ async fn sync_installation_repos(
     if installation.organization_id != org.id {
         return Err(AppError::forbidden("installation not in organization"));
     }
-    state.reload_github_for_org(org.id).await.map_err(AppError::from)?;
+    state
+        .reload_github_for_org(org.id)
+        .await
+        .map_err(AppError::from)?;
     let github = state.github_client().await;
     let listed = github
         .list_installation_repos(&installation_id)
@@ -847,7 +973,9 @@ async fn set_run_mode(
         )));
     }
     state.db.set_pending_mode(run_id, &req.mode_id).await?;
-    Ok(Json(serde_json::json!({ "ok": true, "modeId": req.mode_id.trim() })))
+    Ok(Json(
+        serde_json::json!({ "ok": true, "modeId": req.mode_id.trim() }),
+    ))
 }
 
 #[derive(Debug, Deserialize)]
@@ -866,7 +994,12 @@ async fn list_events(
     let _ = authorize_run(&state, user.id, run_id).await?;
     let events = match query.after_cursor {
         Some(cursor) => state.db.events_after_cursor(run_id, cursor).await?,
-        None => state.db.events_after(run_id, query.after_seq.unwrap_or(0)).await?,
+        None => {
+            state
+                .db
+                .events_after(run_id, query.after_seq.unwrap_or(0))
+                .await?
+        }
     };
     Ok(Json(serde_json::json!({
         "events": events,
@@ -887,9 +1020,7 @@ async fn stream_events(
         .get("last-event-id")
         .and_then(|value| value.to_str().ok())
         .and_then(|value| value.parse::<i64>().ok());
-    let mut after = last_event_id
-        .or(query.after_seq)
-        .unwrap_or(0);
+    let mut after = last_event_id.or(query.after_seq).unwrap_or(0);
     let mut after_cursor = query.after_cursor;
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<Event, Infallible>>(32);
     tokio::spawn(async move {
@@ -945,7 +1076,12 @@ async fn cancel_run(
     Ok(Json(
         state
             .db
-            .update_run_status(run_id, RunStatus::Cancelled, None, Some("user_cancelled".into()))
+            .update_run_status(
+                run_id,
+                RunStatus::Cancelled,
+                None,
+                Some("user_cancelled".into()),
+            )
             .await?,
     ))
 }
@@ -1013,7 +1149,10 @@ async fn decide_approval(
         return Err(AppError::not_found("approval not found"));
     }
     if !approval.allowed_decisions.is_empty()
-        && !approval.allowed_decisions.iter().any(|d| d == &req.decision)
+        && !approval
+            .allowed_decisions
+            .iter()
+            .any(|d| d == &req.decision)
     {
         return Err(AppError::conflict(format!(
             "decision {} not allowed",
@@ -1035,7 +1174,9 @@ async fn list_run_files(
 ) -> Result<impl IntoResponse, AppError> {
     let _ = authorize_run(&state, user.id, run_id).await?;
     let root = state.workspace_root.join(run_id.to_string());
-    Ok(Json(workspace::list_files(&root, 500).map_err(AppError::from)?))
+    Ok(Json(
+        workspace::list_files(&root, 500).map_err(AppError::from)?,
+    ))
 }
 
 #[derive(Debug, Deserialize)]
@@ -1192,15 +1333,16 @@ async fn claim_run(
         .await?;
     Ok(Json(claimed.map(
         |(run, attempt_id, generation, resume_session_id, workspace_dir, resume_without_prompt)| {
-        ClaimedRun {
-            run,
-            attempt_id,
-            generation,
-            resume_session_id,
-            resume_without_prompt,
-            workspace_dir,
-        }
-    })))
+            ClaimedRun {
+                run,
+                attempt_id,
+                generation,
+                resume_session_id,
+                resume_without_prompt,
+                workspace_dir,
+            }
+        },
+    )))
 }
 
 async fn queue_stats(
@@ -1272,13 +1414,7 @@ async fn worker_status(
     Ok(Json(
         state
             .db
-            .update_run_status_fenced(
-                run_id,
-                &fence,
-                req.status,
-                req.head_sha,
-                req.failure_code,
-            )
+            .update_run_status_fenced(run_id, &fence, req.status, req.head_sha, req.failure_code)
             .await?,
     ))
 }
@@ -1290,14 +1426,18 @@ async fn worker_title(
     Json(req): Json<WorkerTitleRequest>,
 ) -> Result<impl IntoResponse, AppError> {
     let updated = match req.fence {
-        Some(fence) => state
-            .db
-            .update_run_title_fenced(run_id, &fence, req.title.trim())
-            .await?,
-        None => state
-            .db
-            .update_run_title_legacy(run_id, req.title.trim())
-            .await?,
+        Some(fence) => {
+            state
+                .db
+                .update_run_title_fenced(run_id, &fence, req.title.trim())
+                .await?
+        }
+        None => {
+            state
+                .db
+                .update_run_title_legacy(run_id, req.title.trim())
+                .await?
+        }
     };
     Ok(Json(updated))
 }
@@ -1511,8 +1651,8 @@ mod reconnect_replay_tests {
     use zene_cloud_db::Db;
     use zene_cloud_domain::{
         AuthResponse, ClaimedRun, CreateRepositoryRequest, CreateRunRequest, PermissionMode,
-        RegisterRequest, Repository, Run, RunEvent, RunEventKind, RunStatus, UpdateLlmSettingsRequest,
-        WorkerEventRequest, WorkerFence,
+        RegisterRequest, Repository, Run, RunEvent, RunEventKind, RunStatus,
+        UpdateLlmSettingsRequest, WorkerEventRequest, WorkerFence,
     };
     use zene_cloud_github::{GithubClient, GithubConfig};
 
@@ -1520,7 +1660,10 @@ mod reconnect_replay_tests {
         assert_eq!(response.status(), StatusCode::OK);
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         serde_json::from_slice(&bytes).unwrap_or_else(|error| {
-            panic!("invalid JSON response: {error}; body={}", String::from_utf8_lossy(&bytes))
+            panic!(
+                "invalid JSON response: {error}; body={}",
+                String::from_utf8_lossy(&bytes)
+            )
         })
     }
 
@@ -1575,7 +1718,8 @@ mod reconnect_replay_tests {
         db.migrate().await.unwrap();
         let worker_token = "integration-worker-token";
         db.ensure_dev_worker_token(worker_token).await.unwrap();
-        let workspace_root = std::env::temp_dir().join(format!("zene-api-replay-{}", Uuid::new_v4()));
+        let workspace_root =
+            std::env::temp_dir().join(format!("zene-api-replay-{}", Uuid::new_v4()));
         tokio::fs::create_dir_all(&workspace_root).await.unwrap();
         let state = AppState::new(
             db.clone(),
@@ -1749,7 +1893,10 @@ mod reconnect_replay_tests {
         assert!(second.seq > first.seq);
         let persisted = state.db.events_after(run.id, first.seq).await.unwrap();
         assert_eq!(
-            persisted.iter().filter(|event| event.payload == second.payload).count(),
+            persisted
+                .iter()
+                .filter(|event| event.payload == second.payload)
+                .count(),
             1
         );
 

--- a/cloud/apps/web/components/App.tsx
+++ b/cloud/apps/web/components/App.tsx
@@ -352,17 +352,6 @@ function AppInner() {
     setView("new");
   }, []);
 
-  const onAuthenticated = useCallback(
-    async (auth: { user: User; organization: Organization }) => {
-      setUser(auth.user);
-      setOrg(auth.organization);
-      setAuthed(true);
-      await Promise.all([refreshGithub(), refreshRepos().catch(() => {}), refreshRuns()]);
-      showNewAgent();
-    },
-    [refreshGithub, refreshRepos, refreshRuns, showNewAgent],
-  );
-
   const bootstrapped = useRef(false);
   useEffect(() => {
     if (bootstrapped.current) return;
@@ -375,6 +364,17 @@ function AppInner() {
     setSelectedRepoIdState(readPref("zc.repoId", ""));
 
     (async () => {
+      const params = new URLSearchParams(window.location.search);
+      const auth = params.get("auth");
+      const authError = params.get("auth_error");
+      if (auth || authError) {
+        params.delete("auth");
+        params.delete("auth_error");
+        const next = params.toString();
+        history.replaceState({}, "", next ? `${location.pathname}?${next}` : location.pathname);
+      }
+      if (authError) toast("This sign-in link is invalid or expired", "error");
+      if (auth) setToken(auth);
       const token = loadToken();
       if (!token) {
         setReady(true);
@@ -392,7 +392,7 @@ function AppInner() {
         setReady(true);
       }
     })();
-  }, [refreshGithub, refreshRepos, refreshRuns]);
+  }, [refreshGithub, refreshRepos, refreshRuns, toast]);
 
   // Deep-link after OAuth redirect
   useEffect(() => {
@@ -413,7 +413,7 @@ function AppInner() {
   if (!ready) return null;
 
   if (!authed) {
-    return <AuthView onAuthenticated={onAuthenticated} />;
+    return <AuthView />;
   }
 
   return (

--- a/cloud/apps/web/components/AuthView.tsx
+++ b/cloud/apps/web/components/AuthView.tsx
@@ -1,140 +1,152 @@
 "use client";
 
 import { useState } from "react";
-import { api, setToken } from "@/lib/api";
-import type { Organization, User } from "@/lib/types";
+import { api } from "@/lib/api";
 import { useToast } from "./Toast";
 
-interface AuthResponse {
-  token: string;
-  user: User;
-  organization: Organization;
+function isValidEmail(value: string): boolean {
+  const email = value.trim();
+  const at = email.indexOf("@");
+  if (at <= 0) return false;
+  const domain = email.slice(at + 1);
+  return domain.includes(".") && !domain.startsWith(".") && !domain.endsWith(".");
 }
 
-function authErrorMessage(raw: string, isLogin: boolean): string {
-  const msg = raw.trim();
-  const lower = msg.toLowerCase();
-  if (lower.includes("invalid credentials")) {
-    return "Email or password is incorrect";
-  }
-  if (lower.includes("already registered") || lower.includes("already exists")) {
-    return "This email is already registered";
-  }
-  if (lower.includes("password") && (lower.includes("short") || lower.includes("at least"))) {
-    return "Password must be at least 8 characters";
-  }
-  return msg || (isLogin ? "Sign in failed" : "Registration failed");
-}
-
-export function AuthView({
-  onAuthenticated,
-}: {
-  onAuthenticated: (auth: AuthResponse) => void;
-}) {
+export function AuthView() {
   const toast = useToast();
-  const [mode, setMode] = useState<"login" | "register">("register");
-  const [displayName, setDisplayName] = useState("");
   const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
   const [busy, setBusy] = useState(false);
-  const isLogin = mode === "login";
+  const [sentTo, setSentTo] = useState("");
+  const [loginUrl, setLoginUrl] = useState<string | null>(null);
 
   const submit = async () => {
+    const value = email.trim();
+    if (!isValidEmail(value)) {
+      toast("Enter a valid email address", "error");
+      return;
+    }
     setBusy(true);
     try {
-      const path = isLogin ? "/api/v1/auth/login" : "/api/v1/auth/register";
-      const payload = isLogin
-        ? { email: email.trim(), password }
-        : { email: email.trim(), password, displayName: displayName.trim() || "User" };
-      const auth = await api<AuthResponse>(path, { method: "POST", body: JSON.stringify(payload) });
-      setToken(auth.token);
-      onAuthenticated(auth);
+      const res = await api<{ ok: boolean; loginUrl?: string }>("/api/v1/auth/email", {
+        method: "POST",
+        body: JSON.stringify({ email: value }),
+      });
+      setSentTo(value);
+      setLoginUrl(res.loginUrl || null);
     } catch (err) {
       const raw = err instanceof Error ? err.message : String(err);
-      toast(authErrorMessage(raw, isLogin), "error");
+      toast(raw || "Could not send sign-in link", "error");
     } finally {
       setBusy(false);
     }
   };
 
   return (
-    <div className="grid min-h-full place-items-center overflow-auto bg-canvas-bg px-[18px] py-7">
-      <div className="flex w-[min(384px,100%)] flex-col rounded-md bg-canvas px-7 pb-6 pt-8 shadow-card">
-        <div className="mb-4 flex flex-col items-center justify-center gap-2 text-center">
-          <div className="grid h-8 w-8 place-items-center rounded-sm bg-chip text-[13px] font-semibold text-ink">
-            Z
+    <div className="grid min-h-full place-items-center overflow-auto bg-canvas-bg px-5 py-10">
+      <div className="grid w-full max-w-[840px] items-start gap-10 min-[800px]:grid-cols-[minmax(0,1fr)_320px]">
+        <section>
+          <div className="mb-5 flex items-center gap-2">
+            <div className="grid h-7 w-7 place-items-center rounded-sm bg-chip text-[12px] font-semibold text-ink">
+              Z
+            </div>
+            <strong className="text-[13px] font-semibold text-ink">Zene</strong>
           </div>
-          <strong className="text-[13px] font-semibold text-ink">Zene</strong>
-        </div>
-        <h1 className="mb-1 text-center text-[22px] font-semibold tracking-[-0.02em] text-ink">
-          {isLogin ? "Sign in" : "Create account"}
-        </h1>
-        <p className="mb-5 text-center text-[13px] leading-normal text-muted">
-          {isLogin ? "Continue to Cloud Console." : "Register to run agents against your repositories."}
-        </p>
-        <div className="mb-2 flex gap-2">
-          <button
-            type="button"
-            className={`btn flex-1 ${isLogin ? "btn-primary" : ""}`}
-            onClick={() => setMode("login")}
-          >
-            Log in
-          </button>
-          <button
-            type="button"
-            className={`btn flex-1 ${isLogin ? "" : "btn-primary"}`}
-            onClick={() => setMode("register")}
-          >
-            Register
-          </button>
-        </div>
-        {!isLogin && (
-          <div>
-            <label className="field-label" htmlFor="displayName">
-              Display name
-            </label>
-            <input
-              id="displayName"
-              className="field-input"
-              autoComplete="name"
-              placeholder="Ada"
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-            />
-          </div>
-        )}
-        <label className="field-label" htmlFor="email">
-          Email
-        </label>
-        <input
-          id="email"
-          className="field-input"
-          type="email"
-          autoComplete="email"
-          placeholder="you@company.com"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
-        <label className="field-label" htmlFor="password">
-          Password
-        </label>
-        <input
-          id="password"
-          className="field-input"
-          type="password"
-          autoComplete={isLogin ? "current-password" : "new-password"}
-          placeholder="At least 8 characters"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") submit();
-          }}
-        />
-        <div className="mt-4">
-          <button type="button" className="btn btn-primary w-full" disabled={busy} onClick={submit}>
-            Continue
-          </button>
-        </div>
+          <h1 className="mb-2 text-[22px] font-semibold tracking-[-0.02em] text-ink">
+            Cloud console for coding agents
+          </h1>
+          <p className="mb-6 max-w-[36em] text-[13.5px] leading-[1.55] text-muted">
+            Start a task on a GitHub repository. The agent clones the repo, runs commands, and edits
+            files in an isolated workspace. You see each step, the diffs, and the checks. Approve or
+            take over when a step needs you.
+          </p>
+          <dl className="max-w-[36em] space-y-3.5">
+            <div>
+              <dt className="text-[13px] font-semibold text-ink">Connect GitHub</dt>
+              <dd className="mt-0.5 text-[13px] leading-normal text-muted">
+                Authorize the app and pick a repository.
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[13px] font-semibold text-ink">Run a task</dt>
+              <dd className="mt-0.5 text-[13px] leading-normal text-muted">
+                Describe the change. The agent works in the background; closing the browser does not
+                stop it.
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[13px] font-semibold text-ink">Review before it lands</dt>
+              <dd className="mt-0.5 text-[13px] leading-normal text-muted">
+                Inspect diffs, tests, and the pull request. Nothing is merged without you.
+              </dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className="rounded-md bg-canvas px-6 py-6 shadow-card">
+          {sentTo ? (
+            <>
+              <h2 className="mb-1 text-[16px] font-semibold text-ink">Check your email</h2>
+              <p className="mb-4 text-[13px] leading-normal text-muted">
+                We sent a sign-in link to <span className="font-medium text-ink">{sentTo}</span>.
+                Open it to continue. New accounts are created automatically.
+              </p>
+              {loginUrl && (
+                <div className="mb-4 rounded-sm bg-canvas-bg px-3 py-2.5">
+                  <p className="mb-2 text-[12px] leading-normal text-muted">
+                    Email sending is off on this host. Open the sign-in link directly.
+                  </p>
+                  <button
+                    type="button"
+                    className="btn btn-primary w-full"
+                    onClick={() => {
+                      window.location.assign(loginUrl);
+                    }}
+                  >
+                    Open sign-in link
+                  </button>
+                </div>
+              )}
+              <button
+                type="button"
+                className="btn w-full"
+                onClick={() => {
+                  setSentTo("");
+                  setLoginUrl(null);
+                }}
+              >
+                Use a different email
+              </button>
+            </>
+          ) : (
+            <>
+              <h2 className="mb-1 text-[16px] font-semibold text-ink">Sign in</h2>
+              <p className="mb-4 text-[13px] leading-normal text-muted">
+                Enter your work email. We send a one-time link. No password.
+              </p>
+              <label className="field-label" htmlFor="email">
+                Email
+              </label>
+              <input
+                id="email"
+                className="field-input"
+                type="email"
+                autoComplete="email"
+                autoFocus
+                placeholder="you@company.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") submit();
+                }}
+              />
+              <div className="mt-4">
+                <button type="button" className="btn btn-primary w-full" disabled={busy} onClick={submit}>
+                  {busy ? "Sending…" : "Send sign-in link"}
+                </button>
+              </div>
+            </>
+          )}
+        </section>
       </div>
     </div>
   );

--- a/cloud/crates/db/src/lib.rs
+++ b/cloud/crates/db/src/lib.rs
@@ -15,9 +15,10 @@ use std::str::FromStr;
 use uuid::Uuid;
 use zene_cloud_domain::{
     ApprovalDecision, ApprovalKind, ApprovalRequest, ApprovalRisk, ApprovalStatus, AuthResponse,
-    CloneAuthResponse, CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest, LoginRequest, Organization,
-    PlatformEvent, QueueActive, QueueHold, QueueStats, RegisterRequest, Repository, Run, RunEvent, RunEventKind, RunMessage,
-    RunStatus, PermissionMode, MessageRole, User, WorkerCommand, WorkerFence,
+    CloneAuthResponse, CreateApprovalRequest, CreateRepositoryRequest, CreateRunRequest,
+    LoginRequest, MessageRole, Organization, PermissionMode, PlatformEvent, QueueActive, QueueHold,
+    QueueStats, RegisterRequest, Repository, Run, RunEvent, RunEventKind, RunMessage, RunStatus,
+    User, WorkerCommand, WorkerFence,
 };
 
 /// Worker attempt lease renewed by heartbeat (seconds).
@@ -110,6 +111,10 @@ impl Db {
                 "012_run_pending_mode",
                 include_str!("../../../migrations/012_run_pending_mode.sql"),
             ),
+            (
+                "013_email_login",
+                include_str!("../../../migrations/013_email_login.sql"),
+            ),
         ];
 
         for (version, sql) in migrations {
@@ -151,13 +156,11 @@ impl Db {
                 }
             }
 
-            sqlx::query(
-                "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
-            )
-            .bind(version)
-            .bind(Utc::now().to_rfc3339())
-            .execute(&self.pool)
-            .await?;
+            sqlx::query("INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)")
+                .bind(version)
+                .bind(Utc::now().to_rfc3339())
+                .execute(&self.pool)
+                .await?;
         }
         Ok(())
     }
@@ -209,15 +212,13 @@ impl Db {
         .context("email may already exist")?;
 
         let slug = org_id.to_string();
-        sqlx::query(
-            "INSERT INTO organizations (id, slug, name, created_at) VALUES (?, ?, ?, ?)",
-        )
-        .bind(&slug)
-        .bind(&slug)
-        .bind(format!("{}'s Workspace", req.display_name))
-        .bind(now.to_rfc3339())
-        .execute(&mut *tx)
-        .await?;
+        sqlx::query("INSERT INTO organizations (id, slug, name, created_at) VALUES (?, ?, ?, ?)")
+            .bind(&slug)
+            .bind(&slug)
+            .bind(format!("{}'s Workspace", req.display_name))
+            .bind(now.to_rfc3339())
+            .execute(&mut *tx)
+            .await?;
 
         sqlx::query(
             "INSERT INTO organization_members (organization_id, user_id, role, joined_at)
@@ -248,6 +249,114 @@ impl Db {
                 created_at: now,
             },
         })
+    }
+
+    pub async fn create_email_login_token(&self, email: &str) -> Result<String> {
+        let email = email.trim().to_lowercase();
+        if !is_valid_email(&email) {
+            bail!("invalid email");
+        }
+        let now = Utc::now();
+        let recent: Option<(String,)> = sqlx::query_as(
+            "SELECT created_at FROM email_login_tokens
+             WHERE email = ? AND consumed_at IS NULL AND expires_at > ?
+             ORDER BY created_at DESC LIMIT 1",
+        )
+        .bind(&email)
+        .bind(now.to_rfc3339())
+        .fetch_optional(&self.pool)
+        .await?;
+        if let Some((created_at,)) = recent {
+            if now - parse_time(&created_at) < Duration::seconds(30) {
+                bail!("wait a moment before requesting another link");
+            }
+        }
+        sqlx::query(
+            "UPDATE email_login_tokens SET consumed_at = ? WHERE email = ? AND consumed_at IS NULL",
+        )
+        .bind(now.to_rfc3339())
+        .bind(&email)
+        .execute(&self.pool)
+        .await?;
+
+        let raw = format!("el_{}", Uuid::new_v4().simple());
+        let expires = now + Duration::minutes(15);
+        sqlx::query(
+            "INSERT INTO email_login_tokens
+             (id, email, token_hash, expires_at, created_at)
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(&email)
+        .bind(hash_token(&raw))
+        .bind(expires.to_rfc3339())
+        .bind(now.to_rfc3339())
+        .execute(&self.pool)
+        .await?;
+        Ok(raw)
+    }
+
+    pub async fn invalidate_email_login_tokens(&self, email: &str) -> Result<()> {
+        let email = email.trim().to_lowercase();
+        sqlx::query(
+            "UPDATE email_login_tokens SET consumed_at = ? WHERE email = ? AND consumed_at IS NULL",
+        )
+        .bind(Utc::now().to_rfc3339())
+        .bind(email)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn consume_email_login_token(&self, token: &str) -> Result<AuthResponse> {
+        let now = Utc::now();
+        let row: Option<(String,)> = sqlx::query_as(
+            "UPDATE email_login_tokens
+             SET consumed_at = ?
+             WHERE token_hash = ? AND consumed_at IS NULL AND expires_at > ?
+             RETURNING email",
+        )
+        .bind(now.to_rfc3339())
+        .bind(hash_token(token.trim()))
+        .bind(now.to_rfc3339())
+        .fetch_optional(&self.pool)
+        .await?;
+        let Some((email,)) = row else {
+            bail!("invalid or expired sign-in link");
+        };
+        self.login_or_register_by_email(&email).await
+    }
+
+    async fn login_or_register_by_email(&self, email: &str) -> Result<AuthResponse> {
+        if let Some(user) = self.find_user_by_email(email).await? {
+            let org = self.primary_org(user.id).await?;
+            let token = self.create_session(user.id).await?;
+            return Ok(AuthResponse {
+                token,
+                user,
+                organization: org,
+            });
+        }
+        self.register(RegisterRequest {
+            email: email.to_string(),
+            password: format!("email:{}", Uuid::new_v4()),
+            display_name: display_name_from_email(email),
+        })
+        .await
+    }
+
+    async fn find_user_by_email(&self, email: &str) -> Result<Option<User>> {
+        let row: Option<(String, String, String, String)> =
+            sqlx::query_as("SELECT id, email, display_name, created_at FROM users WHERE email = ?")
+                .bind(email)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.map(|(id, email, display_name, created_at)| User {
+            id: Uuid::parse_str(&id).unwrap(),
+            email,
+            display_name,
+            created_at: parse_time(&created_at),
+        }))
     }
 
     pub async fn login(&self, req: LoginRequest) -> Result<AuthResponse> {
@@ -332,9 +441,9 @@ impl Db {
     ) -> Result<Repository> {
         let id = Uuid::new_v4();
         let now = Utc::now();
-        let clone_url = req.clone_url.unwrap_or_else(|| {
-            format!("https://github.com/{}/{}.git", req.owner, req.name)
-        });
+        let clone_url = req
+            .clone_url
+            .unwrap_or_else(|| format!("https://github.com/{}/{}.git", req.owner, req.name));
         sqlx::query(
             "INSERT INTO repositories
              (id, organization_id, provider, owner, name, default_branch, clone_url, created_at)
@@ -618,13 +727,13 @@ impl Db {
             .await?
             .into_run();
         if title.is_some() {
-            let title_event_id = fence
-                .map(|fence| format!("platform.run.title.worker.{}", fence.generation));
+            let title_event_id =
+                fence.map(|fence| format!("platform.run.title.worker.{}", fence.generation));
             self.append_event_tx(
                 &mut tx,
                 run_id,
                 fence.map_or(0, |fence| fence.generation),
-                title_event_id.as_deref().or(Some("platform.run.title")), 
+                title_event_id.as_deref().or(Some("platform.run.title")),
                 None,
                 RunEventKind::Platform,
                 platform_payload(PlatformEvent::RunTitle {
@@ -662,10 +771,7 @@ impl Db {
             "DELETE FROM git_operations WHERE run_id = ?",
             "DELETE FROM runs WHERE id = ?",
         ] {
-            sqlx::query(sql)
-                .bind(&run_id_s)
-                .execute(&mut *tx)
-                .await?;
+            sqlx::query(sql).bind(&run_id_s).execute(&mut *tx).await?;
         }
         tx.commit().await?;
         Ok(())
@@ -757,16 +863,17 @@ impl Db {
              ORDER BY created_at ASC LIMIT 1"
         );
         let row = sqlx::query_as::<_, RunRow>(&sql)
-        .fetch_optional(&mut *tx)
-        .await?;
+            .fetch_optional(&mut *tx)
+            .await?;
         let Some(row) = row else {
             return Ok(None);
         };
         let run_id = row.id.clone();
-        let last_error: Option<String> = sqlx::query_scalar("SELECT last_error FROM runs WHERE id = ?")
-            .bind(&run_id)
-            .fetch_optional(&mut *tx)
-            .await?;
+        let last_error: Option<String> =
+            sqlx::query_scalar("SELECT last_error FROM runs WHERE id = ?")
+                .bind(&run_id)
+                .fetch_optional(&mut *tx)
+                .await?;
         let run = row.into_run();
         let attempt_id = Uuid::new_v4();
         let attempt = sqlx::query_scalar::<_, i64>(
@@ -823,7 +930,10 @@ impl Db {
             .join(run.id.to_string())
             .to_string_lossy()
             .to_string();
-        let mut run = self.get_run(run.id).await?.context("run missing after claim")?;
+        let mut run = self
+            .get_run(run.id)
+            .await?
+            .context("run missing after claim")?;
         run.status = RunStatus::Provisioning;
         Ok(Some((
             run,
@@ -836,23 +946,13 @@ impl Db {
     }
 
     /// Re-queue a terminal run so the user can continue in the same thread.
-    pub async fn user_retry_run(
-        &self,
-        run_id: Uuid,
-        follow_up: Option<&str>,
-    ) -> Result<Run> {
-        let run = self
-            .get_run(run_id)
-            .await?
-            .context("run not found")?;
+    pub async fn user_retry_run(&self, run_id: Uuid, follow_up: Option<&str>) -> Result<Run> {
+        let run = self.get_run(run_id).await?.context("run not found")?;
         if !matches!(
             run.status,
             RunStatus::Failed | RunStatus::TimedOut | RunStatus::Cancelled
         ) {
-            bail!(
-                "run status {} cannot be retried",
-                run.status.as_str()
-            );
+            bail!("run status {} cannot be retried", run.status.as_str());
         }
         let now = Utc::now().to_rfc3339();
         let mut tx = self.pool.begin().await?;
@@ -1060,12 +1160,13 @@ impl Db {
             run_status_payload(status, head_sha),
         )
         .await?;
-        let updated = sqlx::query_as::<_, RunRow>(&format!("SELECT {RUN_COLUMNS} FROM runs WHERE id = ?"))
-            .bind(run_id.to_string())
-            .fetch_optional(&mut *tx)
-            .await?
-            .map(RunRow::into_run)
-            .context("run missing after status update")?;
+        let updated =
+            sqlx::query_as::<_, RunRow>(&format!("SELECT {RUN_COLUMNS} FROM runs WHERE id = ?"))
+                .bind(run_id.to_string())
+                .fetch_optional(&mut *tx)
+                .await?
+                .map(RunRow::into_run)
+                .context("run missing after status update")?;
         tx.commit().await?;
         Ok(updated)
     }
@@ -1166,7 +1267,10 @@ impl Db {
                         // SQLite may store without offset; treat as UTC.
                         chrono::NaiveDateTime::parse_from_str(&since, "%Y-%m-%d %H:%M:%S%.f")
                             .or_else(|_| {
-                                chrono::NaiveDateTime::parse_from_str(&since, "%Y-%m-%dT%H:%M:%S%.f")
+                                chrono::NaiveDateTime::parse_from_str(
+                                    &since,
+                                    "%Y-%m-%dT%H:%M:%S%.f",
+                                )
                             })
                             .ok()
                             .map(|ndt| ndt.and_utc())
@@ -1200,7 +1304,15 @@ impl Db {
         let mut tx = self.pool.begin().await?;
         self.validate_worker_fence(&mut tx, run_id, fence).await?;
         let event = self
-            .append_event_tx(&mut tx, run_id, fence.generation, source_event_id, None, event_type, payload)
+            .append_event_tx(
+                &mut tx,
+                run_id,
+                fence.generation,
+                source_event_id,
+                None,
+                event_type,
+                payload,
+            )
             .await?;
         tx.commit().await?;
         Ok(event)
@@ -1216,7 +1328,15 @@ impl Db {
     ) -> Result<RunEvent> {
         let mut tx = self.pool.begin().await?;
         let event = self
-            .append_event_tx(&mut tx, run_id, attempt_generation, source_event_id, None, event_type, payload)
+            .append_event_tx(
+                &mut tx,
+                run_id,
+                attempt_generation,
+                source_event_id,
+                None,
+                event_type,
+                payload,
+            )
             .await?;
         tx.commit().await?;
         Ok(event)
@@ -1234,7 +1354,15 @@ impl Db {
         let mut tx = self.pool.begin().await?;
         self.validate_worker_fence(&mut tx, run_id, fence).await?;
         let event = self
-            .append_event_tx(&mut tx, run_id, fence.generation, source_event_id, cursor, event_type, payload)
+            .append_event_tx(
+                &mut tx,
+                run_id,
+                fence.generation,
+                source_event_id,
+                cursor,
+                event_type,
+                payload,
+            )
             .await?;
         tx.commit().await?;
         Ok(event)
@@ -1302,11 +1430,7 @@ impl Db {
         })
     }
 
-    async fn validate_worker_fence_simple(
-        &self,
-        run_id: Uuid,
-        fence: &WorkerFence,
-    ) -> Result<()> {
+    async fn validate_worker_fence_simple(&self, run_id: Uuid, fence: &WorkerFence) -> Result<()> {
         let row: Option<(i64, Option<String>, Option<String>)> = sqlx::query_as(
             "SELECT generation, worker_id, finished_at FROM run_attempts
              WHERE id = ? AND run_id = ?",
@@ -1317,7 +1441,10 @@ impl Db {
         .await?;
         match row {
             Some((generation, Some(worker_id), None))
-                if generation == fence.generation && worker_id == fence.worker_id => Ok(()),
+                if generation == fence.generation && worker_id == fence.worker_id =>
+            {
+                Ok(())
+            }
             _ => bail!("stale_attempt: worker fence rejected runtime session update"),
         }
     }
@@ -1360,14 +1487,16 @@ impl Db {
         .await?;
         Ok(rows
             .into_iter()
-            .map(|(seq, cursor, event_type, payload_json, created_at)| RunEvent {
-                run_id,
-                seq,
-                cursor: cursor.and_then(|value| u64::try_from(value).ok()),
-                event_type,
-                payload: serde_json::from_str(&payload_json).unwrap_or(serde_json::json!({})),
-                created_at: parse_time(&created_at),
-            })
+            .map(
+                |(seq, cursor, event_type, payload_json, created_at)| RunEvent {
+                    run_id,
+                    seq,
+                    cursor: cursor.and_then(|value| u64::try_from(value).ok()),
+                    event_type,
+                    payload: serde_json::from_str(&payload_json).unwrap_or(serde_json::json!({})),
+                    created_at: parse_time(&created_at),
+                },
+            )
             .collect())
     }
 
@@ -1377,7 +1506,11 @@ impl Db {
     /// retain every event and use `seq` for ordering. The cursor is translated
     /// to the greatest canonical sequence observed at or before that provider
     /// position; callers therefore cannot lose platform events without a cursor.
-    pub async fn events_after_cursor(&self, run_id: Uuid, after_cursor: u64) -> Result<Vec<RunEvent>> {
+    pub async fn events_after_cursor(
+        &self,
+        run_id: Uuid,
+        after_cursor: u64,
+    ) -> Result<Vec<RunEvent>> {
         let after_seq: i64 = sqlx::query_scalar(
             "SELECT COALESCE(MAX(seq), 0) FROM run_events
              WHERE run_id = ? AND cursor IS NOT NULL AND cursor <= ?",
@@ -1427,12 +1560,11 @@ impl Db {
             }),
         )
         .await?;
-        let current_status: Option<String> = sqlx::query_scalar(
-            "SELECT status FROM runs WHERE id = ?",
-        )
-        .bind(run_id.to_string())
-        .fetch_optional(&mut *tx)
-        .await?;
+        let current_status: Option<String> =
+            sqlx::query_scalar("SELECT status FROM runs WHERE id = ?")
+                .bind(run_id.to_string())
+                .fetch_optional(&mut *tx)
+                .await?;
         if current_status.as_deref() == Some(RunStatus::Completed.as_str()) {
             // Re-queue with the follow-up as the next claim prompt.
             sqlx::query("UPDATE runs SET prompt = ? WHERE id = ?")
@@ -1485,22 +1617,21 @@ impl Db {
         .await?;
         Ok(rows
             .into_iter()
-            .map(|(id, run_id, author_id, role, content, created_at)| RunMessage {
-                id: Uuid::parse_str(&id).unwrap(),
-                run_id: Uuid::parse_str(&run_id).unwrap(),
-                author_id: author_id.and_then(|v| Uuid::parse_str(&v).ok()),
-                role: MessageRole::parse(&role).unwrap_or(MessageRole::Assistant),
-                content,
-                created_at: parse_time(&created_at),
-            })
+            .map(
+                |(id, run_id, author_id, role, content, created_at)| RunMessage {
+                    id: Uuid::parse_str(&id).unwrap(),
+                    run_id: Uuid::parse_str(&run_id).unwrap(),
+                    author_id: author_id.and_then(|v| Uuid::parse_str(&v).ok()),
+                    role: MessageRole::parse(&role).unwrap_or(MessageRole::Assistant),
+                    content,
+                    created_at: parse_time(&created_at),
+                },
+            )
             .collect())
     }
 
     pub async fn get_clone_auth(&self, run_id: Uuid) -> Result<CloneAuthResponse> {
-        let run = self
-            .get_run(run_id)
-            .await?
-            .context("run not found")?;
+        let run = self.get_run(run_id).await?.context("run not found")?;
         let repo = self
             .get_repository(run.repository_id)
             .await?
@@ -1528,8 +1659,7 @@ impl Db {
 
         // Phase 0: no GitHub App tokens yet — treat as mock workspace unless a real
         // clone URL looks locally usable (file:// or existing path).
-        let mock = !repo.clone_url.starts_with("file://")
-            && !Path::new(&repo.clone_url).exists();
+        let mock = !repo.clone_url.starts_with("file://") && !Path::new(&repo.clone_url).exists();
         let now = Utc::now();
         sqlx::query(
             "INSERT OR REPLACE INTO run_clone_credentials
@@ -1622,7 +1752,8 @@ impl Db {
         run_id: Uuid,
         fence: &WorkerFence,
     ) -> Result<Vec<WorkerCommand>> {
-        self.poll_worker_commands_fenced_at(run_id, fence, Utc::now()).await
+        self.poll_worker_commands_fenced_at(run_id, fence, Utc::now())
+            .await
     }
 
     pub async fn poll_worker_commands_fenced_at(
@@ -1635,10 +1766,7 @@ impl Db {
         // delivery. Claims expire so a crashed worker cannot lose a follow-up.
         const CLAIM_LEASE: i64 = 60;
         let stale_before = (now - Duration::seconds(CLAIM_LEASE)).to_rfc3339();
-        let run = self
-            .get_run(run_id)
-            .await?
-            .context("run not found")?;
+        let run = self.get_run(run_id).await?.context("run not found")?;
         let mut tx = self.pool.begin().await?;
         self.validate_worker_fence(&mut tx, run_id, fence).await?;
         let mut commands = Vec::new();
@@ -1647,7 +1775,10 @@ impl Db {
             run.status,
             RunStatus::Cancelled | RunStatus::Stopping | RunStatus::TimedOut
         ) {
-            commands.push(WorkerCommand::cancel(format!("cancel-{}", run.status.as_str())));
+            commands.push(WorkerCommand::cancel(format!(
+                "cancel-{}",
+                run.status.as_str()
+            )));
         }
 
         let rows: Vec<(String, String)> = sqlx::query_as(
@@ -1681,7 +1812,11 @@ impl Db {
                 continue;
             }
             let message_id = Uuid::parse_str(&id)?;
-            commands.push(WorkerCommand::prompt(format!("msg-{id}"), content, message_id));
+            commands.push(WorkerCommand::prompt(
+                format!("msg-{id}"),
+                content,
+                message_id,
+            ));
         }
         tx.commit().await?;
         Ok(commands)
@@ -1772,17 +1907,17 @@ impl Db {
     /// workers must use `poll_worker_commands_fenced` followed by ack.
     #[allow(dead_code)]
     pub async fn poll_worker_commands(&self, run_id: Uuid) -> Result<Vec<WorkerCommand>> {
-        let run = self
-            .get_run(run_id)
-            .await?
-            .context("run not found")?;
+        let run = self.get_run(run_id).await?.context("run not found")?;
         let mut commands = Vec::new();
 
         if matches!(
             run.status,
             RunStatus::Cancelled | RunStatus::Stopping | RunStatus::TimedOut
         ) {
-            commands.push(WorkerCommand::cancel(format!("cancel-{}", run.status.as_str())));
+            commands.push(WorkerCommand::cancel(format!(
+                "cancel-{}",
+                run.status.as_str()
+            )));
         }
 
         let rows: Vec<(String, String)> = sqlx::query_as(
@@ -1796,7 +1931,11 @@ impl Db {
 
         for (id, content) in rows {
             let message_id = Uuid::parse_str(&id)?;
-            commands.push(WorkerCommand::prompt(format!("msg-{id}"), content, message_id));
+            commands.push(WorkerCommand::prompt(
+                format!("msg-{id}"),
+                content,
+                message_id,
+            ));
         }
 
         Ok(commands)
@@ -1807,10 +1946,7 @@ impl Db {
         run_id: Uuid,
         req: CreateApprovalRequest,
     ) -> Result<ApprovalRequest> {
-        let run = self
-            .get_run(run_id)
-            .await?
-            .context("run not found")?;
+        let run = self.get_run(run_id).await?.context("run not found")?;
 
         let id = Uuid::new_v4();
         let now = Utc::now();
@@ -1825,11 +1961,7 @@ impl Db {
         } else {
             None
         };
-        let resolved_at = if auto {
-            Some(now.to_rfc3339())
-        } else {
-            None
-        };
+        let resolved_at = if auto { Some(now.to_rfc3339()) } else { None };
         let allowed = serde_json::to_string(&req.allowed_decisions)?;
         let payload = serde_json::to_string(&req.payload)?;
 
@@ -2018,10 +2150,7 @@ impl Db {
         idempotency_key: &str,
         result: serde_json::Value,
     ) -> Result<serde_json::Value> {
-        let run = self
-            .get_run(run_id)
-            .await?
-            .context("run not found")?;
+        let run = self.get_run(run_id).await?.context("run not found")?;
         let id = Uuid::new_v4();
         let now = Utc::now();
         sqlx::query(
@@ -2157,6 +2286,29 @@ impl RunRow {
             archived_at: self.archived_at.as_deref().map(parse_time),
         }
     }
+}
+
+fn is_valid_email(email: &str) -> bool {
+    let Some((local, domain)) = email.split_once('@') else {
+        return false;
+    };
+    !local.is_empty()
+        && domain.contains('.')
+        && !domain.starts_with('.')
+        && !domain.ends_with('.')
+        && email.len() <= 254
+        && email
+            .chars()
+            .all(|c| c.is_ascii() && !c.is_ascii_whitespace())
+}
+
+fn display_name_from_email(email: &str) -> String {
+    email
+        .split_once('@')
+        .map(|(local, _)| local.trim())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("User")
+        .to_string()
 }
 
 fn hash_password(password: &str) -> Result<String> {
@@ -2296,7 +2448,8 @@ pub(crate) fn map_approval_full_row(
     }
 }
 
-const RUN_COLUMNS: &str = "id, organization_id, repository_id, requested_by, status, status_version,
+const RUN_COLUMNS: &str =
+    "id, organization_id, repository_id, requested_by, status, status_version,
     title, prompt, base_ref, base_sha, head_branch, head_sha, model, permission_mode, max_turns,
     created_at, started_at, finished_at, archived_at";
 

--- a/cloud/crates/db/tests/smoke.rs
+++ b/cloud/crates/db/tests/smoke.rs
@@ -12,7 +12,9 @@ use zene_cloud_domain::{
 async fn register_create_run_and_claim() {
     let db = Db::connect("sqlite::memory:").await.unwrap();
     db.migrate().await.unwrap();
-    db.ensure_dev_worker_token("dev-worker-token").await.unwrap();
+    db.ensure_dev_worker_token("dev-worker-token")
+        .await
+        .unwrap();
 
     let auth = db
         .register(RegisterRequest {
@@ -118,14 +120,24 @@ async fn register_create_run_and_claim() {
 
     let mut stale = fence.clone();
     stale.generation += 1;
-    assert!(db.heartbeat_fenced(run.id, &stale).await.unwrap_err().to_string().contains("stale_attempt"));
-    assert!(db.append_event_fenced(
-        run.id,
-        &stale,
-        Some("stale-event"),
-        RunEventKind::Runtime,
-        serde_json::json!({}),
-    ).await.unwrap_err().to_string().contains("stale_attempt"));
+    assert!(db
+        .heartbeat_fenced(run.id, &stale)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("stale_attempt"));
+    assert!(db
+        .append_event_fenced(
+            run.id,
+            &stale,
+            Some("stale-event"),
+            RunEventKind::Runtime,
+            serde_json::json!({}),
+        )
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("stale_attempt"));
     assert!(db
         .set_runtime_session_id_fenced(run.id, &stale, "stale-session")
         .await
@@ -142,14 +154,9 @@ async fn register_create_run_and_claim() {
     )
     .await
     .unwrap();
-    db.update_run_status(
-        run.id,
-        zene_cloud_domain::RunStatus::Queued,
-        None,
-        None,
-    )
-    .await
-    .unwrap();
+    db.update_run_status(run.id, zene_cloud_domain::RunStatus::Queued, None, None)
+        .await
+        .unwrap();
     let reclaimed = db
         .claim_next_run("worker-2", std::path::Path::new("/tmp/zc-workspaces"))
         .await
@@ -282,16 +289,27 @@ async fn run_state_mutations_have_matching_events() {
     assert!(updated.finished_at.is_some());
 
     let message = db
-        .add_message(run.id, Some(auth.user.id), MessageRole::User, "follow-up", None)
+        .add_message(
+            run.id,
+            Some(auth.user.id),
+            MessageRole::User,
+            "follow-up",
+            None,
+        )
         .await
         .unwrap();
-    assert_eq!(db.get_run(run.id).await.unwrap().unwrap().status, RunStatus::Queued);
+    assert_eq!(
+        db.get_run(run.id).await.unwrap().unwrap().status,
+        RunStatus::Queued
+    );
 
     let events = db.events_after(run.id, 0).await.unwrap();
     assert!(events.iter().any(|event| {
         event.payload["event"] == "run.title" && event.payload["title"] == "Renamed"
     }));
-    assert!(events.iter().any(|event| event.payload["event"] == "run.archived"));
+    assert!(events
+        .iter()
+        .any(|event| event.payload["event"] == "run.archived"));
     assert!(events.iter().any(|event| {
         event.payload["event"] == "message.created" && event.payload["text"] == "follow-up"
     }));
@@ -413,7 +431,10 @@ async fn concurrent_approval_decisions_have_one_winner_event() {
 
     assert_eq!(left.status, right.status);
     assert_eq!(left.decision, right.decision);
-    assert!(matches!(left.status, ApprovalStatus::Approved | ApprovalStatus::Denied));
+    assert!(matches!(
+        left.status,
+        ApprovalStatus::Approved | ApprovalStatus::Denied
+    ));
     let events = db.events_after(run_id, 0).await.unwrap();
     assert_eq!(
         events
@@ -437,78 +458,211 @@ async fn worker_command_is_retried_until_fenced_ack() {
         .await
         .unwrap();
     let repo = db
-        .create_repository(auth.organization.id, CreateRepositoryRequest {
-            owner: "test".into(), name: "delivery".into(), default_branch: "main".into(), clone_url: None,
-        })
+        .create_repository(
+            auth.organization.id,
+            CreateRepositoryRequest {
+                owner: "test".into(),
+                name: "delivery".into(),
+                default_branch: "main".into(),
+                clone_url: None,
+            },
+        )
         .await
         .unwrap();
-    let run = db.create_run(auth.organization.id, auth.user.id, CreateRunRequest {
-        repository_id: repo.id, prompt: "initial".into(), base_ref: None, model: "default".into(),
-        permission_mode: PermissionMode::Default, max_turns: 10, mode_id: None,
-    }).await.unwrap();
-    let claimed = db.claim_next_run("worker-delivery", std::path::Path::new("/tmp/zc-workspaces"))
-        .await.unwrap().unwrap();
-    let fence = WorkerFence { attempt_id: claimed.1, generation: claimed.2, worker_id: "worker-delivery".into() };
-    let message = db.add_message(run.id, Some(auth.user.id), MessageRole::User, "follow-up", None).await.unwrap();
-    let commands = db.poll_worker_commands_fenced(run.id, &fence).await.unwrap();
-    assert_eq!(commands.iter().filter_map(|command| command.message_id).collect::<Vec<_>>(), vec![message.id]);
-    assert!(commands.iter().all(|command| command.kind == WorkerCommandKind::Prompt));
-    assert!(db.poll_worker_commands_fenced(run.id, &fence).await.unwrap().iter().all(|command| command.message_id != Some(message.id)));
+    let run = db
+        .create_run(
+            auth.organization.id,
+            auth.user.id,
+            CreateRunRequest {
+                repository_id: repo.id,
+                prompt: "initial".into(),
+                base_ref: None,
+                model: "default".into(),
+                permission_mode: PermissionMode::Default,
+                max_turns: 10,
+                mode_id: None,
+            },
+        )
+        .await
+        .unwrap();
+    let claimed = db
+        .claim_next_run(
+            "worker-delivery",
+            std::path::Path::new("/tmp/zc-workspaces"),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    let fence = WorkerFence {
+        attempt_id: claimed.1,
+        generation: claimed.2,
+        worker_id: "worker-delivery".into(),
+    };
+    let message = db
+        .add_message(
+            run.id,
+            Some(auth.user.id),
+            MessageRole::User,
+            "follow-up",
+            None,
+        )
+        .await
+        .unwrap();
+    let commands = db
+        .poll_worker_commands_fenced(run.id, &fence)
+        .await
+        .unwrap();
+    assert_eq!(
+        commands
+            .iter()
+            .filter_map(|command| command.message_id)
+            .collect::<Vec<_>>(),
+        vec![message.id]
+    );
+    assert!(commands
+        .iter()
+        .all(|command| command.kind == WorkerCommandKind::Prompt));
+    assert!(db
+        .poll_worker_commands_fenced(run.id, &fence)
+        .await
+        .unwrap()
+        .iter()
+        .all(|command| command.message_id != Some(message.id)));
     let mut stale_fence = fence.clone();
     stale_fence.generation += 1;
-    assert!(db.ack_worker_command_fenced(run.id, &stale_fence, message.id).await.unwrap_err().to_string().contains("stale_attempt"));
-    db.ack_worker_command_fenced(run.id, &fence, message.id).await.unwrap();
-    assert!(db.poll_worker_commands_fenced(run.id, &fence).await.unwrap().iter().all(|command| command.message_id != Some(message.id)));
+    assert!(db
+        .ack_worker_command_fenced(run.id, &stale_fence, message.id)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("stale_attempt"));
+    db.ack_worker_command_fenced(run.id, &fence, message.id)
+        .await
+        .unwrap();
+    assert!(db
+        .poll_worker_commands_fenced(run.id, &fence)
+        .await
+        .unwrap()
+        .iter()
+        .all(|command| command.message_id != Some(message.id)));
 
-    let message = db.add_message(run.id, Some(auth.user.id), MessageRole::User, "retry me", None).await.unwrap();
+    let message = db
+        .add_message(
+            run.id,
+            Some(auth.user.id),
+            MessageRole::User,
+            "retry me",
+            None,
+        )
+        .await
+        .unwrap();
     let first_claim = chrono::Utc::now();
-    let _ = db.poll_worker_commands_fenced_at(run.id, &fence, first_claim).await.unwrap();
-    let retry = db.poll_worker_commands_fenced_at(
-        run.id,
-        &fence,
-        first_claim + chrono::Duration::seconds(61),
-    ).await.unwrap();
-    assert!(retry.iter().any(|command| command.message_id == Some(message.id)));
+    let _ = db
+        .poll_worker_commands_fenced_at(run.id, &fence, first_claim)
+        .await
+        .unwrap();
+    let retry = db
+        .poll_worker_commands_fenced_at(run.id, &fence, first_claim + chrono::Duration::seconds(61))
+        .await
+        .unwrap();
+    assert!(retry
+        .iter()
+        .any(|command| command.message_id == Some(message.id)));
 }
 
 #[tokio::test]
 async fn stale_waiting_for_user_attempt_is_requeued_but_approval_holds_are_not() {
     async fn make_run(db: &Db, suffix: &str) -> (zene_cloud_domain::Run, WorkerFence) {
-        let auth = db.register(RegisterRequest {
-            email: format!("{}-{}@example.com", suffix, Uuid::new_v4()),
-            password: "password123".into(), display_name: suffix.into(),
-        }).await.unwrap();
-        let repo = db.create_repository(auth.organization.id, CreateRepositoryRequest {
-            owner: suffix.into(), name: suffix.into(), default_branch: "main".into(), clone_url: None,
-        }).await.unwrap();
-        let run = db.create_run(auth.organization.id, auth.user.id, CreateRunRequest {
-            repository_id: repo.id, prompt: suffix.into(), base_ref: None, model: "default".into(),
-            permission_mode: PermissionMode::Default, max_turns: 10, mode_id: None,
-        }).await.unwrap();
-        let claimed = db.claim_next_run("stale-policy-worker", std::path::Path::new("/tmp/zc-workspaces"))
-            .await.unwrap().unwrap();
-        let fence = WorkerFence { attempt_id: claimed.1, generation: claimed.2, worker_id: "stale-policy-worker".into() };
+        let auth = db
+            .register(RegisterRequest {
+                email: format!("{}-{}@example.com", suffix, Uuid::new_v4()),
+                password: "password123".into(),
+                display_name: suffix.into(),
+            })
+            .await
+            .unwrap();
+        let repo = db
+            .create_repository(
+                auth.organization.id,
+                CreateRepositoryRequest {
+                    owner: suffix.into(),
+                    name: suffix.into(),
+                    default_branch: "main".into(),
+                    clone_url: None,
+                },
+            )
+            .await
+            .unwrap();
+        let run = db
+            .create_run(
+                auth.organization.id,
+                auth.user.id,
+                CreateRunRequest {
+                    repository_id: repo.id,
+                    prompt: suffix.into(),
+                    base_ref: None,
+                    model: "default".into(),
+                    permission_mode: PermissionMode::Default,
+                    max_turns: 10,
+                    mode_id: None,
+                },
+            )
+            .await
+            .unwrap();
+        let claimed = db
+            .claim_next_run(
+                "stale-policy-worker",
+                std::path::Path::new("/tmp/zc-workspaces"),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        let fence = WorkerFence {
+            attempt_id: claimed.1,
+            generation: claimed.2,
+            worker_id: "stale-policy-worker".into(),
+        };
         (run, fence)
     }
 
     let db = Db::connect("sqlite::memory:").await.unwrap();
     db.migrate().await.unwrap();
     let (user_run, user_fence) = make_run(&db, "user-hold").await;
-    db.update_run_status_fenced(user_run.id, &user_fence, RunStatus::WaitingForUser, None, None).await.unwrap();
+    db.update_run_status_fenced(
+        user_run.id,
+        &user_fence,
+        RunStatus::WaitingForUser,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
     let (approval_run, approval_fence) = make_run(&db, "approval-hold").await;
-    db.update_run_status_fenced(approval_run.id, &approval_fence, RunStatus::WaitingForApproval, None, None).await.unwrap();
+    db.update_run_status_fenced(
+        approval_run.id,
+        &approval_fence,
+        RunStatus::WaitingForApproval,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
     // Lease is WORKER_LEASE_SECS with RECLAIM_GRACE_SECS grace before reclaim.
     assert_eq!(
-        db.reclaim_stale_runs_at(
-            chrono::Utc::now() + chrono::Duration::seconds(180 + 60 + 1)
-        )
+        db.reclaim_stale_runs_at(chrono::Utc::now() + chrono::Duration::seconds(180 + 60 + 1))
             .await
             .unwrap(),
         1
     );
-    assert_eq!(db.get_run(user_run.id).await.unwrap().unwrap().status, RunStatus::Queued);
-    assert_eq!(db.get_run(approval_run.id).await.unwrap().unwrap().status, RunStatus::WaitingForApproval);
+    assert_eq!(
+        db.get_run(user_run.id).await.unwrap().unwrap().status,
+        RunStatus::Queued
+    );
+    assert_eq!(
+        db.get_run(approval_run.id).await.unwrap().unwrap().status,
+        RunStatus::WaitingForApproval
+    );
     // Approval lifecycle remains deliberately outside this durability slice.
 }
 
@@ -609,7 +763,10 @@ async fn worker_title_is_fenced_and_retry_idempotent() {
     db.update_run_title_fenced(run.id, &second_fence, "Replacement title")
         .await
         .unwrap();
-    assert_eq!(db.get_run(run.id).await.unwrap().unwrap().title, "Replacement title");
+    assert_eq!(
+        db.get_run(run.id).await.unwrap().unwrap().title,
+        "Replacement title"
+    );
 }
 
 #[tokio::test]
@@ -640,7 +797,6 @@ async fn event_cursor_migration_retries_after_partial_ddl() {
 
     db.migrate().await.unwrap();
 }
-
 
 #[tokio::test]
 async fn register_same_display_name_gets_unique_org_slug() {
@@ -711,7 +867,10 @@ async fn pending_mode_is_queued_and_taken_once() {
     assert_eq!(taken.as_deref(), Some("plan"));
     assert_eq!(db.take_pending_mode(run.id).await.unwrap(), None);
     db.set_pending_mode(run.id, "default").await.unwrap();
-    assert_eq!(db.take_pending_mode(run.id).await.unwrap().as_deref(), Some("default"));
+    assert_eq!(
+        db.take_pending_mode(run.id).await.unwrap().as_deref(),
+        Some("default")
+    );
 }
 
 #[tokio::test]
@@ -764,9 +923,15 @@ async fn worker_requeue_clears_terminal_state_and_preserves_history() {
         generation: claimed.2,
         worker_id: "requeue-worker".into(),
     };
-    db.add_message(run.id, Some(auth.user.id), MessageRole::User, "follow-up", None)
-        .await
-        .unwrap();
+    db.add_message(
+        run.id,
+        Some(auth.user.id),
+        MessageRole::User,
+        "follow-up",
+        None,
+    )
+    .await
+    .unwrap();
     db.append_event(
         run.id,
         fence.generation,
@@ -842,7 +1007,11 @@ async fn clone_credentials_are_cached_for_reclaim() {
         mock: false,
     };
     db.store_clone_credentials(&auth_response).await.unwrap();
-    let cached = db.get_cached_clone_credentials(run.id).await.unwrap().unwrap();
+    let cached = db
+        .get_cached_clone_credentials(run.id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(cached.token.as_deref(), Some("ghs_cached"));
 }
 
@@ -911,4 +1080,31 @@ async fn user_retry_requeues_failed_run_and_resumes_without_prompt() {
     assert_eq!(replacement.0.status, RunStatus::Provisioning);
     assert_eq!(replacement.3.as_deref(), Some("runtime-session-retry"));
     assert!(replacement.5);
+}
+
+#[tokio::test]
+async fn email_login_creates_user_then_signs_in_existing() {
+    let db = Db::connect("sqlite::memory:").await.unwrap();
+    db.migrate().await.unwrap();
+    let email = format!("email-login-{}@example.com", Uuid::new_v4());
+
+    let token = db.create_email_login_token(&email).await.unwrap();
+    let auth = db.consume_email_login_token(&token).await.unwrap();
+    assert_eq!(auth.user.email, email);
+    assert!(db.consume_email_login_token(&token).await.is_err());
+
+    let token2 = db.create_email_login_token(&email).await.unwrap();
+    let auth2 = db.consume_email_login_token(&token2).await.unwrap();
+    assert_eq!(auth2.user.id, auth.user.id);
+    assert_eq!(auth2.organization.id, auth.organization.id);
+}
+
+#[tokio::test]
+async fn email_login_rejects_invalid_and_rate_limits() {
+    let db = Db::connect("sqlite::memory:").await.unwrap();
+    db.migrate().await.unwrap();
+    assert!(db.create_email_login_token("not-an-email").await.is_err());
+    let email = format!("rate-{}@example.com", Uuid::new_v4());
+    db.create_email_login_token(&email).await.unwrap();
+    assert!(db.create_email_login_token(&email).await.is_err());
 }

--- a/cloud/crates/domain/src/lib.rs
+++ b/cloud/crates/domain/src/lib.rs
@@ -109,10 +109,7 @@ impl RunStatus {
     }
 
     pub fn is_terminal(self) -> bool {
-        matches!(
-            self,
-            Self::Failed | Self::TimedOut | Self::Cancelled
-        )
+        matches!(self, Self::Failed | Self::TimedOut | Self::Cancelled)
     }
 }
 
@@ -738,6 +735,20 @@ pub struct LoginRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct EmailLoginRequest {
+    pub email: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EmailLoginResponse {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub login_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AuthResponse {
     pub token: String,
     pub user: User,
@@ -835,11 +846,10 @@ mod tests {
     use super::{
         ApprovalDecision, ApprovalEventPayload, ApprovalKind, ApprovalRisk, ApprovalStatus,
         CloudEventKind, CreateApprovalRequest, GithubAccountType, GithubInstallationStatus,
-        GithubMode, MessageRole, PlatformEvent, PermissionMode, ProjectionPayload,
-        PullRequestState,
-        RunEventKind, RunStatus, TextEventPayload, ToolCallPayload, WorkerCommand,
-        WorkerCommandAckRequest, WorkerCommandKind, WorkerEventRequest, WorkerFence,
-        WorkerClaimRequest, WorkerPushRequest, WorkerSessionRequest,
+        GithubMode, MessageRole, PermissionMode, PlatformEvent, ProjectionPayload,
+        PullRequestState, RunEventKind, RunStatus, TextEventPayload, ToolCallPayload,
+        WorkerClaimRequest, WorkerCommand, WorkerCommandAckRequest, WorkerCommandKind,
+        WorkerEventRequest, WorkerFence, WorkerPushRequest, WorkerSessionRequest,
     };
 
     #[test]
@@ -939,7 +949,8 @@ mod tests {
         assert_eq!(encoded["text"], "hello");
         assert_eq!(encoded["messageId"], uuid::Uuid::nil().to_string());
 
-        let parsed: WorkerCommand = serde_json::from_value(encoded).expect("prompt should deserialize");
+        let parsed: WorkerCommand =
+            serde_json::from_value(encoded).expect("prompt should deserialize");
         assert_eq!(parsed.kind, WorkerCommandKind::Prompt);
         assert_eq!(parsed.text.as_deref(), Some("hello"));
 
@@ -949,7 +960,8 @@ mod tests {
         assert!(encoded["text"].is_null());
         assert!(encoded["messageId"].is_null());
 
-        let parsed: WorkerCommand = serde_json::from_value(encoded).expect("cancel should deserialize");
+        let parsed: WorkerCommand =
+            serde_json::from_value(encoded).expect("cancel should deserialize");
         assert_eq!(parsed.kind, WorkerCommandKind::Cancel);
     }
 
@@ -1127,14 +1139,23 @@ mod tests {
         }
         assert_eq!(CloudEventKind::parse("platform"), None);
         assert_eq!(CloudEventKind::parse("runtime"), None);
-        assert_eq!(RunEventKind::parse("platform"), Some(RunEventKind::Platform));
+        assert_eq!(
+            RunEventKind::parse("platform"),
+            Some(RunEventKind::Platform)
+        );
         assert_eq!(RunEventKind::parse("runtime"), Some(RunEventKind::Runtime));
-        assert_eq!(RunEventKind::parse("text_delta"), Some(RunEventKind::TextDelta));
+        assert_eq!(
+            RunEventKind::parse("text_delta"),
+            Some(RunEventKind::TextDelta)
+        );
         assert_eq!(
             RunEventKind::from(CloudEventKind::ToolCall).as_event_type(),
             "tool_call"
         );
-        assert_eq!(serde_json::to_value(RunEventKind::Platform).expect("platform"), serde_json::json!("platform"));
+        assert_eq!(
+            serde_json::to_value(RunEventKind::Platform).expect("platform"),
+            serde_json::json!("platform")
+        );
         assert_eq!(RunEventKind::parse("not-a-kind"), None);
     }
 

--- a/cloud/deploy/env.example
+++ b/cloud/deploy/env.example
@@ -36,6 +36,10 @@ ZENE_CLOUD_WORKER_SCALE_INTERVAL_MS=1000
 # ZENE_BASE_URL=
 # ZENE_MODEL=
 
+# Email sign-in (Resend). Domain on RESEND_FROM must be verified.
+# RESEND_API_KEY=re_...
+# RESEND_FROM=Zene <noreply@zene.run>
+
 # GitHub App (live mode)
 # GITHUB_APP_ID=
 # GITHUB_APP_SLUG=

--- a/cloud/email.env.example
+++ b/cloud/email.env.example
@@ -1,0 +1,7 @@
+# Copy to email.env. Used by cloud/scripts/dev.sh.
+# Get an API key at https://resend.com. Verify the from-domain first.
+# Until zene.run is verified, you can send from Resend's test address:
+
+export RESEND_API_KEY=re_...
+export RESEND_FROM="Zene <beth.t@example.com>"
+# export RESEND_FROM="Zene <noreply@zene.run>"

--- a/cloud/github.env.example
+++ b/cloud/github.env.example
@@ -8,3 +8,7 @@ export GITHUB_APP_PRIVATE_KEY_PATH="$HOME/.zene/github-app.pem"
 # Optional OAuth (Connect flow uses GitHub App install only)
 # export GITHUB_CLIENT_ID=
 # export GITHUB_CLIENT_SECRET=
+
+# Email sign-in (Resend). Without RESEND_API_KEY, the landing page shows the link locally.
+# export RESEND_API_KEY=re_...
+# export RESEND_FROM="Zene <noreply@zene.run>"

--- a/cloud/migrations/013_email_login.sql
+++ b/cloud/migrations/013_email_login.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS email_login_tokens (
+    id TEXT PRIMARY KEY NOT NULL,
+    email TEXT NOT NULL,
+    token_hash TEXT NOT NULL UNIQUE,
+    expires_at TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    consumed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_login_tokens_email
+    ON email_login_tokens(email);

--- a/cloud/scripts/dev.sh
+++ b/cloud/scripts/dev.sh
@@ -15,6 +15,14 @@ if [[ -f "$ROOT/github.env" ]]; then
   set +a
 fi
 
+# Optional Resend credentials for email sign-in.
+if [[ -f "$ROOT/email.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "$ROOT/email.env"
+  set +a
+fi
+
 export ZENE_CLOUD_DATABASE_URL="${ZENE_CLOUD_DATABASE_URL:-sqlite:$ROOT/data/zene-cloud.db}"
 export ZENE_CLOUD_WORKER_TOKEN="${ZENE_CLOUD_WORKER_TOKEN:-dev-worker-token}"
 export ZENE_CLOUD_WEB_DIR="${ZENE_CLOUD_WEB_DIR:-$ROOT/apps/web/dist}"


### PR DESCRIPTION
## Summary
- Replace the password register card with a short Zene intro and a single email field.
- Send a one-time sign-in link via Resend (`RESEND_API_KEY` / `RESEND_FROM`); opening the link creates the account or signs in.
- When Resend is unset, the landing page shows the local sign-in URL so development still works.

## Test plan
- [ ] Open the unauthenticated Console and confirm the intro + email form (no password fields).
- [ ] With `RESEND_API_KEY` unset, request a link and open the local sign-in URL to enter Console.
- [ ] With Resend configured, receive the email, open the link, and land in Console as a new user.
- [ ] Request a second link for the same email and confirm it signs into the existing account.
- [ ] Open an expired or reused link and confirm the invalid-link toast.


Made with [Cursor](https://cursor.com)