### PR TITLE
feat(cloud): add Cursor-style Commit & Create PR workflow

### DIFF
--- a/cloud/apps/api/src/routes.rs
+++ b/cloud/apps/api/src/routes.rs
@@ -100,6 +100,14 @@ pub fn router(state: AppState) -> Router {
             "/api/v1/runs/{run_id}/pull-requests",
             get(list_run_prs).post(create_run_pr),
         )
+        .route(
+            "/api/v1/runs/{run_id}/pull-requests/{pr_id}/ready",
+            post(mark_run_pr_ready),
+        )
+        .route(
+            "/api/v1/runs/{run_id}/pull-requests/{pr_id}/merge",
+            post(merge_run_pr),
+        )
         .route("/api/v1/runs/{run_id}/git/push", post(user_push))
         .route("/internal/v1/runs/claim", post(claim_run))
         .route("/internal/v1/queue/stats", get(queue_stats))
@@ -1298,6 +1306,40 @@ async fn create_run_pr(
         .await
         .map_err(AppError::from)?;
     Ok(Json(pr))
+}
+
+async fn mark_run_pr_ready(
+    State(state): State<AppState>,
+    AuthUser(user): AuthUser,
+    Path((run_id, pr_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, AppError> {
+    let run = authorize_run(&state, user.id, run_id).await?;
+    let pr = state
+        .db
+        .get_pull_request(pr_id)
+        .await?
+        .filter(|pr| pr.run_id == run_id)
+        .ok_or_else(|| AppError::not_found("pull request not found"))?;
+    let git_broker = state.git_broker().await;
+    let updated = git_broker.mark_pr_ready(&run, &pr).await.map_err(AppError::from)?;
+    Ok(Json(updated))
+}
+
+async fn merge_run_pr(
+    State(state): State<AppState>,
+    AuthUser(user): AuthUser,
+    Path((run_id, pr_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, AppError> {
+    let run = authorize_run(&state, user.id, run_id).await?;
+    let pr = state
+        .db
+        .get_pull_request(pr_id)
+        .await?
+        .filter(|pr| pr.run_id == run_id)
+        .ok_or_else(|| AppError::not_found("pull request not found"))?;
+    let git_broker = state.git_broker().await;
+    let updated = git_broker.merge_pr(&run, &pr).await.map_err(AppError::from)?;
+    Ok(Json(updated))
 }
 
 async fn user_push(

--- a/cloud/apps/web/components/CodePanel.tsx
+++ b/cloud/apps/web/components/CodePanel.tsx
@@ -12,7 +12,7 @@ import {
   IconRefresh,
 } from "@/lib/icons";
 import { readSessionUi, writeSessionUi, type SessionIdeTab } from "@/lib/sessionUi";
-import { fetchRunPullRequests, publishRunToGithub } from "@/lib/gitPublish";
+import { fetchRunPullRequests, commitAndCreatePullRequest } from "@/lib/gitPublish";
 import { FileTree } from "./FileTree";
 import { GitPanel } from "./GitPanel";
 import { CodeViewer } from "./CodeViewer";
@@ -183,7 +183,7 @@ export function CodePanel({
     null,
   );
   const [latestPr, setLatestPr] = useState<PullRequest | null>(null);
-  const [pushBusy, setPushBusy] = useState(false);
+  const [commitBusy, setCommitBusy] = useState(false);
   const [treeExpandAll, setTreeExpandAll] = useState(0);
   const [treeCollapseAll, setTreeCollapseAll] = useState(0);
   const [mdPreview, setMdPreviewState] = useState(() => saved.mdPreview !== false);
@@ -281,11 +281,11 @@ export function CodePanel({
     return () => document.removeEventListener("mousedown", onDoc);
   }, [menuOpen]);
 
-  const pushBranch = async () => {
+  const commitAndCreatePr = async () => {
     setMenuOpen(false);
-    setPushBusy(true);
+    setCommitBusy(true);
     try {
-      const result = await publishRunToGithub(runId, {
+      const result = await commitAndCreatePullRequest(runId, {
         title: defaultPrTitle?.trim() || "Changes from Zene Cloud",
         baseRef: defaultBaseRef,
         headBranch,
@@ -295,14 +295,15 @@ export function CodePanel({
       await loadPrs();
       const pr = result.pullRequest;
       if (pr?.url && pr.providerNumber != null) {
-        toast(`Pushed · PR #${pr.providerNumber}`, "ok");
+        toast(`Draft PR #${pr.providerNumber} created`, "ok");
+        window.open(pr.url, "_blank", "noopener,noreferrer");
       } else {
-        toast(`Pushed · ${result.push.headSha || result.push.pushUrl || "ok"}`, "ok");
+        toast(`Committed · ${result.push.headSha || result.push.pushUrl || "ok"}`, "ok");
       }
     } catch (err) {
       toast(err instanceof Error ? err.message : String(err), "error");
     } finally {
-      setPushBusy(false);
+      setCommitBusy(false);
     }
   };
   const mainTabs: { id: IdeTab; label: string }[] = [
@@ -405,8 +406,8 @@ export function CodePanel({
                 <button type="button" className="menu-item w-full" onClick={() => { setMenuOpen(false); loadFiles(); loadPrs(); }}>
                   Refresh
                 </button>
-                <button type="button" className="menu-item w-full" onClick={pushBranch}>
-                  Push & create PR
+                <button type="button" className="menu-item w-full" onClick={() => { void commitAndCreatePr(); }}>
+                  Commit & Create PR
                 </button>
                 <button
                   type="button"
@@ -431,11 +432,10 @@ export function CodePanel({
             defaultTitle={defaultPrTitle}
             defaultBaseRef={defaultBaseRef}
             headBranch={headBranch}
-            prUrl={latestPr?.url}
-            prState={latestPr?.state}
-            pushBusy={pushBusy}
-            onPush={pushBranch}
-            onCreatePr={() => setPrModalOpen(true)}
+            pullRequest={latestPr}
+            onPullRequestChange={setLatestPr}
+            onCommitAndCreatePr={commitAndCreatePr}
+            commitBusy={commitBusy}
           />
         )}
         {tab === "files" && (

--- a/cloud/apps/web/components/GitPanel.tsx
+++ b/cloud/apps/web/components/GitPanel.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import type { PullRequestState } from "@/lib/types";
+import type { PullRequest, PullRequestState } from "@/lib/types";
 import { readSessionUi, writeSessionUi, type SessionGitSubTab } from "@/lib/sessionUi";
+import { markPullRequestReady, mergePullRequest } from "@/lib/gitPublish";
 import { ChangesPanel } from "./ChangesPanel";
 import { CommitsPanel } from "./CommitsPanel";
 import { ReviewPanel } from "./ReviewPanel";
-import { IconUpload } from "@/lib/icons";
+import { IconExternal } from "@/lib/icons";
+import { useToast } from "./Toast";
 
 export type GitSubTab = SessionGitSubTab;
 
@@ -19,31 +21,40 @@ function prStateClass(state?: PullRequestState | string): string {
   return "bg-tertiary text-ink";
 }
 
+function prStateLabel(state?: PullRequestState | string): string {
+  const s = (state || "").toLowerCase();
+  if (s === "open") return "Open";
+  if (s === "draft") return "Draft";
+  if (s === "merged") return "Merged";
+  if (s === "closed") return "Closed";
+  return state || "";
+}
+
 export function GitPanel({
   runId,
   defaultTitle,
   defaultBaseRef,
   headBranch,
-  prUrl,
-  prState,
-  onPush,
-  pushBusy,
-  onCreatePr,
+  pullRequest,
+  onPullRequestChange,
+  onCommitAndCreatePr,
+  commitBusy,
 }: {
   runId: string;
   defaultTitle?: string;
   defaultBaseRef?: string;
   headBranch?: string;
-  prUrl?: string;
-  prState?: PullRequestState;
-  onPush?: () => void | Promise<void>;
-  pushBusy?: boolean;
-  onCreatePr?: () => void;
+  pullRequest?: PullRequest | null;
+  onPullRequestChange?: (pr: PullRequest | null) => void;
+  onCommitAndCreatePr?: () => void | Promise<void>;
+  commitBusy?: boolean;
 }) {
+  const toast = useToast();
   const [subTab, setSubTabState] = useState<GitSubTab>(() => {
     const saved = readSessionUi(runId).gitSubTab;
     return saved === "review" || saved === "commits" || saved === "diff" ? saved : "diff";
   });
+  const [actionBusy, setActionBusy] = useState(false);
   const setSubTab = useCallback(
     (next: GitSubTab) => {
       setSubTabState(next);
@@ -51,22 +62,61 @@ export function GitPanel({
     },
     [runId],
   );
-  const title = defaultTitle || "Changes";
+  const title = pullRequest?.title || defaultTitle || "Changes";
   const base = defaultBaseRef || "main";
+  const prState = pullRequest?.state;
+  const prUrl = pullRequest?.url;
+  const prId = pullRequest?.id;
+
+  const markReady = useCallback(async () => {
+    if (!prId) return;
+    setActionBusy(true);
+    try {
+      const updated = await markPullRequestReady(runId, prId);
+      onPullRequestChange?.(updated);
+      toast("Pull request marked as ready", "ok");
+    } catch (err) {
+      toast(err instanceof Error ? err.message : String(err), "error");
+    } finally {
+      setActionBusy(false);
+    }
+  }, [prId, runId, onPullRequestChange, toast]);
+
+  const merge = useCallback(async () => {
+    if (!prId) return;
+    setActionBusy(true);
+    try {
+      const updated = await mergePullRequest(runId, prId);
+      onPullRequestChange?.(updated);
+      toast("Pull request merged", "ok");
+    } catch (err) {
+      toast(err instanceof Error ? err.message : String(err), "error");
+    } finally {
+      setActionBusy(false);
+    }
+  }, [prId, runId, onPullRequestChange, toast]);
+
+  const showMarkReady = prState === "draft" && !!prId;
+  const showMerge = prState === "open" && !!prId;
+  const showCommit = !pullRequest && onCommitAndCreatePr;
 
   return (
     <div className="grid h-full min-h-0 grid-rows-[auto_auto_minmax(0,1fr)]">
-      <div className="bg-canvas px-3 py-2.5">
-        <div className="min-w-0">
+      <div className="flex items-start justify-between gap-2 bg-canvas px-3 py-2.5">
+        <div className="min-w-0 flex-1">
           {prUrl ? (
             <a
               href={prUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="block truncate text-[13px] font-semibold leading-snug text-ink hover:underline"
+              className="inline-flex max-w-full items-center gap-1 truncate text-[13px] font-semibold leading-snug text-ink hover:underline"
               title={title}
             >
-              {title}
+              <span className="truncate">{title}</span>
+              {pullRequest?.providerNumber != null ? (
+                <span className="shrink-0 text-muted">#{pullRequest.providerNumber}</span>
+              ) : null}
+              <IconExternal className="h-3.5 w-3.5 shrink-0 text-muted" />
             </a>
           ) : (
             <div className="truncate text-[13px] font-semibold leading-snug text-ink" title={title}>
@@ -76,9 +126,9 @@ export function GitPanel({
           <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] text-muted">
             {prState && (
               <span
-                className={`rounded px-1.5 py-0.5 text-[10px] font-semibold capitalize ${prStateClass(prState)}`}
+                className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${prStateClass(prState)}`}
               >
-                {prState}
+                {prStateLabel(prState)}
               </span>
             )}
             {headBranch ? (
@@ -90,12 +140,34 @@ export function GitPanel({
             )}
           </div>
         </div>
+        <div className="flex shrink-0 items-center gap-1.5">
+          {showMarkReady ? (
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              disabled={actionBusy}
+              onClick={() => void markReady()}
+            >
+              {actionBusy ? "Updating…" : "Mark as ready"}
+            </button>
+          ) : null}
+          {showMerge ? (
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              disabled={actionBusy}
+              onClick={() => void merge()}
+            >
+              {actionBusy ? "Merging…" : "Merge"}
+            </button>
+          ) : null}
+        </div>
       </div>
       <div className="flex h-8 items-center justify-between gap-2 border-b border-line bg-canvas px-2">
         <div className="flex min-w-0 items-center gap-0.5">
           {(
             [
-              { id: "diff" as const, label: "Diff" },
+              { id: "diff" as const, label: "Changes" },
               { id: "review" as const, label: "Review" },
               { id: "commits" as const, label: "Commits" },
             ] as const
@@ -115,24 +187,16 @@ export function GitPanel({
             </button>
           ))}
         </div>
-        <div className="flex shrink-0 items-center gap-1">
-          {onCreatePr ? (
-            <button type="button" className="btn btn-sm hidden min-[641px]:inline-flex" onClick={onCreatePr}>
-              Create PR
-            </button>
-          ) : null}
-          {onPush ? (
-            <button
-              type="button"
-              className="btn btn-primary btn-sm inline-flex items-center gap-1"
-              disabled={pushBusy}
-              onClick={() => void onPush()}
-            >
-              <IconUpload className="h-3.5 w-3.5" />
-              {pushBusy ? "Pushing…" : "Push"}
-            </button>
-          ) : null}
-        </div>
+        {showCommit ? (
+          <button
+            type="button"
+            className="btn btn-primary btn-sm shrink-0"
+            disabled={commitBusy}
+            onClick={() => void onCommitAndCreatePr()}
+          >
+            {commitBusy ? "Committing…" : "Commit & Create PR"}
+          </button>
+        ) : null}
       </div>
       <div className="min-h-0 overflow-hidden">
         {subTab === "diff" && <ChangesPanel runId={runId} baseRef={defaultBaseRef} />}

--- a/cloud/apps/web/components/PrPanel.tsx
+++ b/cloud/apps/web/components/PrPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { createRunPullRequest, fetchRunPullRequests, publishRunToGithub } from "@/lib/gitPublish";
+import { commitAndCreatePullRequest, createRunPullRequest, fetchRunPullRequests } from "@/lib/gitPublish";
 import { buildDefaultPrBody } from "@/lib/prBody";
 import type { GitCompare, PullRequest } from "@/lib/types";
 import { IconExternal, IconRefresh } from "@/lib/icons";
@@ -70,7 +70,7 @@ export function PrPanel({
     setError("");
     setBusy(true);
     try {
-      const result = await publishRunToGithub(runId, {
+      const result = await commitAndCreatePullRequest(runId, {
         title: t,
         baseRef: baseRef.trim() || defaultBaseRef,
         headBranch,
@@ -80,8 +80,8 @@ export function PrPanel({
       });
       toast(
         result.pullRequest?.providerNumber != null
-          ? `Pushed · PR #${result.pullRequest.providerNumber}`
-          : `Pushed · ${result.push.headSha || result.push.pushUrl || "ok"}`,
+          ? `Draft PR #${result.pullRequest.providerNumber} created`
+          : `Committed · ${result.push.headSha || result.push.pushUrl || "ok"}`,
         "ok",
       );
       if (!dialog) await loadPrs();
@@ -170,7 +170,7 @@ export function PrPanel({
       </label>
       <div className={`flex flex-wrap gap-2 ${dialog ? "" : "mb-4"}`}>
         <button type="button" className="btn btn-primary btn-sm" disabled={busy} onClick={publish}>
-          {busy ? "Creating…" : dialog ? "Create pull request" : "Push & create PR"}
+          {busy ? "Creating…" : dialog ? "Commit & Create PR" : "Commit & Create PR"}
         </button>
         {!dialog && (
           <>

--- a/cloud/apps/web/components/PullRequestDialog.tsx
+++ b/cloud/apps/web/components/PullRequestDialog.tsx
@@ -49,7 +49,7 @@ export function PullRequestDialog({
       >
         <div className="flex items-center justify-between gap-2 border-b border-line px-4 py-3">
           <h2 id="pr-dialog-title" className="m-0 text-[15px] font-semibold text-ink">
-            Create pull request
+            Commit & Create PR
           </h2>
           <button type="button" className="btn btn-sm" onClick={onClose}>
             Cancel

--- a/cloud/apps/web/components/PushPromptCard.tsx
+++ b/cloud/apps/web/components/PushPromptCard.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from "react";
 import type { GitCompare } from "@/lib/types";
-import { publishRunToGithub, type PublishResult } from "@/lib/gitPublish";
+import { commitAndCreatePullRequest, type PublishResult } from "@/lib/gitPublish";
 import { IconExternal, IconGithub } from "@/lib/icons";
 
 export function PushPromptCard({
@@ -36,7 +36,7 @@ export function PushPromptCard({
     setError("");
     setBusy(true);
     try {
-      const next = await publishRunToGithub(runId, {
+      const next = await commitAndCreatePullRequest(runId, {
         title: title?.trim() || "Changes from Zene Cloud",
         baseRef: baseRef || base,
         headBranch: branch,
@@ -45,6 +45,9 @@ export function PushPromptCard({
       });
       setResult(next);
       onPublished?.(next);
+      if (next.pullRequest?.url) {
+        window.open(next.pullRequest.url, "_blank", "noopener,noreferrer");
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -58,7 +61,7 @@ export function PushPromptCard({
       <div className="self-stretch rounded-md border border-line bg-canvas p-3.5 min-[981px]:ml-9">
         <div className="mb-1 flex items-center gap-2 text-[13px] font-semibold text-ink">
           <IconGithub className="h-4 w-4 shrink-0" />
-          <span>Pushed to GitHub</span>
+          <span>Draft PR created</span>
           {pr?.providerNumber != null && pr.url ? (
             <a
               href={pr.url}
@@ -74,7 +77,7 @@ export function PushPromptCard({
         <p className="m-0 text-[12px] leading-snug text-muted">
           {pr?.url ? (
             <>
-              Draft PR{" "}
+              Open{" "}
               <a
                 href={pr.url}
                 target="_blank"
@@ -83,10 +86,10 @@ export function PushPromptCard({
               >
                 {pr.title}
               </a>{" "}
-              created.
+              to mark as ready, then merge when checks pass.
             </>
           ) : (
-            <>Branch pushed{result.push.headSha ? ` · ${result.push.headSha.slice(0, 7)}` : ""}.</>
+            <>Changes committed{result.push.headSha ? ` · ${result.push.headSha.slice(0, 7)}` : ""}.</>
           )}
         </p>
       </div>
@@ -95,9 +98,9 @@ export function PushPromptCard({
 
   return (
     <div className="self-stretch rounded-md border-l-2 border-primary bg-secondary p-3.5 min-[981px]:ml-9">
-      <h4 className="mb-1 text-[13px] font-semibold text-ink">Push to GitHub?</h4>
+      <h4 className="mb-1 text-[13px] font-semibold text-ink">Commit & Create PR?</h4>
       <p className="mb-3 text-[12px] leading-snug text-muted">
-        <span className="font-medium text-ink">{fileCount} file(s)</span> are not on GitHub yet (
+        <span className="font-medium text-ink">{fileCount} file(s)</span> changed (
         <span className="font-mono text-[#1a7f37]">+{additions}</span>{" "}
         <span className="font-mono text-[#cf222e]">−{deletions}</span>
         {" vs "}
@@ -108,11 +111,11 @@ export function PushPromptCard({
             <span className="font-mono text-ink">{branch}</span>
           </>
         ) : null}
-        ). A draft pull request will be created after push.
+        ). Changes will be committed, pushed, and opened as a draft PR.
       </p>
       <div className="flex flex-wrap gap-2">
         <button type="button" className="btn btn-primary btn-sm" disabled={busy} onClick={() => void publish()}>
-          {busy ? "Pushing…" : "Push & create PR"}
+          {busy ? "Committing…" : "Commit & Create PR"}
         </button>
         <button type="button" className="btn btn-sm" disabled={busy} onClick={onDismiss}>
           Not now

--- a/cloud/apps/web/lib/gitPublish.ts
+++ b/cloud/apps/web/lib/gitPublish.ts
@@ -67,8 +67,8 @@ export async function createRunPullRequest(
   });
 }
 
-/** Push branch to GitHub, then open a draft PR when none exists yet. */
-export async function publishRunToGithub(
+/** Commit workspace changes, push branch, then open a draft PR when none exists yet. */
+export async function commitAndCreatePullRequest(
   runId: string,
   opts: PublishOptions,
 ): Promise<PublishResult> {
@@ -81,6 +81,29 @@ export async function publishRunToGithub(
   const body = opts.body?.trim() || buildDefaultPrBody(opts.compare);
   const pullRequest = await createRunPullRequest(runId, { ...opts, body });
   return { push, pullRequest };
+}
+
+/** @deprecated Use commitAndCreatePullRequest */
+export const publishRunToGithub = commitAndCreatePullRequest;
+
+export async function markPullRequestReady(
+  runId: string,
+  prId: string,
+): Promise<PullRequest> {
+  return api<PullRequest>(`/api/v1/runs/${runId}/pull-requests/${prId}/ready`, {
+    method: "POST",
+    body: "{}",
+  });
+}
+
+export async function mergePullRequest(
+  runId: string,
+  prId: string,
+): Promise<PullRequest> {
+  return api<PullRequest>(`/api/v1/runs/${runId}/pull-requests/${prId}/merge`, {
+    method: "POST",
+    body: "{}",
+  });
 }
 
 export function hasUnpublishedChanges(

--- a/cloud/apps/web/lib/types.ts
+++ b/cloud/apps/web/lib/types.ts
@@ -78,6 +78,7 @@ export interface Run {
   title: string;
   status: RunStatus;
   repositoryId: string;
+  workspaceId?: string;
   headBranch?: string;
   baseRef?: string;
   model?: string;
@@ -364,6 +365,7 @@ export interface GitCommit {
 export type PullRequestState = "open" | "closed" | "merged" | "draft";
 
 export interface PullRequest {
+  id: string;
   title: string;
   url?: string;
   providerNumber?: number;

--- a/cloud/crates/db/src/github.rs
+++ b/cloud/crates/db/src/github.rs
@@ -681,6 +681,78 @@ impl Db {
             .collect())
     }
 
+    pub async fn get_pull_request(&self, pr_id: Uuid) -> Result<Option<PullRequest>> {
+        let row: Option<(
+            String,
+            String,
+            String,
+            Option<i64>,
+            Option<String>,
+            String,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+            String,
+            i64,
+            String,
+        )> = sqlx::query_as(
+            "SELECT id, repository_id, run_id, provider_number, url, title, body, base_sha,
+                    head_sha, state, draft, created_at
+             FROM pull_requests WHERE id = ?",
+        )
+        .bind(pr_id.to_string())
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(
+            |(
+                id,
+                repository_id,
+                run_id,
+                provider_number,
+                url,
+                title,
+                body,
+                base_sha,
+                head_sha,
+                state,
+                draft,
+                created_at,
+            )| {
+                PullRequest {
+                    id: Uuid::parse_str(&id).unwrap(),
+                    repository_id: Uuid::parse_str(&repository_id).unwrap(),
+                    run_id: Uuid::parse_str(&run_id).unwrap(),
+                    provider_number,
+                    url,
+                    title,
+                    body,
+                    base_sha,
+                    head_sha,
+                    state: PullRequestState::parse(&state).unwrap_or(PullRequestState::Open),
+                    draft: draft != 0,
+                    created_at: parse_time(&created_at),
+                }
+            },
+        ))
+    }
+
+    pub async fn update_pull_request_state(
+        &self,
+        pr_id: Uuid,
+        state: PullRequestState,
+        draft: bool,
+    ) -> Result<Option<PullRequest>> {
+        sqlx::query(
+            "UPDATE pull_requests SET state = ?, draft = ? WHERE id = ?",
+        )
+        .bind(state.as_str())
+        .bind(if draft { 1 } else { 0 })
+        .bind(pr_id.to_string())
+        .execute(&self.pool)
+        .await?;
+        self.get_pull_request(pr_id).await
+    }
+
     pub async fn append_audit(
         &self,
         organization_id: Option<Uuid>,

--- a/cloud/crates/git-broker/src/lib.rs
+++ b/cloud/crates/git-broker/src/lib.rs
@@ -328,6 +328,110 @@ impl GitBroker {
         Ok(pr)
     }
 
+    pub async fn mark_pr_ready(&self, run: &Run, pr: &PullRequest) -> Result<PullRequest> {
+        let repo = self
+            .db
+            .get_repository(run.repository_id)
+            .await?
+            .context("repository not found")?;
+        let number = pr
+            .provider_number
+            .context("pull request has no provider number")?;
+
+        let remote = if self.mode == GithubMode::Mock || self.github.is_mock() {
+            self.github
+                .mark_pull_request_ready("mock-install", &repo.owner, &repo.name, number)
+                .await?
+        } else {
+            let installation_id = repo
+                .installation_id
+                .as_deref()
+                .context("repository has no GitHub installation_id")?;
+            self.github
+                .mark_pull_request_ready(installation_id, &repo.owner, &repo.name, number)
+                .await?
+        };
+
+        self.db
+            .update_pull_request_state(pr.id, PullRequestState::Open, false)
+            .await?
+            .context("update pull request state")?;
+
+        self.db
+            .append_audit(
+                Some(run.organization_id),
+                "system",
+                Some("git-broker"),
+                "git.pr.ready",
+                Some("pull_request"),
+                Some(&pr.id.to_string()),
+                Some(serde_json::json!({
+                    "runId": run.id,
+                    "url": remote.url,
+                    "number": remote.provider_number,
+                })),
+            )
+            .await?;
+
+        Ok(self
+            .db
+            .get_pull_request(pr.id)
+            .await?
+            .context("pull request not found")?)
+    }
+
+    pub async fn merge_pr(&self, run: &Run, pr: &PullRequest) -> Result<PullRequest> {
+        let repo = self
+            .db
+            .get_repository(run.repository_id)
+            .await?
+            .context("repository not found")?;
+        let number = pr
+            .provider_number
+            .context("pull request has no provider number")?;
+
+        let remote = if self.mode == GithubMode::Mock || self.github.is_mock() {
+            self.github
+                .merge_pull_request("mock-install", &repo.owner, &repo.name, number)
+                .await?
+        } else {
+            let installation_id = repo
+                .installation_id
+                .as_deref()
+                .context("repository has no GitHub installation_id")?;
+            self.github
+                .merge_pull_request(installation_id, &repo.owner, &repo.name, number)
+                .await?
+        };
+
+        self.db
+            .update_pull_request_state(pr.id, PullRequestState::Merged, false)
+            .await?
+            .context("update pull request state")?;
+
+        self.db
+            .append_audit(
+                Some(run.organization_id),
+                "system",
+                Some("git-broker"),
+                "git.pr.merged",
+                Some("pull_request"),
+                Some(&pr.id.to_string()),
+                Some(serde_json::json!({
+                    "runId": run.id,
+                    "url": remote.url,
+                    "number": remote.provider_number,
+                })),
+            )
+            .await?;
+
+        Ok(self
+            .db
+            .get_pull_request(pr.id)
+            .await?
+            .context("pull request not found")?)
+    }
+
     async fn mock_accept_bundle(
         &self,
         run: &Run,
@@ -473,18 +577,19 @@ fn inject_token_into_https_url(clone_url: &str, token: &str) -> Result<String> {
 }
 
 async fn run_git(cwd: &Path, args: &[&str]) -> Result<()> {
-    let status = Command::new("git")
+    let output = Command::new("git")
         .args(args)
         .current_dir(cwd)
         .env("GIT_TERMINAL_PROMPT", "0")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .status()
+        .output()
         .await
         .with_context(|| format!("spawn git {}", args.join(" ")))?;
-    if !status.success() {
-        bail!("git {} failed with {status}", args.join(" "));
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git {} failed with {}: {stderr}", args.join(" "), output.status);
     }
     Ok(())
 }

--- a/cloud/crates/github/src/client.rs
+++ b/cloud/crates/github/src/client.rs
@@ -519,6 +519,193 @@ impl GithubClient {
             created_at: chrono::Utc::now(),
         })
     }
+
+    /// Mark a draft pull request ready for review (`draft: false`).
+    pub async fn mark_pull_request_ready(
+        &self,
+        installation_id: &str,
+        owner: &str,
+        repo: &str,
+        number: i64,
+    ) -> Result<PullRequest> {
+        if self.is_mock() {
+            return Ok(PullRequest {
+                id: uuid::Uuid::new_v4(),
+                repository_id: uuid::Uuid::nil(),
+                run_id: uuid::Uuid::nil(),
+                provider_number: Some(number),
+                url: Some(format!(
+                    "https://github.com/{owner}/{repo}/pull/{number}"
+                )),
+                title: "Mock PR".into(),
+                body: None,
+                base_sha: None,
+                head_sha: None,
+                state: PullRequestState::Open,
+                draft: false,
+                created_at: chrono::Utc::now(),
+            });
+        }
+
+        let token = self.installation_token(installation_id).await?;
+        let url = format!(
+            "{}/repos/{owner}/{repo}/pulls/{number}",
+            self.config.api_base
+        );
+
+        #[derive(serde::Serialize)]
+        struct Body {
+            draft: bool,
+        }
+        #[derive(Deserialize)]
+        struct Resp {
+            number: i64,
+            html_url: String,
+            state: String,
+            draft: Option<bool>,
+            title: String,
+            body: Option<String>,
+        }
+
+        let resp = self
+            .http
+            .patch(&url)
+            .header("Accept", "application/vnd.github+json")
+            .header("Authorization", format!("Bearer {}", token.token))
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .json(&Body { draft: false })
+            .send()
+            .await
+            .context("mark pull request ready")?;
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            bail!("mark pull request ready failed ({status}): {text}");
+        }
+        let pr: Resp = serde_json::from_str(&text).context("parse pull request")?;
+        Ok(PullRequest {
+            id: uuid::Uuid::new_v4(),
+            repository_id: uuid::Uuid::nil(),
+            run_id: uuid::Uuid::nil(),
+            provider_number: Some(pr.number),
+            url: Some(pr.html_url),
+            title: pr.title,
+            body: pr.body,
+            base_sha: None,
+            head_sha: None,
+            state: pull_request_state(&pr.state, pr.draft.unwrap_or(false)),
+            draft: pr.draft.unwrap_or(false),
+            created_at: chrono::Utc::now(),
+        })
+    }
+
+    /// Merge an open pull request.
+    pub async fn merge_pull_request(
+        &self,
+        installation_id: &str,
+        owner: &str,
+        repo: &str,
+        number: i64,
+    ) -> Result<PullRequest> {
+        if self.is_mock() {
+            return Ok(PullRequest {
+                id: uuid::Uuid::new_v4(),
+                repository_id: uuid::Uuid::nil(),
+                run_id: uuid::Uuid::nil(),
+                provider_number: Some(number),
+                url: Some(format!(
+                    "https://github.com/{owner}/{repo}/pull/{number}"
+                )),
+                title: "Mock PR".into(),
+                body: None,
+                base_sha: None,
+                head_sha: None,
+                state: PullRequestState::Merged,
+                draft: false,
+                created_at: chrono::Utc::now(),
+            });
+        }
+
+        let token = self.installation_token(installation_id).await?;
+        let url = format!(
+            "{}/repos/{owner}/{repo}/pulls/{number}/merge",
+            self.config.api_base
+        );
+
+        #[derive(Deserialize)]
+        struct Resp {
+            #[allow(dead_code)]
+            merged: bool,
+            #[allow(dead_code)]
+            message: Option<String>,
+        }
+
+        let resp = self
+            .http
+            .put(&url)
+            .header("Accept", "application/vnd.github+json")
+            .header("Authorization", format!("Bearer {}", token.token))
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .context("merge pull request")?;
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            bail!("merge pull request failed ({status}): {text}");
+        }
+        let _: Resp = serde_json::from_str(&text).context("parse merge response")?;
+
+        let pr_url = format!(
+            "{}/repos/{owner}/{repo}/pulls/{number}",
+            self.config.api_base
+        );
+        let get = self
+            .http
+            .get(&pr_url)
+            .header("Accept", "application/vnd.github+json")
+            .header("Authorization", format!("Bearer {}", token.token))
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .send()
+            .await
+            .context("fetch merged pull request")?;
+        let status = get.status();
+        let text = get.text().await.unwrap_or_default();
+        if !status.is_success() {
+            bail!("fetch merged pull request failed ({status}): {text}");
+        }
+        #[derive(Deserialize)]
+        struct PrResp {
+            number: i64,
+            html_url: String,
+            state: String,
+            draft: Option<bool>,
+            title: String,
+            body: Option<String>,
+            merged: Option<bool>,
+        }
+        let pr: PrResp = serde_json::from_str(&text).context("parse pull request")?;
+        let state = if pr.merged.unwrap_or(false) || pr.state == "closed" {
+            PullRequestState::Merged
+        } else {
+            pull_request_state(&pr.state, pr.draft.unwrap_or(false))
+        };
+        Ok(PullRequest {
+            id: uuid::Uuid::new_v4(),
+            repository_id: uuid::Uuid::nil(),
+            run_id: uuid::Uuid::nil(),
+            provider_number: Some(pr.number),
+            url: Some(pr.html_url),
+            title: pr.title,
+            body: pr.body,
+            base_sha: None,
+            head_sha: None,
+            state,
+            draft: pr.draft.unwrap_or(false),
+            created_at: chrono::Utc::now(),
+        })
+    }
 }
 
 fn github_account_type(value: &str) -> GithubAccountType {


### PR DESCRIPTION
## Summary
- Rename push flow to **Commit & Create PR** across Console UI (Changes panel, dialog, chat prompt).
- After creation, open the draft PR link and show in-panel actions: **Mark as ready** and **Merge**.
- Add GitHub API + broker endpoints for marking PRs ready and merging.

## Test plan
- [ ] Run an agent, click **Commit & Create PR** — verify commit, push, draft PR creation, and PR link opens.
- [ ] In Changes panel, click **Mark as ready** on a draft PR — state updates to Open.
- [ ] Click **Merge** on an open PR — state updates to Merged.

Made with [Cursor](https://cursor.com)