### PR TITLE
feat(sandbox): forward network allowlist to agentcell egress firewall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 [[package]]
 name = "eero-keel-core"
 version = "0.0.15"
-source = "git+https://github.com/EeroEternal/keel#75bd2cfdd5f9e937bed59eb0774295ef7fddf6b2"
+source = "git+https://github.com/EeroEternal/keel#b2475b68987c11ba8f65b4cec400b7c3549851fb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "eero-keel-enforce"
 version = "0.0.15"
-source = "git+https://github.com/EeroEternal/keel#75bd2cfdd5f9e937bed59eb0774295ef7fddf6b2"
+source = "git+https://github.com/EeroEternal/keel#b2475b68987c11ba8f65b4cec400b7c3549851fb"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "eero-keel-policy"
 version = "0.0.15"
-source = "git+https://github.com/EeroEternal/keel#75bd2cfdd5f9e937bed59eb0774295ef7fddf6b2"
+source = "git+https://github.com/EeroEternal/keel#b2475b68987c11ba8f65b4cec400b7c3549851fb"
 dependencies = [
  "chrono",
  "serde",
@@ -801,7 +801,7 @@ dependencies = [
 [[package]]
 name = "eero-keel-record"
 version = "0.0.15"
-source = "git+https://github.com/EeroEternal/keel#75bd2cfdd5f9e937bed59eb0774295ef7fddf6b2"
+source = "git+https://github.com/EeroEternal/keel#b2475b68987c11ba8f65b4cec400b7c3549851fb"
 dependencies = [
  "async-trait",
  "chrono",

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -186,7 +186,17 @@ impl LocalSandbox {
         let backend = if profile == "agentcell"
             || std::env::var("ZENE_SANDBOX_BACKEND").ok().as_deref() == Some("agentcell")
         {
-            keel_core::backend_agentcell(keel_core::AgentCellOptions::default())
+            let mut ac_opts = keel_core::AgentCellOptions::default();
+            if let keel_core::NetworkPolicy::Allowlist(rules) = &network {
+                if let Some(first) = rules.first() {
+                    ac_opts.egress = Some(if let Some(port) = first.port {
+                        format!("{}:{}", first.host, port)
+                    } else {
+                        format!("{}:443", first.host)
+                    });
+                }
+            }
+            keel_core::backend_agentcell(ac_opts)
         } else {
             backend_local_process(options::local_process_options())
         };


### PR DESCRIPTION
## Summary

This PR links Zene's `NetworkPolicy::Allowlist` directly to AgentCell's newly merged `--egress HOST:PORT` capability (via `eero-keel-core` #b2475b68).

### Highlights

1. **Egress Firewall Wiring**:
   - In `crates/sandbox/src/lib.rs`, when `profile == "agentcell"` or `ZENE_SANDBOX_BACKEND=agentcell` is active and an allowlist rule exists (e.g. `api.openai.com:443`), sets `ac_opts.egress` accordingly.
   - Keel's `AgentCellBackend` automatically passes `--egress api.openai.com:443` to `sand`, instructing the host firewall to only permit DNS (53) + target port egress, dropping all other outbound network traffic.
2. **Keel Alignment**:
   - Updates `eero-keel-*` to latest commit `b2475b68` containing merged `AgentCellBackend` with `--egress` and `--secure` (AgentLSM) support.

### Verification
- `cargo test -p zene-sandbox`: 23/23 tests pass.