### PR TITLE
feat(context): commit-time tool-result shaping — stop in-place prefix rewrite (#130)

### DIFF
--- a/crates/context/src/compaction.rs
+++ b/crates/context/src/compaction.rs
@@ -456,7 +456,8 @@ pub fn plan_compaction(
 }
 
 fn truncate_message_body(content: &str, max_content_chars: usize) -> Option<String> {
-    if content.starts_with("[truncated ") {
+    // Already commit-shaped (handle or placeholder): never rewrite.
+    if content.starts_with("[truncated ") || content.starts_with("[zene-tool-output ") {
         return None;
     }
     let char_count = content.chars().count();
@@ -585,6 +586,9 @@ fn record_compaction_result<S: ContextSession + ?Sized>(
     );
 }
 
+/// Retained for tests and explicit callers. Not used by [`compact_session`]
+/// (#130: in-place prefix rewrite is a BodyMutate).
+#[allow(dead_code)]
 fn try_truncate_only_compaction<S: ContextSession + ?Sized>(
     session: &mut S,
     config: &CompactionConfig,
@@ -676,41 +680,16 @@ fn try_slice_keep_compaction<S: ContextSession + ?Sized>(
     Some(result)
 }
 
-/// Overflow recovery: apply phase-1 truncation in place before a retry (no threshold check).
+/// Overflow recovery: never rewrite older prefix bodies (#130).
+/// Current-turn tool tails are shaped via [`apply_steps_truncate_pass`];
+/// everything else must go through slice/summarize (epoch++).
 pub fn apply_overflow_truncate_pass<S: ContextSession + ?Sized>(
     session: &mut S,
     config: &CompactionConfig,
-    tools: &[ToolDefinition],
-    estimator: &TokenEstimator,
+    _tools: &[ToolDefinition],
+    _estimator: &TokenEstimator,
 ) -> bool {
-    let tokens_before = estimate_session_tokens(session, tools, estimator);
-    let messages = projected_messages(session);
-    let Some(plan) = plan_compaction(&messages, config, estimator) else {
-        return false;
-    };
-    let prefix_start = system_prefix_start(&messages);
-    let mut projected = messages;
-    let truncated = truncate_old_message_bodies(
-        &mut projected,
-        prefix_start,
-        plan.tail_start,
-        TRUNCATE_TOOL_RESULT_MAX_CHARS,
-        TRUNCATE_ASSISTANT_TEXT_MAX_CHARS,
-    );
-    if truncated == 0 {
-        return false;
-    }
-
-    let tokens_after = tokens::estimate_context(&projected, tools, estimator) as u32;
-    session.commit_compaction_snapshot(
-        "context_overflow_truncate",
-        truncated,
-        None,
-        Some(tokens_before),
-        Some(tokens_after),
-        projected,
-    );
-    true
+    apply_steps_truncate_pass(session, config)
 }
 
 pub fn subagent_compaction_config(parent: &CompactionConfig) -> CompactionConfig {
@@ -805,10 +784,7 @@ where
 {
     let tokens_before = tokens::estimate_context(messages, tools, estimator) as u32;
 
-    if let Some(result) = try_truncate_only_on_messages(messages, config, tools, estimator) {
-        return Ok(Some(result));
-    }
-
+    // #130: skip in-place prefix rewrite; slice/summarize only.
     if let Some(result) = try_slice_keep_on_messages(messages, config, tools, estimator) {
         return Ok(Some(result));
     }
@@ -868,6 +844,8 @@ where
     }))
 }
 
+/// Retained for tests. Not used by [`compact_with_phases`] (#130).
+#[allow(dead_code)]
 fn try_truncate_only_on_messages(
     messages: &mut Vec<Message>,
     config: &CompactionConfig,
@@ -989,10 +967,8 @@ pub async fn compact_session<S: ContextSession + ?Sized>(
     prefire: Option<&PrefireCache>,
     memory_block: Option<&str>,
 ) -> Result<Option<CompactionResult>> {
-    if let Some(result) = try_truncate_only_compaction(session, config, tools, estimator) {
-        return Ok(Some(result));
-    }
-
+    // #130: do not rewrite existing prefix bodies in place (BodyMutate).
+    // Commit-time shaping + slice/summarize (epoch++) are the only size valves.
     if let Some(result) = try_slice_keep_compaction(session, config, tools, estimator) {
         return Ok(Some(result));
     }
@@ -1295,6 +1271,19 @@ mod tests {
     }
 
     #[test]
+    #[test]
+    fn truncate_old_skips_commit_shaped_handles() {
+        let handle = "[zene-tool-output path=\"/tmp/out.txt\" bytes=9000]".to_string();
+        let mut messages = vec![
+            Message::system("sys"),
+            tool_msg(&handle),
+            user_msg("recent"),
+        ];
+        let truncated = truncate_old_message_bodies(&mut messages, 1, 2, 100, 100);
+        assert_eq!(truncated, 0);
+        assert_eq!(messages[1].content.as_deref(), Some(handle.as_str()));
+    }
+
     fn truncate_old_tool_results_replaces_large_bodies() {
         let mut messages = vec![
             Message::system("sys"),

--- a/crates/tool-runtime/src/output_bound.rs
+++ b/crates/tool-runtime/src/output_bound.rs
@@ -6,16 +6,20 @@ pub const TOOL_MAX_OUTPUT_BYTES: usize = 30_000;
 const ENV_TOOL_OUTPUT_HANDLES: &str = "ZENE_TOOL_OUTPUT_HANDLES";
 
 /// When true, spilled tool output is referenced by handle only (no large inline preview).
+///
+/// Defaults **on**: commit-time shaping (#130) prefers a short immutable handle
+/// over a large inline body that compaction would later rewrite (BodyMutate).
+/// Set `ZENE_TOOL_OUTPUT_HANDLES=0` to restore the inline-preview fallback.
 pub fn tool_output_handles_enabled() -> bool {
     std::env::var(ENV_TOOL_OUTPUT_HANDLES)
         .ok()
         .map(|v| {
-            matches!(
+            !matches!(
                 v.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
+                "0" | "false" | "no" | "off"
             )
         })
-        .unwrap_or(false)
+        .unwrap_or(true)
 }
 
 pub fn tool_max_output_bytes() -> usize {
@@ -114,6 +118,24 @@ mod tests {
         let plan = plan_tool_output_bound("y".repeat(2000), "Bash");
         std::env::remove_var("ZENE_MAX_TOOL_OUTPUT_BYTES");
         assert!(matches!(plan, ToolBoundPlan::Spill(_)));
+    }
+
+    #[test]
+    fn handles_default_on_without_env() {
+        std::env::remove_var("ZENE_TOOL_OUTPUT_HANDLES");
+        assert!(tool_output_handles_enabled());
+        let out = format_bounded_output("yyyy", 400, Some("/tmp/out.txt"), 2000);
+        assert!(out.starts_with("[zene-tool-output path="));
+        assert!(!out.contains("yyyy"));
+    }
+
+    #[test]
+    fn handles_can_be_disabled() {
+        std::env::set_var("ZENE_TOOL_OUTPUT_HANDLES", "0");
+        let out = format_bounded_output("yyyy", 400, Some("/tmp/out.txt"), 2000);
+        std::env::remove_var("ZENE_TOOL_OUTPUT_HANDLES");
+        assert!(out.contains("yyyy"));
+        assert!(out.contains("[truncated"));
     }
 
     #[test]

--- a/crates/tool-runtime/src/spill_store.rs
+++ b/crates/tool-runtime/src/spill_store.rs
@@ -93,8 +93,12 @@ mod tests {
         std::env::remove_var("ZENE_MAX_TOOL_OUTPUT_BYTES");
         let store = FsToolOutputStore::new(dir.path());
         let out = apply_tool_bound_plan(plan, &store);
-        assert!(out.contains("truncated"));
+        // Default commit shape is a handle (#130); path still points at the spill.
         assert!(out.contains(".zene/tool-output/"));
+        assert!(
+            out.starts_with("[zene-tool-output ") || out.contains("[truncated"),
+            "expected handle or truncated placeholder, got {out}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements [#130](https://github.com/EeroEternal/zene/issues/130): tool results are **shaped once at commit** and never rewritten in place. Prefix bytes stay frozen; size control after that is slice-keep or LLM summarize (`epoch++`).

Closes the Cortex-side `BodyMutate` class of prefix breaks (#128 P2).

## What changed

1. **Handles default ON** (`ZENE_TOOL_OUTPUT_HANDLES=0` restores the old inline preview). Spilled output is a short `[zene-tool-output path=… bytes=N]` placeholder from the first write — compaction has nothing left to rewrite.
2. **`compact_session` / `compact_with_phases` no longer run truncate-only** in-place rewrite of older prefix bodies. They fall through to slice-keep or summarize.
3. **`apply_overflow_truncate_pass`** only shapes the **current-turn** tool tail (steps-first). Older prefix messages are left untouched; further recovery is compact.
4. **`truncate_old_message_bodies`** treats handles and `[truncated …]` as already-shaped (no-op). Residual helper kept for tests.

## Acceptance

- [x] Existing history bytes are not rewritten on the non-compact path
- [x] Overflow still recovers (current-turn truncate, then compact)
- [x] Existing compaction tests green + new “handle is immutable under truncate_old” test
- [x] Handles default-on / can-disable tests

`break_kind=body_mutate` still will not fire in production (the mutate path is gone). That is the desired end state, not a miss: the classifier can stay for residual/test use.

## Test plan

- [x] `cargo test -p zene-context -p zene-tool-runtime -p zene-core`
- [x] `cargo test --workspace`

Related: #128 #3, Cortex write-through (EeroEternal/cortex#5).
