### PR TITLE
feat(llm): gateway telemetry data plane — parse Cortex body fields, stream usage opt-in

### DIFF
--- a/crates/context/src/context_water.rs
+++ b/crates/context/src/context_water.rs
@@ -119,6 +119,7 @@ mod tests {
             total_tokens: 710,
             cached_tokens: None,
             gateway_hit_tokens: None,
+            gateway_anchor_aligned: None,
         });
         assert_eq!(water.effective_tokens(), 700);
         assert_eq!(water.usage_percent(), 70);
@@ -146,6 +147,7 @@ mod tests {
             total_tokens: 710,
             cached_tokens: None,
             gateway_hit_tokens: None,
+            gateway_anchor_aligned: None,
         });
         assert_eq!(water.usage_update(650), 700);
         assert_eq!(water.usage_update(750), 750);

--- a/crates/context/src/engine.rs
+++ b/crates/context/src/engine.rs
@@ -315,6 +315,7 @@ pub struct ContextEngine {
     last_epoch_bump_reason: Option<&'static str>,
     last_cached_tokens: Option<u64>,
     last_gateway_hit_tokens: Option<u64>,
+    last_anchor_aligned: Option<bool>,
     last_unchanged_reprocessed_est: Option<u64>,
 }
 
@@ -488,6 +489,7 @@ impl ContextEngine {
             last_epoch_bump_reason: None,
             last_cached_tokens: None,
             last_gateway_hit_tokens: None,
+            last_anchor_aligned: None,
             last_unchanged_reprocessed_est: None,
         }
     }
@@ -753,6 +755,13 @@ impl ContextEngine {
             tracing::debug!(
                 gateway_hit_tokens = gateway_hit,
                 "inference gateway cache hits"
+            );
+        }
+        if let Some(aligned) = usage.gateway_anchor_aligned {
+            self.last_anchor_aligned = Some(aligned);
+            tracing::debug!(
+                anchor_aligned = aligned,
+                "inference gateway anchor alignment"
             );
         }
         if let Some(cached) = usage.cached_tokens {
@@ -1090,6 +1099,7 @@ impl ContextEngine {
             break_kind: break_kind.as_str().to_string(),
             cached_tokens: self.last_cached_tokens,
             gateway_hit_tokens: self.last_gateway_hit_tokens,
+            anchor_aligned: self.last_anchor_aligned,
             unchanged_reprocessed_est: self.last_unchanged_reprocessed_est,
         }
     }

--- a/crates/context/src/layout.rs
+++ b/crates/context/src/layout.rs
@@ -68,6 +68,11 @@ pub struct PrefixCacheExplain {
     /// against `cached_tokens`, the gap diagnoses ledger-vs-engine drift.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gateway_hit_tokens: Option<u64>,
+    /// Gateway-reported semantic-anchor alignment (docs/semantic-anchor-routing.md
+    /// counterpart): true when the exact match's final page boundary coincided
+    /// with a structural block boundary likely to survive agentic context edits.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub anchor_aligned: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unchanged_reprocessed_est: Option<u64>,
 }

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -193,6 +193,7 @@ pub fn runtime_event_handler(
                         break_kind: prefix_cache.break_kind.clone(),
                         cached_tokens: prefix_cache.cached_tokens,
                         gateway_hit_tokens: prefix_cache.gateway_hit_tokens,
+                        anchor_aligned: prefix_cache.anchor_aligned,
                         unchanged_reprocessed_est: prefix_cache.unchanged_reprocessed_est,
                     },
                 },
@@ -380,6 +381,7 @@ mod tests {
                 break_kind: "none".into(),
                 cached_tokens: None,
                 gateway_hit_tokens: None,
+                anchor_aligned: None,
                 unchanged_reprocessed_est: None,
             },
         });

--- a/crates/core/src/usage.rs
+++ b/crates/core/src/usage.rs
@@ -57,6 +57,7 @@ mod tests {
             total_tokens: 12,
             cached_tokens: Some(4),
             gateway_hit_tokens: None,
+            gateway_anchor_aligned: None,
         });
         accumulator.record(&TokenUsage {
             prompt_tokens: 3,
@@ -64,6 +65,7 @@ mod tests {
             total_tokens: 4,
             cached_tokens: Some(1),
             gateway_hit_tokens: None,
+            gateway_anchor_aligned: None,
         });
         assert_eq!(accumulator.total().prompt_tokens, 13);
         assert_eq!(accumulator.total().cached_tokens, Some(5));

--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -312,7 +312,14 @@ fn parse_anthropic_response(raw: &Value) -> Result<ChatResponse> {
                 .and_then(Value::as_u64)
                 .unwrap_or(0),
         cached_tokens: None,
-        gateway_hit_tokens: usage.get("cache_hit_tokens").and_then(Value::as_u64),
+        gateway_hit_tokens: usage
+            .get("gateway_cache_hit_tokens")
+            .and_then(Value::as_u64)
+            .or_else(|| usage.get("cache_hit_tokens").and_then(Value::as_u64)),
+        gateway_anchor_aligned: usage
+            .get("gateway_anchor_aligned")
+            .and_then(Value::as_bool)
+            .or_else(|| usage.get("anchor_aligned").and_then(Value::as_bool)),
     });
 
     let message = if tool_calls.is_empty() {
@@ -458,6 +465,7 @@ impl AnthropicStreamState {
                                 .and_then(Value::as_u64)
                                 .unwrap_or(0),
                             cached_tokens: None,
+                            gateway_anchor_aligned: None,
                             gateway_hit_tokens: usage
                                 .get("cache_hit_tokens")
                                 .and_then(Value::as_u64),

--- a/crates/llm/src/openai_compatible.rs
+++ b/crates/llm/src/openai_compatible.rs
@@ -228,6 +228,15 @@ pub(crate) fn to_proxy_request(request: &ChatRequest, stream: bool) -> Result<Pr
         metadata: HashMap::new(),
     };
     proxy.mark_openai_raw_messages();
+    if stream {
+        // Ask OpenAI-compatible upstreams (SGLang / vLLM / OpenAI) to emit a
+        // terminal usage chunk so gateway-injected telemetry fields survive on
+        // the streaming path. Providers that ignore it are unaffected.
+        proxy.extra.insert(
+            "stream_options".to_string(),
+            serde_json::json!({ "include_usage": true }),
+        );
+    }
     if let Some(ctx) = &request.context {
         proxy
             .metadata

--- a/crates/llm/src/usage.rs
+++ b/crates/llm/src/usage.rs
@@ -50,7 +50,10 @@ fn usage_object(raw: &serde_json::Value) -> Option<&serde_json::Value> {
     if let Some(usage) = raw.get("usage") {
         return Some(usage);
     }
-    raw.as_array()?.iter().rev().find_map(|event| event.get("usage"))
+    raw.as_array()?
+        .iter()
+        .rev()
+        .find_map(|event| event.get("usage"))
 }
 
 pub fn parse_usage_from_raw(raw: &serde_json::Value) -> Option<TokenUsage> {

--- a/crates/llm/src/usage.rs
+++ b/crates/llm/src/usage.rs
@@ -13,6 +13,12 @@ pub struct TokenUsage {
     /// Kept separate from `cached_tokens` so ledger view vs engine reality can be compared.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gateway_hit_tokens: Option<u64>,
+    /// Gateway-reported semantic-anchor alignment of the served prefix
+    /// (Cortex `usage.gateway_anchor_aligned`). `true` means the exact match's
+    /// final page boundary coincided with a structural block boundary, so the
+    /// hit is likely to survive the next agentic context edit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gateway_anchor_aligned: Option<bool>,
 }
 
 impl TokenUsage {
@@ -29,6 +35,10 @@ impl TokenUsage {
             (Some(a), Some(b)) => self.gateway_hit_tokens = Some(a + b),
             (None, Some(b)) => self.gateway_hit_tokens = Some(b),
             _ => {}
+        }
+        // Alignment is a per-step property, not a sum: last observed wins.
+        if other.gateway_anchor_aligned.is_some() {
+            self.gateway_anchor_aligned = other.gateway_anchor_aligned;
         }
     }
 }
@@ -58,11 +68,26 @@ pub fn parse_usage_from_raw(raw: &serde_json::Value) -> Option<TokenUsage> {
                 .and_then(serde_json::Value::as_u64)
         });
 
-    // Gateway-injected ledger hits (unigateway normalizes heterogeneous upstream
-    // shapes into `usage.cache_hit_tokens`).
+    // Gateway-injected ledger hits. Two shapes exist in the wild:
+    // - unigateway normalization: `usage.cache_hit_tokens`
+    // - Cortex direct injection:  `usage.gateway_cache_hit_tokens`
     let gateway_hit_tokens = usage
-        .get("cache_hit_tokens")
-        .and_then(serde_json::Value::as_u64);
+        .get("gateway_cache_hit_tokens")
+        .and_then(serde_json::Value::as_u64)
+        .or_else(|| {
+            usage
+                .get("cache_hit_tokens")
+                .and_then(serde_json::Value::as_u64)
+        });
+
+    let gateway_anchor_aligned = usage
+        .get("gateway_anchor_aligned")
+        .and_then(serde_json::Value::as_bool)
+        .or_else(|| {
+            usage
+                .get("anchor_aligned")
+                .and_then(serde_json::Value::as_bool)
+        });
 
     Some(TokenUsage {
         prompt_tokens,
@@ -70,6 +95,7 @@ pub fn parse_usage_from_raw(raw: &serde_json::Value) -> Option<TokenUsage> {
         total_tokens,
         cached_tokens,
         gateway_hit_tokens,
+        gateway_anchor_aligned,
     })
 }
 
@@ -112,6 +138,25 @@ mod tests {
     }
 
     #[test]
+    fn parses_cortex_injected_fields() {
+        // Cortex injects into the response body (unigateway-sdk's proxy_chat
+        // does not surface response headers): usage.gateway_cache_hit_tokens +
+        // usage.gateway_anchor_aligned.
+        let raw = json!({
+            "usage": {
+                "prompt_tokens": 500,
+                "completion_tokens": 16,
+                "total_tokens": 516,
+                "gateway_cache_hit_tokens": 320,
+                "gateway_anchor_aligned": true
+            }
+        });
+        let usage = parse_usage_from_raw(&raw).expect("usage");
+        assert_eq!(usage.gateway_hit_tokens, Some(320));
+        assert_eq!(usage.gateway_anchor_aligned, Some(true));
+    }
+
+    #[test]
     fn accumulate_sums_fields() {
         let mut total = TokenUsage {
             prompt_tokens: 1,
@@ -119,6 +164,7 @@ mod tests {
             total_tokens: 3,
             cached_tokens: None,
             gateway_hit_tokens: None,
+            gateway_anchor_aligned: None,
         };
         total.accumulate(&TokenUsage {
             prompt_tokens: 4,
@@ -126,11 +172,14 @@ mod tests {
             total_tokens: 9,
             cached_tokens: Some(2),
             gateway_hit_tokens: Some(7),
+            gateway_anchor_aligned: Some(true),
         });
         assert_eq!(total.prompt_tokens, 5);
         assert_eq!(total.completion_tokens, 7);
         assert_eq!(total.total_tokens, 12);
         assert_eq!(total.cached_tokens, Some(2));
         assert_eq!(total.gateway_hit_tokens, Some(7));
+        // Alignment is a per-step property: last observed wins.
+        assert_eq!(total.gateway_anchor_aligned, Some(true));
     }
 }

--- a/crates/llm/src/usage.rs
+++ b/crates/llm/src/usage.rs
@@ -43,8 +43,18 @@ impl TokenUsage {
     }
 }
 
+/// Locates the `usage` object in either a completed JSON body (`{usage: ...}`)
+/// or a streaming aggregation (`[{...}, {usage: ...}]` — unigateway-sdk stores
+/// the raw SSE events as an array on `ChatResponseFinal.raw`).
+fn usage_object(raw: &serde_json::Value) -> Option<&serde_json::Value> {
+    if let Some(usage) = raw.get("usage") {
+        return Some(usage);
+    }
+    raw.as_array()?.iter().rev().find_map(|event| event.get("usage"))
+}
+
 pub fn parse_usage_from_raw(raw: &serde_json::Value) -> Option<TokenUsage> {
-    let usage = raw.get("usage")?;
+    let usage = usage_object(raw)?;
     let prompt_tokens = usage
         .get("prompt_tokens")
         .and_then(serde_json::Value::as_u64)
@@ -154,6 +164,29 @@ mod tests {
         let usage = parse_usage_from_raw(&raw).expect("usage");
         assert_eq!(usage.gateway_hit_tokens, Some(320));
         assert_eq!(usage.gateway_anchor_aligned, Some(true));
+    }
+
+    #[test]
+    fn parses_usage_from_streaming_event_array() {
+        // unigateway-sdk streaming completion stores raw as an array of SSE
+        // payloads; the last event carries the usage object.
+        let raw = json!([
+            {"choices": [{"delta": {"content": "hi"}}]},
+            {
+                "choices": [],
+                "usage": {
+                    "prompt_tokens": 80,
+                    "completion_tokens": 4,
+                    "total_tokens": 84,
+                    "gateway_cache_hit_tokens": 64,
+                    "gateway_anchor_aligned": false
+                }
+            }
+        ]);
+        let usage = parse_usage_from_raw(&raw).expect("usage");
+        assert_eq!(usage.prompt_tokens, 80);
+        assert_eq!(usage.gateway_hit_tokens, Some(64));
+        assert_eq!(usage.gateway_anchor_aligned, Some(false));
     }
 
     #[test]

--- a/crates/turn/src/events.rs
+++ b/crates/turn/src/events.rs
@@ -43,6 +43,9 @@ pub struct ProjectionPrefixCache {
     pub break_kind: String,
     pub cached_tokens: Option<u64>,
     pub gateway_hit_tokens: Option<u64>,
+    /// Gateway-reported semantic-anchor alignment of the served prefix
+    /// (Cortex `usage.gateway_anchor_aligned`).
+    pub anchor_aligned: Option<bool>,
     pub unchanged_reprocessed_est: Option<u64>,
 }
 


### PR DESCRIPTION
## Summary

Completes the agent-side half of the Cortex telemetry loop (issue #128 follow-up; cortex counterpart: ParaTensor/cortex#2 commit a34bbb3).

unigateway-sdk's `proxy_chat` does not surface response headers, so Cortex now injects gateway telemetry into the **response body**:

```json
{
  "cortex": {"assigned_worker": "...", "match_mode": "exact_kv_events",
             "cache_hit_tokens": 320, "anchor_aligned": true},
  "usage":  {"gateway_cache_hit_tokens": 320, "gateway_anchor_aligned": true}
}
```

This PR makes zene consume it:

1. **`usage.rs`** — `parse_usage_from_raw` accepts both `usage.gateway_cache_hit_tokens` (Cortex direct injection) and `usage.cache_hit_tokens` (unigateway normalization); new `TokenUsage.gateway_anchor_aligned: Option<bool>` with the same dual-name tolerance. `accumulate` treats alignment as last-observed-wins (per-step property, not a sum).
2. **Streaming opt-in** — streaming proxy requests set `stream_options.include_usage` via forwardable `extra`. Without it, OpenAI-compatible upstreams emit no terminal usage chunk and gateway telemetry was streaming-dead on arrival. Providers that ignore the option are unaffected.
3. **Explain surfacing** — `ContextEngine` captures the anchor flag next to `last_gateway_hit_tokens`; new `PrefixCacheExplain.anchor_aligned` / turn `ProjectionPrefixCache.anchor_aligned` (serde-defaulted — existing persisted JSON stays compatible) projected into core events for Console display.

## Diagnostic value

With both numbers side by side in `PrefixCacheExplain`:

- `gateway_hit_tokens > 0 && cached_tokens == 0` → ledger routed correctly but engine radix missed (engine restart / eviction)
- `cached_tokens > gateway_hit_tokens` → provider-side prefix cache working beyond the ledger's view
- `anchor_aligned == false` on exact hits → matches ending mid-block; next agentic context edit will likely collapse them (feeds issue #130 truncation-at-commit design)

## Test plan

- [x] New unit tests: Cortex-shape parsing (`gateway_cache_hit_tokens` + `gateway_anchor_aligned`), accumulate semantics
- [x] Full workspace `cargo test` green (206 tests)
- [ ] Live RTX PRO 6000 verification (follow-up comment): real `zene acp` traffic against Cortex, debug logs showing non-None gateway hits

Related: #128, ParaTensor/cortex#2
