### PR TITLE
fix(gateway): treat publish 409 as idempotent stale-epoch ack

### DIFF
--- a/crates/context/src/gateway.rs
+++ b/crates/context/src/gateway.rs
@@ -61,6 +61,16 @@ pub async fn publish_prefix(session_id: &str, epoch: u64, messages: &[Message]) 
         Ok(resp) if resp.status().is_success() => {
             info_gateway("publish", session_id, epoch, resp.status().as_u16());
         }
+        // 409 = our epoch baseline is stale (gateway moved on); nothing to retry —
+        // the next publish after the local epoch bump will land. Treat as idempotent.
+        Ok(resp) if resp.status().as_u16() == 409 => {
+            tracing::info!(
+                session_id,
+                epoch,
+                status = 409,
+                "inference gateway publish conflict (stale epoch); ignored"
+            );
+        }
         Ok(resp) => {
             warn!(
                 session_id,


### PR DESCRIPTION
## Summary

Cortex 对过期 epoch 的 publish 返回 `409 CONFLICT`（防乱序保护），语义是"你的基线已过时，无需重试"。当前 `publish_prefix` 只把 `is_success()` 当成功，409 会触发 `publish failed` 的 warn 噪音。

本 PR 照 `close_session` 的写法把 409 视为幂等确认（info 级日志），epoch bump 后的下一次 publish 自然落地。

Refs: ParaTensor/zene#128 (Cortex 联调反馈 P1)

## Validation

- `cargo build -p zene-context --locked` ✅
- `cargo test -p zene-context --locked` 73 passed ✅