### PR TITLE
chore: pin unigateway crates to crates.io 2.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3389,8 +3389,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unigateway-core"
-version = "2.15.0"
-source = "git+https://github.com/EeroEternal/unigateway?branch=main#dfaae051021218443ac9470ef9192c90174e68fc"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9996db59b55783ac7062b60ac9d48a355eddef43d9460d06f1fc2d70d5f39895"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -3405,8 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "unigateway-host"
-version = "2.15.0"
-source = "git+https://github.com/EeroEternal/unigateway?branch=main#dfaae051021218443ac9470ef9192c90174e68fc"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef17eb5be23ee0cf1160f791a89327ec817d470fee6e2a9004882a4dbe65f9ee"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3422,8 +3424,9 @@ dependencies = [
 
 [[package]]
 name = "unigateway-protocol"
-version = "2.15.0"
-source = "git+https://github.com/EeroEternal/unigateway?branch=main#dfaae051021218443ac9470ef9192c90174e68fc"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d6eafd041d3ef78047167a02c0eaaaaf511c0ab462ccbc6170181d2eaebc10"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3437,8 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "unigateway-sdk"
-version = "2.15.0"
-source = "git+https://github.com/EeroEternal/unigateway?branch=main#dfaae051021218443ac9470ef9192c90174e68fc"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae47955b8707c2c11e582e192f329033bad0c80ba5c0275770f0904aa3b50d91"
 dependencies = [
  "unigateway-core",
  "unigateway-host",
@@ -3448,8 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "unigateway-session"
-version = "2.15.0"
-source = "git+https://github.com/EeroEternal/unigateway?branch=main#dfaae051021218443ac9470ef9192c90174e68fc"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbd522789e1b1ca136f3b6fb1cca3728c92ca0e42ed4c8b2a21c08ec02ab123"
 dependencies = [
  "anyhow",
  "axum",
@@ -3462,8 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "unigateway-session-redis"
-version = "2.15.0"
-source = "git+https://github.com/EeroEternal/unigateway?branch=main#dfaae051021218443ac9470ef9192c90174e68fc"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f704d2d041e339619c0426b7f825c8e32b4e18be23f4c826f1aedadc26a6e3"
 dependencies = [
  "redis",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,12 +69,8 @@ zene-tool-runtime = { path = "crates/tool-runtime" }
 zene-turn = { path = "crates/turn" }
 zene-workspace = { path = "crates/workspace" }
 zene-index = { path = "crates/index" }
-# Pinned to git main until a crates.io release (>=2.15.1) ships
-# `CompletedResponse::response_headers` / `StreamingResponse::response_headers`
-# (EeroEternal/unigateway#6). All unigateway crates must share one source or the
-# type graph splits between registry and git copies.
-unigateway-sdk = { git = "https://github.com/EeroEternal/unigateway", branch = "main", default-features = false, features = ["core"] }
-unigateway-session = { git = "https://github.com/EeroEternal/unigateway", branch = "main" }
-unigateway-session-redis = { git = "https://github.com/EeroEternal/unigateway", branch = "main" }
+unigateway-sdk = { version = "2.15.1", default-features = false, features = ["core"] }
+unigateway-session = { version = "2.15.1" }
+unigateway-session-redis = { version = "2.15.1" }
 llm_providers = "0.12.0"
 tiktoken-rs = "0.12"


### PR DESCRIPTION
## Summary

unigateway **2.15.1** is on crates.io (tag `v2.15.1`, includes #6 `response_headers`).

This drops the temporary git-main pin so zene can `cargo publish` again.

```toml
unigateway-sdk = { version = "2.15.1", default-features = false, features = ["core"] }
unigateway-session = { version = "2.15.1" }
unigateway-session-redis = { version = "2.15.1" }
```

`apps/inference-gateway` already uses `workspace = true`.

## Test plan

- [x] `cargo update` resolved registry 2.15.1
- [x] `cargo test -p zene-llm` / `zene-context` / `zene-core` green
