### PR TITLE
feat(llm): read gateway telemetry from upstream response headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,9 +3389,8 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unigateway-core"
-version = "2.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48720d1d15f70b6b7e85609feb2fdfd4797d4245adb4dcf02a51f953ce743284"
+version = "2.15.0"
+source = "git+https://github.com/EeroEternal/unigateway?branch=main#dfaae051021218443ac9470ef9192c90174e68fc"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -3406,9 +3405,8 @@ dependencies = [
 
 [[package]]
 name = "unigateway-host"
-version = "2.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0c7b40af01e7126e798329828f5f6fa5d7679aed10b26e2711e674e542a000"
+version = "2.15.0"
+source = "git+https://github.com/EeroEternal/unigateway?branch=main#dfaae051021218443ac9470ef9192c90174e68fc"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3424,9 +3422,8 @@ dependencies = [
 
 [[package]]
 name = "unigateway-protocol"
-version = "2.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94dff5f8647364e4accdb6b90ba570f752bca020ed057b7ea5aeaee0f067023d"
+version = "2.15.0"
+source = "git+https://github.com/EeroEternal/unigateway?branch=main#dfaae051021218443ac9470ef9192c90174e68fc"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3440,9 +3437,8 @@ dependencies = [
 
 [[package]]
 name = "unigateway-sdk"
-version = "2.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0ac955477be271811b22959a99e2a34d8b97c29b5ed71b43a4fa459830546b"
+version = "2.15.0"
+source = "git+https://github.com/EeroEternal/unigateway?branch=main#dfaae051021218443ac9470ef9192c90174e68fc"
 dependencies = [
  "unigateway-core",
  "unigateway-host",
@@ -3452,9 +3448,8 @@ dependencies = [
 
 [[package]]
 name = "unigateway-session"
-version = "2.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4291ca4b3f4396b5cdd43e9c7da7b7373ba8744acef4547f632319ba748ef540"
+version = "2.15.0"
+source = "git+https://github.com/EeroEternal/unigateway?branch=main#dfaae051021218443ac9470ef9192c90174e68fc"
 dependencies = [
  "anyhow",
  "axum",
@@ -3467,9 +3462,8 @@ dependencies = [
 
 [[package]]
 name = "unigateway-session-redis"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63795c4e4a104f738401617fc1cdcc3c5741dfbb6610861a643f11d9fd529dde"
+version = "2.15.0"
+source = "git+https://github.com/EeroEternal/unigateway?branch=main#dfaae051021218443ac9470ef9192c90174e68fc"
 dependencies = [
  "redis",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,12 @@ zene-tool-runtime = { path = "crates/tool-runtime" }
 zene-turn = { path = "crates/turn" }
 zene-workspace = { path = "crates/workspace" }
 zene-index = { path = "crates/index" }
-unigateway-sdk = { version = "2.14", default-features = false, features = ["core"] }
+# Pinned to git main until a crates.io release (>=2.15.1) ships
+# `CompletedResponse::response_headers` / `StreamingResponse::response_headers`
+# (EeroEternal/unigateway#6). All unigateway crates must share one source or the
+# type graph splits between registry and git copies.
+unigateway-sdk = { git = "https://github.com/EeroEternal/unigateway", branch = "main", default-features = false, features = ["core"] }
+unigateway-session = { git = "https://github.com/EeroEternal/unigateway", branch = "main" }
+unigateway-session-redis = { git = "https://github.com/EeroEternal/unigateway", branch = "main" }
 llm_providers = "0.12.0"
 tiktoken-rs = "0.12"

--- a/apps/inference-gateway/Cargo.toml
+++ b/apps/inference-gateway/Cargo.toml
@@ -24,9 +24,9 @@ tokio.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-unigateway-sdk = { version = "2.14", features = ["host", "session"] }
-unigateway-session = { version = "2.14", features = ["http"] }
-unigateway-session-redis = "2.14"
+unigateway-sdk = { workspace = true, features = ["host", "session"] }
+unigateway-session = { workspace = true, features = ["http"] }
+unigateway-session-redis = { workspace = true }
 zene-llm = { workspace = true }
 
 [dev-dependencies]

--- a/crates/llm/src/openai_compatible.rs
+++ b/crates/llm/src/openai_compatible.rs
@@ -21,7 +21,7 @@ use crate::message::{Message, Role, ToolCall};
 use crate::provider::{ChatRequest, ChatResponse, Provider, StreamEvent};
 use crate::retry::with_llm_retry;
 use crate::tool::ToolDefinition;
-use crate::usage::{parse_usage_from_raw, TokenUsage};
+use crate::usage::{apply_gateway_headers, parse_usage_from_raw, TokenUsage};
 
 const DEFAULT_POOL_ID: &str = "zene-default";
 const DEFAULT_ENDPOINT_ID: &str = "zene-default";
@@ -116,18 +116,21 @@ impl OpenAiCompatibleProvider {
             .map_err(|err| anyhow!("{err}"))?
         {
             ProxySession::Completed(resp) => {
-                let usage = parse_usage_from_raw(&resp.response.raw);
+                let mut usage = parse_usage_from_raw(&resp.response.raw);
+                apply_gateway_headers(&mut usage, &resp.response_headers);
                 Ok(ChatResponse {
                     message: final_to_message(resp.response),
                     usage,
                 })
             }
             ProxySession::Streaming(streaming) => {
+                let headers = streaming.response_headers.clone();
                 let resp = streaming
                     .into_completion()
                     .await
                     .map_err(|err| anyhow!("{err}"))?;
-                let usage = parse_usage_from_raw(&resp.response.raw);
+                let mut usage = parse_usage_from_raw(&resp.response.raw);
+                apply_gateway_headers(&mut usage, &headers);
                 Ok(ChatResponse {
                     message: final_to_message(resp.response),
                     usage,
@@ -153,13 +156,15 @@ impl OpenAiCompatibleProvider {
 
         match session {
             ProxySession::Completed(resp) => {
+                let mut usage = parse_usage_from_raw(&resp.response.raw);
+                apply_gateway_headers(&mut usage, &resp.response_headers);
                 let message = final_to_message(resp.response.clone());
-                let usage = parse_usage_from_raw(&resp.response.raw);
                 let events = completed_message_to_events(message, usage);
                 Ok(Box::pin(futures::stream::iter(events.into_iter().map(Ok))))
             }
             ProxySession::Streaming(streaming) => {
                 let completion = streaming.completion;
+                let stream_headers = streaming.response_headers.clone();
                 let stream = streaming
                     .stream
                     .map(|chunk| {
@@ -176,10 +181,11 @@ impl OpenAiCompatibleProvider {
                     });
 
                 let done_stream = futures::stream::once(async move {
-                    let usage = match completion.await {
+                    let mut usage = match completion.await {
                         Ok(Ok(resp)) => parse_usage_from_raw(&resp.response.raw),
                         _ => None,
                     };
+                    apply_gateway_headers(&mut usage, &stream_headers);
                     Ok(StreamEvent::Done { usage })
                 });
 

--- a/crates/llm/src/usage.rs
+++ b/crates/llm/src/usage.rs
@@ -56,6 +56,48 @@ fn usage_object(raw: &serde_json::Value) -> Option<&serde_json::Value> {
         .find_map(|event| event.get("usage"))
 }
 
+/// Header names for Cortex gateway routing telemetry.
+const HEADER_HIT_TOKENS: &str = "x-cortex-cache-hit-tokens";
+const HEADER_ANCHOR_ALIGNED: &str = "x-cortex-anchor-aligned";
+
+/// Merges gateway routing headers into parsed usage as a fallback for fields
+/// the response body did not carry. Body values (per-request, injected by the
+/// gateway) win over headers when both are present.
+///
+/// Source: unigateway response_headers (surfaced in unigateway#6); Cortex
+/// emits `x-cortex-cache-hit-tokens` / `x-cortex-anchor-aligned`.
+pub fn apply_gateway_headers(
+    usage: &mut Option<TokenUsage>,
+    headers: &std::collections::HashMap<String, String>,
+) {
+    let hit = headers
+        .get(HEADER_HIT_TOKENS)
+        .and_then(|v| v.parse::<u64>().ok());
+    let aligned = headers
+        .get(HEADER_ANCHOR_ALIGNED)
+        .map(|v| v.trim() == "true");
+    if hit.is_none() && aligned.is_none() {
+        return;
+    }
+    match usage {
+        Some(u) => {
+            if u.gateway_hit_tokens.is_none() {
+                u.gateway_hit_tokens = hit;
+            }
+            if u.gateway_anchor_aligned.is_none() {
+                u.gateway_anchor_aligned = aligned;
+            }
+        }
+        slot @ None => {
+            *slot = Some(TokenUsage {
+                gateway_hit_tokens: hit,
+                gateway_anchor_aligned: aligned,
+                ..TokenUsage::default()
+            });
+        }
+    }
+}
+
 pub fn parse_usage_from_raw(raw: &serde_json::Value) -> Option<TokenUsage> {
     let usage = usage_object(raw)?;
     let prompt_tokens = usage
@@ -116,6 +158,48 @@ pub fn parse_usage_from_raw(raw: &serde_json::Value) -> Option<TokenUsage> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn gateway_headers_fill_missing_fields_without_overriding_body() {
+        use std::collections::HashMap;
+        let mut headers = HashMap::new();
+        headers.insert("x-cortex-cache-hit-tokens".to_string(), "320".to_string());
+        headers.insert("x-cortex-anchor-aligned".to_string(), "true".to_string());
+
+        // Body empty: headers create the usage entry.
+        let mut none: Option<TokenUsage> = None;
+        apply_gateway_headers(&mut none, &headers);
+        let u = none.expect("created");
+        assert_eq!(u.gateway_hit_tokens, Some(320));
+        assert_eq!(u.gateway_anchor_aligned, Some(true));
+
+        // Body present but fields missing: headers fill them.
+        let mut some = Some(TokenUsage {
+            prompt_tokens: 10,
+            ..TokenUsage::default()
+        });
+        apply_gateway_headers(&mut some, &headers);
+        let u = some.expect("kept");
+        assert_eq!(u.gateway_hit_tokens, Some(320));
+        assert_eq!(u.prompt_tokens, 10);
+
+        // Body values win over headers when both exist.
+        let mut both = Some(TokenUsage {
+            gateway_hit_tokens: Some(64),
+            gateway_anchor_aligned: Some(false),
+            ..TokenUsage::default()
+        });
+        apply_gateway_headers(&mut both, &headers);
+        let u = both.expect("kept");
+        assert_eq!(u.gateway_hit_tokens, Some(64));
+        assert_eq!(u.gateway_anchor_aligned, Some(false));
+
+        // Unrelated headers are a no-op.
+        let empty = HashMap::new();
+        let mut none2: Option<TokenUsage> = None;
+        apply_gateway_headers(&mut none2, &empty);
+        assert!(none2.is_none());
+    }
 
     #[test]
     fn parse_openai_usage() {


### PR DESCRIPTION
## Summary

Follow-up to #133, enabled by [EeroEternal/unigateway#6](https://github.com/EeroEternal/unigateway/pull/6) (merged): unigateway now surfaces upstream HTTP response headers on `CompletedResponse` / `StreamingResponse`.

Cortex emits routing diagnostics as headers (`x-cortex-cache-hit-tokens`, `x-cortex-anchor-aligned`). This PR adds the header path as a **supplementary** telemetry channel — the body injection from #133 stays primary (it carries per-request values on both JSON and SSE paths); headers fill in when the body lacks them, e.g. when a future gateway does not inject bodies.

- **`apply_gateway_headers()`** in `usage.rs`: header values only fill `gateway_hit_tokens` / `gateway_anchor_aligned` when the body did not provide them; creates a minimal `TokenUsage` when no usage payload exists at all.
- Wired into all four response paths of the OpenAI-compatible provider (`chat_once` completed/streaming, `chat_stream_once` completed/streaming).
- **Dependency note**: `unigateway-*` crates temporarily pinned to `EeroEternal/unigateway@main` and unified across `zene-llm` + `zene-inference-gateway` so the type graph does not split between registry and git copies. **TODO before next crates.io publish**: pin back to a released version once 2.15.1+ ships `response_headers`.

## Test plan

- [x] New unit test: header fill semantics (create / fill-missing / body-wins / no-op)
- [x] Full workspace `cargo test`: 379 passed
- [x] Live RTX PRO 6000 verification: rebuilt `zene` against this branch, real `zene acp` session against Cortex shows gateway telemetry arriving (`inference gateway cache hits` / `anchor alignment` debug logs) and `publish` → 200

Related: #128, EeroEternal/cortex#3, EeroEternal/unigateway#6
