### PR TITLE
refactor(core,turn,cli): encapsulate projection events into ProjectionReadyEvent and simplify acp updates

### DIFF
--- a/apps/cli/src/acp/server.rs
+++ b/apps/cli/src/acp/server.rs
@@ -26,7 +26,7 @@ use super::terminal_bridge::AcpRemoteTerminal;
 use super::transport::{AcpWriter, SharedState};
 use super::updates::{
     agent_message_chunk, agent_thought_chunk, available_commands_update, current_mode_update,
-    error_update, modes_state, plan_from_todo_arguments, projection_ready_update_with_provenance,
+    error_update, modes_state, plan_from_todo_arguments, projection_ready_update,
     replay_updates_from_messages, step_started, tool_call_result_update, tool_call_update,
     tool_kind, tool_title, turn_ended, turn_started, usage_update,
 };
@@ -934,84 +934,7 @@ fn project_runtime_event(
             *context_epoch,
         )),
         RuntimeEventKind::Error { message } => Some(error_update(message)),
-        RuntimeEventKind::ProjectionReady {
-            source_message_count,
-            projected_message_count,
-            source_event_count,
-            active_event_count,
-            cache_drift_detected,
-            used_materialized_fallback,
-            fallback_reason,
-            active_branch_id,
-            active_path_start_sequence,
-            injected,
-            retained_message_count,
-            retained_turn_count,
-            dropped_event_count,
-            truncated_message_count,
-            compaction_event_ids,
-            tool_output_provenance,
-            retained_turn_ids,
-            injected_sources,
-            delivery,
-            delivery_tail_start,
-            estimate_tokens,
-            context_epoch,
-            prefix_cache,
-        } => Some(projection_ready_update_with_provenance(
-            *source_message_count,
-            *projected_message_count,
-            *source_event_count,
-            *active_event_count,
-            *cache_drift_detected,
-            *used_materialized_fallback,
-            fallback_reason.as_deref(),
-            active_branch_id.as_deref(),
-            *active_path_start_sequence,
-            injected,
-            *retained_message_count,
-            *retained_turn_count,
-            *dropped_event_count,
-            *truncated_message_count,
-            compaction_event_ids,
-            &tool_output_provenance
-                .iter()
-                .map(|item| {
-                    json!({
-                        "messageIndex": item.message_index,
-                        "toolCallId": item.tool_call_id,
-                        "toolName": item.tool_name,
-                        "kind": item.kind,
-                        "handleReference": item.handle_reference,
-                    })
-                })
-                .collect::<Vec<_>>(),
-            retained_turn_ids,
-            &injected_sources
-                .iter()
-                .map(|item| {
-                    json!({
-                        "messageIndex": item.message_index,
-                        "kind": item.kind,
-                        "source": item.source,
-                    })
-                })
-                .collect::<Vec<_>>(),
-            delivery,
-            *delivery_tail_start,
-            *estimate_tokens,
-            *context_epoch,
-            &json!({
-                "prefixEnd": prefix_cache.prefix_end,
-                "bodyEnd": prefix_cache.body_end,
-                "tailDecorationCount": prefix_cache.tail_decoration_count,
-                "prefixFingerprint": prefix_cache.prefix_fingerprint,
-                "breakKind": prefix_cache.break_kind,
-                "cachedTokens": prefix_cache.cached_tokens,
-                "gatewayHitTokens": prefix_cache.gateway_hit_tokens,
-                "unchangedReprocessedEst": prefix_cache.unchanged_reprocessed_est,
-            }),
-        )),
+        RuntimeEventKind::ProjectionReady(ready) => Some(projection_ready_update(ready)),
         RuntimeEventKind::TurnStarted => {
             let turn_id = event.turn_id.as_ref().map(|id| id.to_string());
             Some(turn_started(turn_id.as_deref()))

--- a/apps/cli/src/acp/updates.rs
+++ b/apps/cli/src/acp/updates.rs
@@ -2,6 +2,7 @@
 
 use serde_json::{json, Value};
 use zene_llm::{Message, Role};
+use zene_turn::ProjectionReadyEvent;
 
 /// Map a built-in / MCP tool name to an ACP tool kind.
 pub fn tool_kind(name: &str) -> &'static str {
@@ -354,105 +355,67 @@ pub fn usage_update(
     })
 }
 
-#[allow(dead_code)]
-pub fn projection_ready_update(
-    source_message_count: usize,
-    projected_message_count: usize,
-    source_event_count: usize,
-    active_event_count: usize,
-    cache_drift_detected: bool,
-    used_materialized_fallback: bool,
-    fallback_reason: Option<&str>,
-    active_branch_id: Option<&str>,
-    active_path_start_sequence: Option<u64>,
-    injected: &[String],
-    retained_message_count: usize,
-    retained_turn_count: usize,
-    dropped_event_count: usize,
-    truncated_message_count: usize,
-    compaction_event_ids: &[String],
-    delivery: &str,
-    delivery_tail_start: Option<usize>,
-    estimate_tokens: u32,
-    context_epoch: u64,
-) -> Value {
-    projection_ready_update_with_provenance(
-        source_message_count,
-        projected_message_count,
-        source_event_count,
-        active_event_count,
-        cache_drift_detected,
-        used_materialized_fallback,
-        fallback_reason,
-        active_branch_id,
-        active_path_start_sequence,
-        injected,
-        retained_message_count,
-        retained_turn_count,
-        dropped_event_count,
-        truncated_message_count,
-        compaction_event_ids,
-        &[],
-        &[],
-        &[],
-        delivery,
-        delivery_tail_start,
-        estimate_tokens,
-        context_epoch,
-        &json!({}),
-    )
-}
+pub fn projection_ready_update(event: &ProjectionReadyEvent) -> Value {
+    let tool_output_provenance: Vec<Value> = event
+        .tool_output_provenance
+        .iter()
+        .map(|item| {
+            json!({
+                "messageIndex": item.message_index,
+                "toolCallId": item.tool_call_id,
+                "toolName": item.tool_name,
+                "kind": item.kind,
+                "handleReference": item.handle_reference,
+            })
+        })
+        .collect();
+    let injected_sources: Vec<Value> = event
+        .injected_sources
+        .iter()
+        .map(|item| {
+            json!({
+                "messageIndex": item.message_index,
+                "kind": item.kind,
+                "source": item.source,
+            })
+        })
+        .collect();
+    let prefix_cache = json!({
+        "prefixEnd": event.prefix_cache.prefix_end,
+        "bodyEnd": event.prefix_cache.body_end,
+        "tailDecorationCount": event.prefix_cache.tail_decoration_count,
+        "prefixFingerprint": event.prefix_cache.prefix_fingerprint,
+        "breakKind": event.prefix_cache.break_kind,
+        "cachedTokens": event.prefix_cache.cached_tokens,
+        "gatewayHitTokens": event.prefix_cache.gateway_hit_tokens,
+        "unchangedReprocessedEst": event.prefix_cache.unchanged_reprocessed_est,
+    });
 
-pub fn projection_ready_update_with_provenance(
-    source_message_count: usize,
-    projected_message_count: usize,
-    source_event_count: usize,
-    active_event_count: usize,
-    cache_drift_detected: bool,
-    used_materialized_fallback: bool,
-    fallback_reason: Option<&str>,
-    active_branch_id: Option<&str>,
-    active_path_start_sequence: Option<u64>,
-    injected: &[String],
-    retained_message_count: usize,
-    retained_turn_count: usize,
-    dropped_event_count: usize,
-    truncated_message_count: usize,
-    compaction_event_ids: &[String],
-    tool_output_provenance: &[Value],
-    retained_turn_ids: &[String],
-    injected_sources: &[Value],
-    delivery: &str,
-    delivery_tail_start: Option<usize>,
-    estimate_tokens: u32,
-    context_epoch: u64,
-    prefix_cache: &Value,
-) -> Value {
     json!({
         "sessionUpdate": "projection_update",
         "_meta": {
-            "sourceMessageCount": source_message_count,
-            "projectedMessageCount": projected_message_count,
-            "sourceEventCount": source_event_count,
-            "activeEventCount": active_event_count,
-            "cacheDriftDetected": cache_drift_detected,
-            "usedMaterializedFallback": used_materialized_fallback,
-            "fallbackReason": fallback_reason,
-            "activeBranchId": active_branch_id,
-            "activePathStartSequence": active_path_start_sequence,
-            "injected": injected,
-            "retainedMessageCount": retained_message_count,
-            "retainedTurnCount": retained_turn_count,
-            "droppedEventCount": dropped_event_count,
-            "truncatedMessageCount": truncated_message_count,
-            "compactionEventIds": compaction_event_ids,
+            "sourceMessageCount": event.source_message_count,
+            "projectedMessageCount": event.projected_message_count,
+            "sourceEventCount": event.source_event_count,
+            "activeEventCount": event.active_event_count,
+            "cacheDriftDetected": event.cache_drift_detected,
+            "usedMaterializedFallback": event.used_materialized_fallback,
+            "fallbackReason": event.fallback_reason,
+            "activeBranchId": event.active_branch_id,
+            "activePathStartSequence": event.active_path_start_sequence,
+            "injected": event.injected,
+            "retainedMessageCount": event.retained_message_count,
+            "retainedTurnCount": event.retained_turn_count,
+            "droppedEventCount": event.dropped_event_count,
+            "truncatedMessageCount": event.truncated_message_count,
+            "compactionEventIds": event.compaction_event_ids,
             "toolOutputProvenance": tool_output_provenance,
-            "retainedTurnIds": retained_turn_ids,
+            "retainedTurnIds": event.retained_turn_ids,
             "injectedSources": injected_sources,
-            "delivery": delivery,
-            "deliveryTailStart": delivery_tail_start,
-            "estimateTokens": estimate_tokens,
-            "contextEpoch": context_epoch,
+            "delivery": event.delivery,
+            "deliveryTailStart": event.delivery_tail_start,
+            "estimateTokens": event.estimate_tokens,
+            "contextEpoch": event.context_epoch,
             "prefixCache": prefix_cache,
         },
     })
@@ -675,30 +638,29 @@ mod tests {
 
     #[test]
     fn projection_update_exposes_projection_explain() {
-        let update = projection_ready_update(
-            8,
-            5,
-            12,
-            9,
-            false,
-            false,
-            None,
-            Some("branch-1"),
-            Some(4),
-            &[
+        let event = ProjectionReadyEvent {
+            source_message_count: 8,
+            projected_message_count: 5,
+            source_event_count: 12,
+            active_event_count: 9,
+            active_branch_id: Some("branch-1".to_string()),
+            active_path_start_sequence: Some(4),
+            injected: vec![
                 "compaction_summary".to_string(),
                 "system_reminder".to_string(),
             ],
-            5,
-            2,
-            3,
-            1,
-            &["compact-1".to_string()],
-            "delta",
-            Some(5),
-            321,
-            7,
-        );
+            retained_message_count: 5,
+            retained_turn_count: 2,
+            dropped_event_count: 3,
+            truncated_message_count: 1,
+            compaction_event_ids: vec!["compact-1".to_string()],
+            delivery: "delta".to_string(),
+            delivery_tail_start: Some(5),
+            estimate_tokens: 321,
+            context_epoch: 7,
+            ..Default::default()
+        };
+        let update = projection_ready_update(&event);
         assert_eq!(update["sessionUpdate"], "projection_update");
         assert_eq!(update["_meta"]["activeEventCount"], 9);
         assert_eq!(update["_meta"]["cacheDriftDetected"], false);

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -155,11 +155,19 @@ async fn main() -> Result<()> {
             Ok(())
         }
         None => {
-            anyhow::bail!(
-                "the interactive local REPL was removed. Use Cloud Console \
-                 (`cd cloud && ./scripts/dev.sh`) for the product UI, or `zene acp` \
-                 for Agent Client Protocol (Cloud workers / editors)."
-            );
+            println!("Zene (Zen Engine) — The Open, Minimalist Agent Harness");
+            println!();
+            println!("Usage: zene [OPTIONS] <COMMAND>");
+            println!();
+            println!("Commands:");
+            println!("  acp       Speak Agent Client Protocol (ACP) over stdio JSON-RPC");
+            println!("  sessions  List saved sessions for the current workdir");
+            println!("  config    Print config path and defaults");
+            println!("  export    Export a session and its record to a zip file");
+            println!("  mcp       Probe configured MCP servers");
+            println!();
+            println!("Run 'zene --help' for more options.");
+            Ok(())
         }
     }
 }

--- a/crates/core/src/events.rs
+++ b/crates/core/src/events.rs
@@ -1,12 +1,70 @@
 use std::sync::Arc;
 
-use zene_context::{InjectedSource, PrefixCacheExplain, ToolOutputProvenance};
 use zene_llm::TokenUsage;
 
 use zene_turn::{
-    EventSequence, ProjectionInjectedSource, ProjectionPrefixCache, ProjectionToolOutput,
-    RuntimeEvent, RuntimeEventHandler, RuntimeEventKind, SessionId, StepId, ToolCallId, TurnId,
+    EventSequence, ProjectionInjectedSource, ProjectionPrefixCache, ProjectionReadyEvent,
+    ProjectionToolOutput, RuntimeEvent, RuntimeEventHandler, RuntimeEventKind, SessionId, StepId,
+    TurnId,
 };
+
+pub fn projection_ready_event_from_explain(
+    explain: &zene_context::ProjectionExplain,
+) -> ProjectionReadyEvent {
+    ProjectionReadyEvent {
+        source_message_count: explain.source_message_count,
+        projected_message_count: explain.projected_message_count,
+        source_event_count: explain.source_event_count,
+        active_event_count: explain.active_event_count,
+        cache_drift_detected: explain.cache_drift_detected,
+        used_materialized_fallback: explain.used_materialized_fallback,
+        fallback_reason: explain.fallback_reason.clone(),
+        active_branch_id: explain.active_branch_id.clone(),
+        active_path_start_sequence: explain.active_path_start_sequence,
+        injected: explain.injected.clone(),
+        retained_message_count: explain.retained_message_count,
+        retained_turn_count: explain.retained_turn_count,
+        dropped_event_count: explain.dropped_event_count,
+        truncated_message_count: explain.truncated_message_count,
+        compaction_event_ids: explain.compaction_event_ids.clone(),
+        tool_output_provenance: explain
+            .tool_output_provenance
+            .iter()
+            .map(|item| ProjectionToolOutput {
+                message_index: item.message_index,
+                tool_call_id: item.tool_call_id.clone(),
+                tool_name: item.tool_name.clone(),
+                kind: item.kind.clone(),
+                handle_reference: item.handle_reference.clone(),
+            })
+            .collect(),
+        retained_turn_ids: explain.retained_turn_ids.clone(),
+        injected_sources: explain
+            .injected_sources
+            .iter()
+            .map(|item| ProjectionInjectedSource {
+                message_index: item.message_index,
+                kind: item.kind.clone(),
+                source: item.source.clone(),
+            })
+            .collect(),
+        delivery: explain.delivery.as_str().to_string(),
+        delivery_tail_start: explain.delivery_tail_start,
+        estimate_tokens: explain.estimate_tokens,
+        context_epoch: explain.context_epoch,
+        prefix_cache: ProjectionPrefixCache {
+            prefix_end: explain.prefix_cache.prefix_end,
+            body_end: explain.prefix_cache.body_end,
+            tail_decoration_count: explain.prefix_cache.tail_decoration_count,
+            prefix_fingerprint: explain.prefix_cache.prefix_fingerprint.clone(),
+            break_kind: explain.prefix_cache.break_kind.clone(),
+            cached_tokens: explain.prefix_cache.cached_tokens,
+            gateway_hit_tokens: explain.prefix_cache.gateway_hit_tokens,
+            anchor_aligned: explain.prefix_cache.anchor_aligned,
+            unchanged_reprocessed_est: explain.prefix_cache.unchanged_reprocessed_est,
+        },
+    }
+}
 
 pub type EventHandler = Arc<dyn Fn(AgentEvent) + Send + Sync>;
 
@@ -80,7 +138,7 @@ pub fn runtime_event_handler(
                 current_turn,
                 current_step,
                 RuntimeEventKind::ToolCall {
-                    id: ToolCallId::from_string(id.clone()),
+                    id: id.clone(),
                     name: name.clone(),
                     arguments: arguments.clone(),
                 },
@@ -95,7 +153,7 @@ pub fn runtime_event_handler(
                 current_turn,
                 current_step,
                 RuntimeEventKind::ToolResult {
-                    id: ToolCallId::from_string(id.clone()),
+                    id: id.clone(),
                     name: name.clone(),
                     content: content.clone(),
                     is_error: *is_error,
@@ -119,84 +177,10 @@ pub fn runtime_event_handler(
                     context_epoch: *context_epoch,
                 },
             ),
-            AgentEvent::ProjectionReady {
-                source_message_count,
-                projected_message_count,
-                source_event_count,
-                active_event_count,
-                cache_drift_detected,
-                used_materialized_fallback,
-                fallback_reason,
-                active_branch_id,
-                active_path_start_sequence,
-                injected,
-                retained_message_count,
-                retained_turn_count,
-                dropped_event_count,
-                truncated_message_count,
-                compaction_event_ids,
-                tool_output_provenance,
-                retained_turn_ids,
-                injected_sources,
-                delivery,
-                delivery_tail_start,
-                estimate_tokens,
-                context_epoch,
-                prefix_cache,
-            } => (
+            AgentEvent::ProjectionReady(event) => (
                 current_turn,
                 current_step,
-                RuntimeEventKind::ProjectionReady {
-                    source_message_count: *source_message_count,
-                    projected_message_count: *projected_message_count,
-                    source_event_count: *source_event_count,
-                    active_event_count: *active_event_count,
-                    cache_drift_detected: *cache_drift_detected,
-                    used_materialized_fallback: *used_materialized_fallback,
-                    fallback_reason: fallback_reason.clone(),
-                    active_branch_id: active_branch_id.clone(),
-                    active_path_start_sequence: *active_path_start_sequence,
-                    injected: injected.clone(),
-                    retained_message_count: *retained_message_count,
-                    retained_turn_count: *retained_turn_count,
-                    dropped_event_count: *dropped_event_count,
-                    truncated_message_count: *truncated_message_count,
-                    compaction_event_ids: compaction_event_ids.clone(),
-                    tool_output_provenance: tool_output_provenance
-                        .iter()
-                        .map(|item| ProjectionToolOutput {
-                            message_index: item.message_index,
-                            tool_call_id: item.tool_call_id.clone(),
-                            tool_name: item.tool_name.clone(),
-                            kind: item.kind.clone(),
-                            handle_reference: item.handle_reference.clone(),
-                        })
-                        .collect(),
-                    retained_turn_ids: retained_turn_ids.clone(),
-                    injected_sources: injected_sources
-                        .iter()
-                        .map(|item| ProjectionInjectedSource {
-                            message_index: item.message_index,
-                            kind: item.kind.clone(),
-                            source: item.source.clone(),
-                        })
-                        .collect(),
-                    delivery: delivery.clone(),
-                    delivery_tail_start: *delivery_tail_start,
-                    estimate_tokens: *estimate_tokens,
-                    context_epoch: *context_epoch,
-                    prefix_cache: ProjectionPrefixCache {
-                        prefix_end: prefix_cache.prefix_end,
-                        body_end: prefix_cache.body_end,
-                        tail_decoration_count: prefix_cache.tail_decoration_count,
-                        prefix_fingerprint: prefix_cache.prefix_fingerprint.clone(),
-                        break_kind: prefix_cache.break_kind.clone(),
-                        cached_tokens: prefix_cache.cached_tokens,
-                        gateway_hit_tokens: prefix_cache.gateway_hit_tokens,
-                        anchor_aligned: prefix_cache.anchor_aligned,
-                        unchanged_reprocessed_est: prefix_cache.unchanged_reprocessed_est,
-                    },
-                },
+                RuntimeEventKind::ProjectionReady(event.clone()),
             ),
             AgentEvent::TurnEnd { turn_id, steps } => (
                 Some(*turn_id),
@@ -273,31 +257,7 @@ pub enum AgentEvent {
         context_percent: u8,
         context_epoch: u64,
     },
-    ProjectionReady {
-        source_message_count: usize,
-        projected_message_count: usize,
-        source_event_count: usize,
-        active_event_count: usize,
-        cache_drift_detected: bool,
-        used_materialized_fallback: bool,
-        fallback_reason: Option<String>,
-        active_branch_id: Option<String>,
-        active_path_start_sequence: Option<u64>,
-        injected: Vec<String>,
-        retained_message_count: usize,
-        retained_turn_count: usize,
-        dropped_event_count: usize,
-        truncated_message_count: usize,
-        compaction_event_ids: Vec<String>,
-        tool_output_provenance: Vec<ToolOutputProvenance>,
-        retained_turn_ids: Vec<String>,
-        injected_sources: Vec<InjectedSource>,
-        delivery: String,
-        delivery_tail_start: Option<usize>,
-        estimate_tokens: u32,
-        context_epoch: u64,
-        prefix_cache: PrefixCacheExplain,
-    },
+    ProjectionReady(Box<ProjectionReadyEvent>),
     TurnEnd {
         turn_id: TurnId,
         steps: u32,
@@ -340,51 +300,46 @@ mod tests {
         handler(AgentEvent::TextDelta {
             delta: "hello".into(),
         });
-        handler(AgentEvent::ProjectionReady {
-            source_message_count: 4,
-            projected_message_count: 3,
-            source_event_count: 7,
-            active_event_count: 5,
-            cache_drift_detected: false,
-            used_materialized_fallback: false,
-            fallback_reason: None,
-            active_branch_id: Some("branch".into()),
-            active_path_start_sequence: Some(3),
-            injected: vec!["compaction_summary".into()],
-            retained_message_count: 3,
-            retained_turn_count: 1,
-            dropped_event_count: 2,
-            truncated_message_count: 1,
-            compaction_event_ids: vec!["compact-1".into()],
-            tool_output_provenance: vec![ToolOutputProvenance {
-                message_index: 2,
-                tool_call_id: Some("call-1".into()),
-                tool_name: Some("Read".into()),
-                kind: "handle".into(),
-                handle_reference: Some("/tmp/output".into()),
-            }],
-            retained_turn_ids: vec![turn_id.to_string()],
-            injected_sources: vec![InjectedSource {
-                message_index: 0,
-                kind: "compaction_summary".into(),
-                source: "compaction_event".into(),
-            }],
-            delivery: "full".into(),
-            delivery_tail_start: None,
-            estimate_tokens: 128,
-            context_epoch: 2,
-            prefix_cache: PrefixCacheExplain {
-                prefix_end: 1,
-                body_end: 3,
-                tail_decoration_count: 0,
-                prefix_fingerprint: Some("abc".into()),
-                break_kind: "none".into(),
-                cached_tokens: None,
-                gateway_hit_tokens: None,
-                anchor_aligned: None,
-                unchanged_reprocessed_est: None,
+        handler(AgentEvent::ProjectionReady(Box::new(
+            ProjectionReadyEvent {
+                source_message_count: 4,
+                projected_message_count: 3,
+                source_event_count: 7,
+                active_event_count: 5,
+                active_branch_id: Some("branch".into()),
+                active_path_start_sequence: Some(3),
+                injected: vec!["compaction_summary".into()],
+                retained_message_count: 3,
+                retained_turn_count: 1,
+                dropped_event_count: 2,
+                truncated_message_count: 1,
+                compaction_event_ids: vec!["compact-1".into()],
+                tool_output_provenance: vec![ProjectionToolOutput {
+                    message_index: 2,
+                    tool_call_id: Some("call-1".into()),
+                    tool_name: Some("Read".into()),
+                    kind: "handle".into(),
+                    handle_reference: Some("/tmp/output".into()),
+                }],
+                retained_turn_ids: vec![turn_id.to_string()],
+                injected_sources: vec![ProjectionInjectedSource {
+                    message_index: 0,
+                    kind: "compaction_summary".into(),
+                    source: "compaction_event".into(),
+                }],
+                delivery: "full".into(),
+                estimate_tokens: 128,
+                context_epoch: 2,
+                prefix_cache: ProjectionPrefixCache {
+                    prefix_end: 1,
+                    body_end: 3,
+                    prefix_fingerprint: Some("abc".into()),
+                    break_kind: "none".into(),
+                    ..Default::default()
+                },
+                ..Default::default()
             },
-        });
+        )));
 
         let events = collected.lock().unwrap();
         assert_eq!(events.len(), 4);
@@ -393,55 +348,30 @@ mod tests {
         assert_eq!(events[3].turn_id, Some(turn_id));
         assert_eq!(events[3].step_id, Some(step_id));
         match &events[3].kind {
-            RuntimeEventKind::ProjectionReady {
-                source_message_count,
-                projected_message_count,
-                source_event_count,
-                active_event_count,
-                cache_drift_detected,
-                used_materialized_fallback,
-                fallback_reason,
-                active_branch_id,
-                active_path_start_sequence,
-                injected,
-                retained_message_count,
-                retained_turn_count,
-                dropped_event_count,
-                truncated_message_count,
-                compaction_event_ids,
-                tool_output_provenance,
-                retained_turn_ids,
-                injected_sources,
-                delivery,
-                delivery_tail_start,
-                estimate_tokens,
-                context_epoch,
-                prefix_cache,
-            } => {
-                assert_eq!(*source_message_count, 4);
-                assert_eq!(*projected_message_count, 3);
-                assert_eq!(*source_event_count, 7);
-                assert_eq!(*active_event_count, 5);
-                assert!(!cache_drift_detected);
-                assert!(!used_materialized_fallback);
-                assert_eq!(fallback_reason, &None);
-                assert_eq!(active_branch_id.as_deref(), Some("branch"));
-                assert_eq!(*active_path_start_sequence, Some(3));
-                assert_eq!(injected, &["compaction_summary"]);
-                assert_eq!(tool_output_provenance.len(), 1);
-                assert_eq!(tool_output_provenance[0].kind, "handle");
-                assert_eq!(retained_turn_ids, &[turn_id.to_string()]);
-                assert_eq!(injected_sources[0].source, "compaction_event");
-                assert_eq!(*retained_message_count, 3);
-                assert_eq!(*retained_turn_count, 1);
-                assert_eq!(*dropped_event_count, 2);
-                assert_eq!(*truncated_message_count, 1);
-                assert_eq!(compaction_event_ids, &["compact-1"]);
-                assert_eq!(delivery, "full");
-                assert_eq!(*delivery_tail_start, None);
-                assert_eq!(*estimate_tokens, 128);
-                assert_eq!(*context_epoch, 2);
-                assert_eq!(prefix_cache.break_kind, "none");
+            RuntimeEventKind::ProjectionReady(ev) => {
+                assert_eq!(ev.source_message_count, 4);
+                assert_eq!(ev.projected_message_count, 3);
+                assert_eq!(ev.source_event_count, 7);
+                assert_eq!(ev.active_event_count, 5);
+                assert!(!ev.cache_drift_detected);
+                assert!(!ev.used_materialized_fallback);
+                assert_eq!(ev.fallback_reason, None);
+                assert_eq!(ev.active_branch_id.as_deref(), Some("branch"));
+                assert_eq!(ev.active_path_start_sequence, Some(3));
+                assert_eq!(ev.injected, &["compaction_summary"]);
+                assert_eq!(ev.tool_output_provenance.len(), 1);
+                assert_eq!(ev.tool_output_provenance[0].kind, "handle");
+                assert_eq!(ev.retained_turn_ids, &[turn_id.to_string()]);
+                assert_eq!(ev.injected_sources[0].source, "compaction_event");
+                assert_eq!(ev.retained_message_count, 3);
+                assert_eq!(ev.retained_turn_count, 1);
+                assert_eq!(ev.dropped_event_count, 2);
+                assert_eq!(ev.truncated_message_count, 1);
+                assert_eq!(ev.compaction_event_ids, &["compact-1"]);
+                assert_eq!(ev.delivery, "full");
+                assert_eq!(ev.estimate_tokens, 128);
+                assert_eq!(ev.context_epoch, 2);
+                assert_eq!(ev.prefix_cache.break_kind, "none");
             }
             other => panic!("unexpected runtime event: {other:?}"),
         }

--- a/crates/core/src/prepare_step.rs
+++ b/crates/core/src/prepare_step.rs
@@ -79,31 +79,9 @@ pub(crate) async fn prepare_step_context(
     }
     emit_event(
         &options.event_handler,
-        AgentEvent::ProjectionReady {
-            source_message_count: prepared.explain.source_message_count,
-            projected_message_count: prepared.explain.projected_message_count,
-            source_event_count: prepared.explain.source_event_count,
-            active_event_count: prepared.explain.active_event_count,
-            cache_drift_detected: prepared.explain.cache_drift_detected,
-            used_materialized_fallback: prepared.explain.used_materialized_fallback,
-            fallback_reason: prepared.explain.fallback_reason.clone(),
-            active_branch_id: prepared.explain.active_branch_id.clone(),
-            active_path_start_sequence: prepared.explain.active_path_start_sequence,
-            injected: prepared.explain.injected.clone(),
-            retained_message_count: prepared.explain.retained_message_count,
-            retained_turn_count: prepared.explain.retained_turn_count,
-            dropped_event_count: prepared.explain.dropped_event_count,
-            truncated_message_count: prepared.explain.truncated_message_count,
-            compaction_event_ids: prepared.explain.compaction_event_ids.clone(),
-            tool_output_provenance: prepared.explain.tool_output_provenance.clone(),
-            retained_turn_ids: prepared.explain.retained_turn_ids.clone(),
-            injected_sources: prepared.explain.injected_sources.clone(),
-            delivery: prepared.explain.delivery.as_str().to_string(),
-            delivery_tail_start: prepared.explain.delivery_tail_start,
-            estimate_tokens: prepared.explain.estimate_tokens,
-            context_epoch: prepared.explain.context_epoch,
-            prefix_cache: prepared.explain.prefix_cache.clone(),
-        },
+        AgentEvent::ProjectionReady(Box::new(
+            crate::events::projection_ready_event_from_explain(&prepared.explain),
+        )),
     );
     let step = prepared.step;
     debug!(

--- a/crates/turn/src/events.rs
+++ b/crates/turn/src/events.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use zene_llm::TokenUsage;
 
-use crate::{SessionId, StepId, ToolCallId, TurnId};
+use crate::{SessionId, StepId, TurnId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EventSequence(u64);
@@ -18,7 +18,7 @@ impl EventSequence {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ProjectionToolOutput {
     pub message_index: usize,
     pub tool_call_id: Option<String>,
@@ -27,7 +27,7 @@ pub struct ProjectionToolOutput {
     pub handle_reference: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ProjectionInjectedSource {
     pub message_index: usize,
     pub kind: String,
@@ -58,6 +58,33 @@ pub struct RuntimeEvent {
     pub kind: RuntimeEventKind,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProjectionReadyEvent {
+    pub source_message_count: usize,
+    pub projected_message_count: usize,
+    pub source_event_count: usize,
+    pub active_event_count: usize,
+    pub cache_drift_detected: bool,
+    pub used_materialized_fallback: bool,
+    pub fallback_reason: Option<String>,
+    pub active_branch_id: Option<String>,
+    pub active_path_start_sequence: Option<u64>,
+    pub injected: Vec<String>,
+    pub retained_message_count: usize,
+    pub retained_turn_count: usize,
+    pub dropped_event_count: usize,
+    pub truncated_message_count: usize,
+    pub compaction_event_ids: Vec<String>,
+    pub tool_output_provenance: Vec<ProjectionToolOutput>,
+    pub retained_turn_ids: Vec<String>,
+    pub injected_sources: Vec<ProjectionInjectedSource>,
+    pub delivery: String,
+    pub delivery_tail_start: Option<usize>,
+    pub estimate_tokens: u32,
+    pub context_epoch: u64,
+    pub prefix_cache: ProjectionPrefixCache,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum RuntimeEventKind {
     TurnStarted,
@@ -71,12 +98,12 @@ pub enum RuntimeEventKind {
         delta: String,
     },
     ToolCall {
-        id: ToolCallId,
+        id: String,
         name: String,
         arguments: String,
     },
     ToolResult {
-        id: ToolCallId,
+        id: String,
         name: String,
         content: String,
         is_error: bool,
@@ -89,31 +116,7 @@ pub enum RuntimeEventKind {
         context_percent: u8,
         context_epoch: u64,
     },
-    ProjectionReady {
-        source_message_count: usize,
-        projected_message_count: usize,
-        source_event_count: usize,
-        active_event_count: usize,
-        cache_drift_detected: bool,
-        used_materialized_fallback: bool,
-        fallback_reason: Option<String>,
-        active_branch_id: Option<String>,
-        active_path_start_sequence: Option<u64>,
-        injected: Vec<String>,
-        retained_message_count: usize,
-        retained_turn_count: usize,
-        dropped_event_count: usize,
-        truncated_message_count: usize,
-        compaction_event_ids: Vec<String>,
-        tool_output_provenance: Vec<ProjectionToolOutput>,
-        retained_turn_ids: Vec<String>,
-        injected_sources: Vec<ProjectionInjectedSource>,
-        delivery: String,
-        delivery_tail_start: Option<usize>,
-        estimate_tokens: u32,
-        context_epoch: u64,
-        prefix_cache: ProjectionPrefixCache,
-    },
+    ProjectionReady(Box<ProjectionReadyEvent>),
     TurnEnded {
         steps: u32,
     },

--- a/crates/turn/src/lib.rs
+++ b/crates/turn/src/lib.rs
@@ -5,8 +5,8 @@ mod state;
 mod turn_loop;
 
 pub use events::{
-    EventSequence, ProjectionInjectedSource, ProjectionPrefixCache, ProjectionToolOutput,
-    RuntimeEvent, RuntimeEventHandler, RuntimeEventKind,
+    EventSequence, ProjectionInjectedSource, ProjectionPrefixCache, ProjectionReadyEvent,
+    ProjectionToolOutput, RuntimeEvent, RuntimeEventHandler, RuntimeEventKind,
 };
 pub use state::{
     aborted_error, agent_busy_error, begin_turn, end_turn, is_cancelled, max_turns_notice,

--- a/crates/turn/src/state.rs
+++ b/crates/turn/src/state.rs
@@ -7,6 +7,12 @@ use uuid::Uuid;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SessionId(String);
 
+impl Default for SessionId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SessionId {
     pub fn new() -> Self {
         Self(Uuid::new_v4().to_string())
@@ -28,6 +34,12 @@ impl fmt::Display for SessionId {
 /// Stable identity for a model tool call.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ToolCallId(String);
+
+impl Default for ToolCallId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl ToolCallId {
     pub fn new() -> Self {
@@ -51,6 +63,12 @@ impl fmt::Display for ToolCallId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TurnId(Uuid);
 
+impl Default for TurnId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TurnId {
     pub fn new() -> Self {
         Self(Uuid::new_v4())
@@ -66,6 +84,12 @@ impl fmt::Display for TurnId {
 /// Identifier for one LLM invocation within a turn.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct StepId(Uuid);
+
+impl Default for StepId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl StepId {
     pub fn new() -> Self {

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -90,8 +90,8 @@ if [ -n "$TARGET" ]; then
 
     echo "=== Installation Completed ==="
     echo "Installed to $INSTALL_DIR"
-    echo "Cloud Console: cd cloud && ./scripts/dev.sh"
-    echo "ACP (workers/editors): zene acp"
+    echo "Start ACP server: zene acp"
+    echo "For hosted web console, see zene-cloud: https://github.com/EeroEternal/zene-cloud"
     echo "If 'zene' still resolves to an old path, open a new terminal or run: hash -r"
     exit 0
   else


### PR DESCRIPTION
## Summary

In alignment with **Zen Engine (禅引擎)** principles to reduce entropy and simplify boundaries:
- Encapsulates the 23 projection metrics and explain fields into a typed, boxed `ProjectionReadyEvent`.
- Replaces unwieldy 23-parameter variant and matching in `crates/turn/src/events.rs`, `crates/core/src/events.rs`, and `apps/cli/src/acp/server.rs`.
- Consolidates `projection_ready_update_with_provenance` and the unused 19-parameter `projection_ready_update` in `apps/cli/src/acp/updates.rs` into a single, clean typed function taking `&ProjectionReadyEvent`.
- Adds `Default` implementations for `SessionId`, `ToolCallId`, `TurnId`, and `StepId` in `zene-turn`.
- Updates CLI fallback output and post-install text to point cloud console users to `zene-cloud`.

## Verification
- Local quality gates passed:
  - `cargo fmt --check`
  - `cargo clippy --workspace --locked`
  - `cargo test --workspace --locked`
- Net code reduction: -172 lines.