### PR TITLE
fix(cloud): improve GitHub PR creation flow and dialog UX

### DIFF
--- a/cloud/apps/web/components/CodePanel.tsx
+++ b/cloud/apps/web/components/CodePanel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
-import type { PullRequest, WorkspaceFile } from "@/lib/types";
+import type { GitCompare, PullRequest, WorkspaceFile } from "@/lib/types";
 import {
   IconChevronsCollapse,
   IconChevronsExpand,
@@ -18,7 +18,7 @@ import { GitPanel } from "./GitPanel";
 import { CodeViewer } from "./CodeViewer";
 import { Markdown } from "./Markdown";
 import { CodePanelToggle } from "./PanelToggleButton";
-import { PrPanel } from "./PrPanel";
+import { PullRequestDialog } from "./PullRequestDialog";
 import { useToast } from "./Toast";
 
 function isMarkdownPath(path: string): boolean {
@@ -147,6 +147,7 @@ interface CodePanelProps {
   defaultPrTitle?: string;
   defaultBaseRef?: string;
   headBranch?: string;
+  gitCompare?: GitCompare | null;
   width: number;
   onWidthChange: (w: number) => void;
   /** When true, panel fills remaining width after the chat column; hide the drag handle. */
@@ -161,6 +162,7 @@ export function CodePanel({
   defaultPrTitle,
   defaultBaseRef,
   headBranch,
+  gitCompare,
   width,
   onWidthChange,
   equalSplit = false,
@@ -287,6 +289,7 @@ export function CodePanel({
         title: defaultPrTitle?.trim() || "Changes from Zene Cloud",
         baseRef: defaultBaseRef,
         headBranch,
+        compare: gitCompare,
         draft: true,
       });
       await loadPrs();
@@ -477,47 +480,19 @@ export function CodePanel({
           </div>
         )}
       </div>
-      {prModalOpen && (
-        <div
-          className="absolute inset-0 z-40 flex items-end justify-center bg-black/40 p-3 min-[981px]:items-center"
-          role="presentation"
-          onClick={() => {
-            setPrModalOpen(false);
-            loadPrs();
-          }}
-        >
-          <div
-            className="flex max-h-[90%] w-full max-w-md flex-col overflow-hidden rounded-md bg-canvas shadow-card"
-            role="dialog"
-            aria-modal="true"
-            aria-label="Create pull request"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex items-center justify-between gap-2 border-b border-line px-3 py-2">
-              <div className="text-[13px] font-semibold text-ink">Create pull request</div>
-              <button
-                type="button"
-                className="btn btn-sm"
-                onClick={() => {
-                  setPrModalOpen(false);
-                  loadPrs();
-                }}
-              >
-                Close
-              </button>
-            </div>
-            <div className="min-h-0 flex-1 overflow-auto">
-              <PrPanel
-                runId={runId}
-                defaultTitle={defaultPrTitle}
-                defaultBaseRef={defaultBaseRef}
-                headBranch={headBranch}
-                compact
-              />
-            </div>
-          </div>
-        </div>
-      )}
+      <PullRequestDialog
+        open={prModalOpen}
+        onClose={() => {
+          setPrModalOpen(false);
+          loadPrs();
+        }}
+        runId={runId}
+        defaultTitle={defaultPrTitle}
+        defaultBaseRef={defaultBaseRef}
+        headBranch={headBranch}
+        compare={gitCompare}
+        onSuccess={loadPrs}
+      />
     </aside>
   );
 }

--- a/cloud/apps/web/components/PrPanel.tsx
+++ b/cloud/apps/web/components/PrPanel.tsx
@@ -2,7 +2,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { createRunPullRequest, fetchRunPullRequests, publishRunToGithub } from "@/lib/gitPublish";
-import type { PullRequest } from "@/lib/types";
+import { buildDefaultPrBody } from "@/lib/prBody";
+import type { GitCompare, PullRequest } from "@/lib/types";
 import { IconExternal, IconRefresh } from "@/lib/icons";
 import { useToast } from "./Toast";
 
@@ -11,22 +12,26 @@ export function PrPanel({
   defaultTitle,
   defaultBaseRef,
   headBranch,
-  compact,
+  compare,
+  dialog,
+  onSuccess,
 }: {
   runId: string;
   defaultTitle?: string;
   defaultBaseRef?: string;
   headBranch?: string;
-  compact?: boolean;
+  compare?: GitCompare | null;
+  /** Submit-only layout for the create-PR dialog. */
+  dialog?: boolean;
+  onSuccess?: () => void;
 }) {
   const toast = useToast();
   const [prs, setPrs] = useState<PullRequest[]>([]);
   const [error, setError] = useState("");
-  const [prBusy, setPrBusy] = useState(false);
-  const [pushBusy, setPushBusy] = useState(false);
+  const [busy, setBusy] = useState(false);
 
   const [title, setTitle] = useState(defaultTitle || "");
-  const [body, setBody] = useState("");
+  const [body, setBody] = useState(() => buildDefaultPrBody(compare));
   const [draft, setDraft] = useState(true);
   const [baseRef, setBaseRef] = useState(defaultBaseRef || "");
 
@@ -38,6 +43,11 @@ export function PrPanel({
     if (defaultBaseRef) setBaseRef((b) => b || defaultBaseRef);
   }, [defaultBaseRef]);
 
+  useEffect(() => {
+    const generated = buildDefaultPrBody(compare);
+    if (generated) setBody((b) => b || generated);
+  }, [compare]);
+
   const loadPrs = useCallback(async () => {
     setError("");
     try {
@@ -48,18 +58,24 @@ export function PrPanel({
   }, [runId]);
 
   useEffect(() => {
-    loadPrs();
-  }, [loadPrs]);
+    if (!dialog) loadPrs();
+  }, [dialog, loadPrs]);
 
-  const pushBranch = useCallback(async () => {
+  const publish = useCallback(async () => {
+    const t = title.trim();
+    if (!t) {
+      toast("Title is required", "error");
+      return;
+    }
     setError("");
-    setPushBusy(true);
+    setBusy(true);
     try {
       const result = await publishRunToGithub(runId, {
-        title: title.trim() || defaultTitle || "Changes from Zene Cloud",
+        title: t,
         baseRef: baseRef.trim() || defaultBaseRef,
         headBranch,
         body: body.trim() || undefined,
+        compare,
         draft,
       });
       toast(
@@ -68,15 +84,29 @@ export function PrPanel({
           : `Pushed · ${result.push.headSha || result.push.pushUrl || "ok"}`,
         "ok",
       );
-      await loadPrs();
+      if (!dialog) await loadPrs();
+      onSuccess?.();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       setError(msg);
       toast(msg, "error");
     } finally {
-      setPushBusy(false);
+      setBusy(false);
     }
-  }, [runId, title, defaultTitle, baseRef, defaultBaseRef, headBranch, body, draft, loadPrs, toast]);
+  }, [
+    runId,
+    title,
+    defaultBaseRef,
+    baseRef,
+    headBranch,
+    body,
+    compare,
+    draft,
+    dialog,
+    loadPrs,
+    onSuccess,
+    toast,
+  ]);
 
   const createPr = useCallback(async () => {
     const t = title.trim();
@@ -85,11 +115,11 @@ export function PrPanel({
       return;
     }
     setError("");
-    setPrBusy(true);
+    setBusy(true);
     try {
       await createRunPullRequest(runId, {
         title: t,
-        body: body.trim() || undefined,
+        body: body.trim() || buildDefaultPrBody(compare) || undefined,
         draft,
         baseRef: baseRef.trim() || undefined,
         headBranch: headBranch || undefined,
@@ -101,15 +131,15 @@ export function PrPanel({
       setError(msg);
       toast(msg, "error");
     } finally {
-      setPrBusy(false);
+      setBusy(false);
     }
-  }, [runId, title, body, draft, baseRef, headBranch, loadPrs, toast]);
+  }, [runId, title, body, compare, draft, baseRef, headBranch, loadPrs, toast]);
 
   return (
-    <div className={`flex h-full min-h-0 flex-col overflow-auto ${compact ? "px-3 pb-3 pt-2" : "px-4 pb-5 pt-3.5"}`}>
-      {!compact && <h3 className="panel-title">Create pull request</h3>}
+    <div className={`flex h-full min-h-0 flex-col overflow-auto ${dialog ? "px-4 pb-4 pt-3" : "px-4 pb-5 pt-3.5"}`}>
+      {!dialog && <h3 className="panel-title">Create pull request</h3>}
       {headBranch && (
-        <div className={`font-mono text-[11px] text-muted ${compact ? "mb-2" : "mb-3"}`}>
+        <div className={`font-mono text-[11px] text-muted ${dialog ? "mb-2" : "mb-3"}`}>
           {headBranch} → {baseRef || "main"}
         </div>
       )}
@@ -122,7 +152,7 @@ export function PrPanel({
       />
       <label className="mb-1 block text-[11px] font-medium uppercase tracking-wider text-muted">Body</label>
       <textarea
-        className="field-input mb-3 min-h-[88px] resize-y"
+        className="field-input mb-3 min-h-[120px] resize-y"
         value={body}
         onChange={(e) => setBody(e.target.value)}
         placeholder="Describe the changes…"
@@ -134,62 +164,69 @@ export function PrPanel({
         onChange={(e) => setBaseRef(e.target.value)}
         placeholder="main"
       />
-      <label className="mb-4 flex items-center gap-2 text-[13px] text-ink">
+      <label className={`flex items-center gap-2 text-[13px] text-ink ${dialog ? "mb-4" : "mb-4"}`}>
         <input type="checkbox" checked={draft} onChange={(e) => setDraft(e.target.checked)} />
         Create as draft
       </label>
-      <div className="mb-4 flex flex-wrap gap-2">
-        <button type="button" className="btn btn-primary btn-sm" disabled={prBusy} onClick={createPr}>
-          Create PR
+      <div className={`flex flex-wrap gap-2 ${dialog ? "" : "mb-4"}`}>
+        <button type="button" className="btn btn-primary btn-sm" disabled={busy} onClick={publish}>
+          {busy ? "Creating…" : dialog ? "Create pull request" : "Push & create PR"}
         </button>
-        <button type="button" className="btn btn-sm" disabled={pushBusy} onClick={pushBranch}>
-          Push
-        </button>
-        <button type="button" className="btn btn-sm" onClick={loadPrs} title="Refresh" aria-label="Refresh PRs">
-          <IconRefresh className="h-3.5 w-3.5" />
-        </button>
+        {!dialog && (
+          <>
+            <button type="button" className="btn btn-sm" disabled={busy} onClick={createPr}>
+              Create PR only
+            </button>
+            <button type="button" className="btn btn-sm" onClick={loadPrs} title="Refresh" aria-label="Refresh PRs">
+              <IconRefresh className="h-3.5 w-3.5" />
+            </button>
+          </>
+        )}
       </div>
 
-      {!compact && <h3 className="panel-title">Pull requests</h3>}
-      {compact && <div className="mb-2 text-[11px] font-medium uppercase tracking-wider text-muted">Pull requests</div>}
-      <div>
-        {prs.map((pr, i) => (
-          <div key={i} className="mb-2.5 rounded-lg border border-line bg-canvas p-3">
-            <div className="mb-1 flex items-start justify-between gap-2 text-[13px] font-semibold">
-              {pr.url ? (
-                <a
-                  className="text-ink underline underline-offset-2 hover:text-muted"
-                  href={pr.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {pr.title}
-                </a>
-              ) : (
-                <span>{pr.title}</span>
-              )}
-              {pr.url && (
-                <a
-                  href={pr.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="shrink-0 text-muted hover:text-ink"
-                  aria-label="Open on GitHub"
-                  title="Open on GitHub"
-                >
-                  <IconExternal className="h-3.5 w-3.5" />
-                </a>
-              )}
-            </div>
-            <div className="font-mono text-[11px] text-muted">
-              #{pr.providerNumber ?? "—"} · {pr.state}
-              {pr.draft ? " · draft" : ""}
-            </div>
+      {!dialog && (
+        <>
+          <h3 className="panel-title">Pull requests</h3>
+          <div>
+            {prs.map((pr, i) => (
+              <div key={i} className="mb-2.5 rounded-lg border border-line bg-canvas p-3">
+                <div className="mb-1 flex items-start justify-between gap-2 text-[13px] font-semibold">
+                  {pr.url ? (
+                    <a
+                      className="text-ink underline underline-offset-2 hover:text-muted"
+                      href={pr.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {pr.title}
+                    </a>
+                  ) : (
+                    <span>{pr.title}</span>
+                  )}
+                  {pr.url && (
+                    <a
+                      href={pr.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="shrink-0 text-muted hover:text-ink"
+                      aria-label="Open on GitHub"
+                      title="Open on GitHub"
+                    >
+                      <IconExternal className="h-3.5 w-3.5" />
+                    </a>
+                  )}
+                </div>
+                <div className="font-mono text-[11px] text-muted">
+                  #{pr.providerNumber ?? "—"} · {pr.state}
+                  {pr.draft ? " · draft" : ""}
+                </div>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
-      {!prs.length && !error && (
-        <div className="py-3 text-[13px] leading-normal text-placeholder">No pull requests yet.</div>
+          {!prs.length && !error && (
+            <div className="py-3 text-[13px] leading-normal text-placeholder">No pull requests yet.</div>
+          )}
+        </>
       )}
       {error && <div className="mt-2.5 text-[13px] leading-snug text-danger">{error}</div>}
     </div>

--- a/cloud/apps/web/components/PullRequestDialog.tsx
+++ b/cloud/apps/web/components/PullRequestDialog.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect } from "react";
+import type { GitCompare } from "@/lib/types";
+import { PrPanel } from "./PrPanel";
+
+export function PullRequestDialog({
+  open,
+  onClose,
+  runId,
+  defaultTitle,
+  defaultBaseRef,
+  headBranch,
+  compare,
+  onSuccess,
+}: {
+  open: boolean;
+  onClose: () => void;
+  runId: string;
+  defaultTitle?: string;
+  defaultBaseRef?: string;
+  headBranch?: string;
+  compare?: GitCompare | null;
+  onSuccess?: () => void;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[70] grid place-items-center bg-[rgba(46,52,54,0.45)] p-4"
+      role="presentation"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="pr-dialog-title"
+        className="flex max-h-[min(640px,calc(100vh-32px))] w-[min(480px,calc(100vw-32px))] flex-col overflow-hidden rounded-md bg-canvas shadow-card"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between gap-2 border-b border-line px-4 py-3">
+          <h2 id="pr-dialog-title" className="m-0 text-[15px] font-semibold text-ink">
+            Create pull request
+          </h2>
+          <button type="button" className="btn btn-sm" onClick={onClose}>
+            Cancel
+          </button>
+        </div>
+        <PrPanel
+          runId={runId}
+          defaultTitle={defaultTitle}
+          defaultBaseRef={defaultBaseRef}
+          headBranch={headBranch}
+          compare={compare}
+          dialog
+          onSuccess={() => {
+            onSuccess?.();
+            onClose();
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/cloud/apps/web/components/PushPromptCard.tsx
+++ b/cloud/apps/web/components/PushPromptCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import type { GitCompare, PullRequest } from "@/lib/types";
+import type { GitCompare } from "@/lib/types";
 import { publishRunToGithub, type PublishResult } from "@/lib/gitPublish";
 import { IconExternal, IconGithub } from "@/lib/icons";
 
@@ -40,6 +40,7 @@ export function PushPromptCard({
         title: title?.trim() || "Changes from Zene Cloud",
         baseRef: baseRef || base,
         headBranch: branch,
+        compare,
         draft: true,
       });
       setResult(next);
@@ -49,7 +50,7 @@ export function PushPromptCard({
     } finally {
       setBusy(false);
     }
-  }, [runId, title, baseRef, base, branch, onPublished]);
+  }, [runId, title, baseRef, base, branch, compare, onPublished]);
 
   if (result) {
     const pr = result.pullRequest;
@@ -57,7 +58,7 @@ export function PushPromptCard({
       <div className="self-stretch rounded-md border border-line bg-canvas p-3.5 min-[981px]:ml-9">
         <div className="mb-1 flex items-center gap-2 text-[13px] font-semibold text-ink">
           <IconGithub className="h-4 w-4 shrink-0" />
-          <span>已推送到 GitHub</span>
+          <span>Pushed to GitHub</span>
           {pr?.providerNumber != null && pr.url ? (
             <a
               href={pr.url}
@@ -82,10 +83,10 @@ export function PushPromptCard({
               >
                 {pr.title}
               </a>{" "}
-              已创建。
+              created.
             </>
           ) : (
-            <>分支已推送{result.push.headSha ? ` · ${result.push.headSha.slice(0, 7)}` : ""}。</>
+            <>Branch pushed{result.push.headSha ? ` · ${result.push.headSha.slice(0, 7)}` : ""}.</>
           )}
         </p>
       </div>
@@ -94,13 +95,9 @@ export function PushPromptCard({
 
   return (
     <div className="self-stretch rounded-md border-l-2 border-primary bg-secondary p-3.5 min-[981px]:ml-9">
-      <h4 className="mb-1 text-[13px] font-semibold text-ink">推送到 GitHub？</h4>
+      <h4 className="mb-1 text-[13px] font-semibold text-ink">Push to GitHub?</h4>
       <p className="mb-3 text-[12px] leading-snug text-muted">
-        有{" "}
-        <span className="font-medium text-ink">
-          {fileCount} 个文件
-        </span>{" "}
-        尚未同步到 GitHub（
+        <span className="font-medium text-ink">{fileCount} file(s)</span> are not on GitHub yet (
         <span className="font-mono text-[#1a7f37]">+{additions}</span>{" "}
         <span className="font-mono text-[#cf222e]">−{deletions}</span>
         {" vs "}
@@ -111,14 +108,14 @@ export function PushPromptCard({
             <span className="font-mono text-ink">{branch}</span>
           </>
         ) : null}
-        ）。推送后将自动创建 Draft PR。
+        ). A draft pull request will be created after push.
       </p>
       <div className="flex flex-wrap gap-2">
         <button type="button" className="btn btn-primary btn-sm" disabled={busy} onClick={() => void publish()}>
-          {busy ? "推送中…" : "推送并创建 PR"}
+          {busy ? "Pushing…" : "Push & create PR"}
         </button>
         <button type="button" className="btn btn-sm" disabled={busy} onClick={onDismiss}>
-          暂不推送
+          Not now
         </button>
       </div>
       {error ? <div className="mt-2 text-[12px] text-danger">{error}</div> : null}

--- a/cloud/apps/web/components/RunView.tsx
+++ b/cloud/apps/web/components/RunView.tsx
@@ -2332,6 +2332,7 @@ export function RunView({
           defaultPrTitle={run?.title}
           defaultBaseRef={run?.baseRef}
           headBranch={run?.headBranch}
+          gitCompare={gitCompare}
           width={codeWidth}
           onWidthChange={setCodeWidth}
           onCollapse={onToggleCodePanel}

--- a/cloud/apps/web/lib/gitPublish.ts
+++ b/cloud/apps/web/lib/gitPublish.ts
@@ -1,4 +1,5 @@
 import { api } from "@/lib/api";
+import { buildDefaultPrBody } from "@/lib/prBody";
 import type { GitCompare, PullRequest } from "@/lib/types";
 
 export interface PushResult {
@@ -13,6 +14,13 @@ export interface PublishOptions {
   headBranch?: string;
   body?: string;
   draft?: boolean;
+  compare?: GitCompare | null;
+}
+
+function isActivePullRequest(pr: PullRequest): boolean {
+  if (!pr.url) return false;
+  const state = (pr.state || "").toLowerCase();
+  return state === "open" || state === "draft";
 }
 
 export interface PublishResult {
@@ -66,11 +74,12 @@ export async function publishRunToGithub(
 ): Promise<PublishResult> {
   const push = await pushRunBranch(runId);
   const existing = await fetchRunPullRequests(runId);
-  const linked = existing.find((pr) => pr.url);
+  const linked = existing.find(isActivePullRequest);
   if (linked) {
     return { push, pullRequest: linked };
   }
-  const pullRequest = await createRunPullRequest(runId, opts);
+  const body = opts.body?.trim() || buildDefaultPrBody(opts.compare);
+  const pullRequest = await createRunPullRequest(runId, { ...opts, body });
   return { push, pullRequest };
 }
 
@@ -79,5 +88,5 @@ export function hasUnpublishedChanges(
   pullRequests: PullRequest[],
 ): boolean {
   if (!compare?.files?.length) return false;
-  return !pullRequests.some((pr) => Boolean(pr.url));
+  return !pullRequests.some(isActivePullRequest);
 }

--- a/cloud/apps/web/lib/prBody.ts
+++ b/cloud/apps/web/lib/prBody.ts
@@ -1,0 +1,28 @@
+import type { GitCompare } from "@/lib/types";
+
+/** Default markdown body for a draft PR from diff stats. */
+export function buildDefaultPrBody(compare?: GitCompare | null): string {
+  const lines: string[] = ["Created by Zene Cloud.", ""];
+
+  if (!compare?.files?.length) {
+    return lines.join("\n").trim();
+  }
+
+  lines.push("## Summary");
+  lines.push(`- ${compare.files.length} file(s) changed`);
+  lines.push(`- **+${compare.totalAdditions}** / **−${compare.totalDeletions}** lines`);
+  lines.push("");
+  lines.push("### Changed files");
+
+  const max = 30;
+  for (const f of compare.files.slice(0, max)) {
+    const stat =
+      f.additions || f.deletions ? ` (+${f.additions}/−${f.deletions})` : "";
+    lines.push(`- \`${f.path}\`${stat}`);
+  }
+  if (compare.files.length > max) {
+    lines.push(`- _…and ${compare.files.length - max} more_`);
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes issues in the GitHub PR creation flow where submitted PRs had no body content and the create-PR dialog was clipped/ugly inside the Changes panel.

## Changes

- **Auto-generated PR body** (`lib/prBody.ts`): Builds markdown summary from diff stats (file count, +/- lines, changed file list) when no body is provided.
- **Dialog UX** (`PullRequestDialog.tsx`): Full-viewport fixed dialog matching `ConfirmDialog` design system; Esc to close; auto-closes on success.
- **PrPanel**: Pre-fills body from compare data; primary action is now "Push & create PR" (pushes branch then opens draft PR); dialog mode hides PR list clutter.
- **gitPublish**: Only treats open/draft PRs as existing when skipping PR creation; passes compare into body generation.
- **PushPromptCard**: English copy aligned with Console UI; uses auto-generated body on publish.

## Testing

- `npm run build` in `cloud/apps/web` — compiles successfully with type checking.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14a73ba1-1082-458f-a7d9-76e8ad93c2cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14a73ba1-1082-458f-a7d9-76e8ad93c2cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

