### PR TITLE
fix(cloud): commit workspace changes before GitHub push

### DIFF
--- a/cloud/apps/api/src/routes.rs
+++ b/cloud/apps/api/src/routes.rs
@@ -1307,6 +1307,21 @@ async fn user_push(
 ) -> Result<impl IntoResponse, AppError> {
     let run = authorize_run(&state, user.id, run_id).await?;
     let root = state.workspace_root.join(run_id.to_string());
+    let commit_msg = format!(
+        "zene: {}",
+        run.title.chars().take(72).collect::<String>()
+    );
+    workspace::commit_worktree_if_dirty(&root, &commit_msg)
+        .await
+        .map_err(AppError::from)?;
+    if !workspace::branch_has_commits_ahead(&root, &run.base_ref)
+        .await
+        .map_err(AppError::from)?
+    {
+        return Err(AppError::bad_request(
+            "no commits ahead of base branch; commit your changes before pushing",
+        ));
+    }
     let bundle = create_bundle(&root).await.map_err(AppError::from)?;
     let expected = run.head_sha.clone().unwrap_or_else(|| "HEAD".into());
     let git_broker = state.git_broker().await;
@@ -1556,6 +1571,21 @@ async fn worker_push(
         .await?
         .ok_or_else(|| AppError::not_found("run not found"))?;
     let root = state.workspace_root.join(run_id.to_string());
+    let commit_msg = format!(
+        "zene: {}",
+        run.title.chars().take(72).collect::<String>()
+    );
+    workspace::commit_worktree_if_dirty(&root, &commit_msg)
+        .await
+        .map_err(AppError::from)?;
+    if !workspace::branch_has_commits_ahead(&root, &run.base_ref)
+        .await
+        .map_err(AppError::from)?
+    {
+        return Err(AppError::bad_request(
+            "no commits ahead of base branch; nothing to push",
+        ));
+    }
     let bundle = create_bundle(&root).await.map_err(AppError::from)?;
     let expected = run.head_sha.clone().unwrap_or_else(|| "HEAD".into());
     let key = req

--- a/cloud/apps/api/src/workspace.rs
+++ b/cloud/apps/api/src/workspace.rs
@@ -580,3 +580,81 @@ fn safe_join(root: &Path, rel: &str) -> Result<PathBuf> {
     }
     Ok(canon)
 }
+
+/// Stage and commit all working-tree changes when the repo is dirty.
+/// Returns the new HEAD sha, or the existing HEAD when nothing to commit.
+pub async fn commit_worktree_if_dirty(root: &Path, message: &str) -> Result<Option<String>> {
+    if !root.join(".git").exists() {
+        return Ok(None);
+    }
+    let status = tokio::process::Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(root)
+        .output()
+        .await
+        .context("git status --porcelain")?;
+    if !status.status.success() {
+        let stderr = String::from_utf8_lossy(&status.stderr);
+        bail!("git status failed: {}", stderr.trim());
+    }
+    let porcelain = String::from_utf8_lossy(&status.stdout);
+    if porcelain.trim().is_empty() {
+        return rev_parse(root, "HEAD").await;
+    }
+
+    let add = tokio::process::Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(root)
+        .output()
+        .await
+        .context("git add -A")?;
+    if !add.status.success() {
+        let stderr = String::from_utf8_lossy(&add.stderr);
+        bail!("git add failed: {}", stderr.trim());
+    }
+
+    let msg = message.trim();
+    let msg = if msg.is_empty() { "zene: changes" } else { msg };
+    let commit = tokio::process::Command::new("git")
+        .args([
+            "-c",
+            "user.email=zene-cloud@localhost",
+            "-c",
+            "user.name=Zene Cloud",
+            "commit",
+            "-m",
+            msg,
+        ])
+        .current_dir(root)
+        .output()
+        .await
+        .context("git commit")?;
+    if !commit.status.success() {
+        let stderr = String::from_utf8_lossy(&commit.stderr);
+        bail!("git commit failed: {}", stderr.trim());
+    }
+    rev_parse(root, "HEAD").await
+}
+
+/// True when HEAD has at least one commit not reachable from `base_ref`.
+pub async fn branch_has_commits_ahead(root: &Path, base_ref: &str) -> Result<bool> {
+    if !root.join(".git").exists() {
+        return Ok(false);
+    }
+    let base_oid = resolve_base_oid(root, base_ref).await?;
+    let output = tokio::process::Command::new("git")
+        .args(["rev-list", "--count", &format!("{base_oid}..HEAD")])
+        .current_dir(root)
+        .output()
+        .await
+        .context("git rev-list --count")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git rev-list failed: {}", stderr.trim());
+    }
+    let count = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<u64>()
+        .unwrap_or(0);
+    Ok(count > 0)
+}

--- a/cloud/crates/github/src/client.rs
+++ b/cloud/crates/github/src/client.rs
@@ -496,6 +496,11 @@ impl GithubClient {
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();
         if !status.is_success() {
+            if status.as_u16() == 422 && text.contains("No commits between") {
+                bail!(
+                    "cannot create pull request: branch has no commits ahead of base (push your latest changes first)"
+                );
+            }
             bail!("create pull request failed ({status}): {text}");
         }
         let pr: Resp = serde_json::from_str(&text).context("parse pull request")?;


### PR DESCRIPTION
## Summary
- Auto-commit uncommitted workspace changes before creating a push bundle, so remote branches include agent edits.
- Reject push when HEAD has no commits ahead of the base branch.
- Return a clearer error when GitHub rejects PR creation with "No commits between".

## Test plan
- [ ] Start a cloud run, make file edits without waiting for completion, click Push & create PR — verify branch is pushed with commits and draft PR opens.
- [ ] Push with no changes ahead of base — verify API returns a clear 400 error instead of a GitHub 422.

Made with [Cursor](https://cursor.com)