### PR TITLE
refactor(mcp,core,context): box McpStdioClient and simplify tool scheduler types

### DIFF
--- a/crates/context/src/compaction.rs
+++ b/crates/context/src/compaction.rs
@@ -1074,7 +1074,7 @@ pub async fn compact_session_forced<S: ContextSession + ?Sized>(
         Some(plan) => plan,
         None => {
             let prefix_start = system_prefix_start(&messages);
-            let min_keep = config.min_keep_messages.min(4).max(1);
+            let min_keep = config.min_keep_messages.clamp(1, 4);
             if messages.len().saturating_sub(prefix_start) <= min_keep {
                 return Ok(None);
             }

--- a/crates/core/src/tool_executor.rs
+++ b/crates/core/src/tool_executor.rs
@@ -67,6 +67,11 @@ impl<'a> DefaultToolExecutor<'a> {
         Self { deps }
     }
 
+    fn is_tool_blocked_by_plan_mode(&self, tool_name: &str) -> bool {
+        let state = self.deps.plan_mode.lock();
+        state.is_active() && !state.is_tool_allowed(tool_name)
+    }
+
     pub(crate) async fn execute(
         &self,
         tool_calls: &[ToolCall],
@@ -174,10 +179,7 @@ impl<'a> DefaultToolExecutor<'a> {
                     },
                     None,
                 ))
-            } else if {
-                let state = self.deps.plan_mode.lock();
-                state.is_active() && !state.is_tool_allowed(&call.name)
-            } {
+            } else if self.is_tool_blocked_by_plan_mode(&call.name) {
                 Some((
                     zene_tools::ToolResult {
                         content: PlanModeState::blocked_message(&call.name),

--- a/crates/core/src/tool_scheduler.rs
+++ b/crates/core/src/tool_scheduler.rs
@@ -171,10 +171,14 @@ fn str_field(value: &Value, key: &str) -> Option<String> {
     value.get(key).and_then(|v| v.as_str()).map(str::to_string)
 }
 
+pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+pub type TaskItem<T> = (ToolAccesses, BoxFuture<T>);
+type InFlightTasks<T> = FuturesUnordered<BoxFuture<(usize, T)>>;
+
 struct ScheduledTask<T> {
     index: usize,
     accesses: ToolAccesses,
-    future: Pin<Box<dyn Future<Output = T> + Send>>,
+    future: BoxFuture<T>,
 }
 
 struct ActiveTask {
@@ -186,9 +190,7 @@ pub struct ToolScheduler;
 
 impl ToolScheduler {
     /// Run tool futures with conflict-aware parallelism. Results are returned in input order.
-    pub async fn run_ordered<T>(
-        tasks: Vec<(ToolAccesses, Pin<Box<dyn Future<Output = T> + Send>>)>,
-    ) -> Vec<T>
+    pub async fn run_ordered<T>(tasks: Vec<TaskItem<T>>) -> Vec<T>
     where
         T: Send + 'static,
     {
@@ -207,8 +209,7 @@ impl ToolScheduler {
             })
             .collect();
         let mut active: Vec<ActiveTask> = Vec::new();
-        let mut in_flight: FuturesUnordered<Pin<Box<dyn Future<Output = (usize, T)> + Send>>> =
-            FuturesUnordered::new();
+        let mut in_flight: InFlightTasks<T> = FuturesUnordered::new();
         let mut results: Vec<Option<T>> = (0..count).map(|_| None).collect();
         let mut completed = 0;
 
@@ -256,7 +257,7 @@ fn is_blocked<T>(
 fn start_queued_tasks<T>(
     queued: &mut Vec<ScheduledTask<T>>,
     active: &mut Vec<ActiveTask>,
-    in_flight: &mut FuturesUnordered<Pin<Box<dyn Future<Output = (usize, T)> + Send>>>,
+    in_flight: &mut InFlightTasks<T>,
 ) where
     T: Send + 'static,
 {

--- a/crates/mcp/src/manager.rs
+++ b/crates/mcp/src/manager.rs
@@ -66,6 +66,7 @@ impl McpManager {
             } else {
                 McpStdioClient::connect(&server_name, &server_config, sandbox)
                     .await
+                    .map(Box::new)
                     .map(McpClientHandle::Stdio)
             };
 

--- a/crates/mcp/src/transport.rs
+++ b/crates/mcp/src/transport.rs
@@ -7,7 +7,7 @@ use crate::client::{McpStdioClient, McpToolInfo};
 use crate::http::McpHttpClient;
 
 pub enum McpClientHandle {
-    Stdio(McpStdioClient),
+    Stdio(Box<McpStdioClient>),
     Http(McpHttpClient),
 }
 


### PR DESCRIPTION
## Summary

Continuing the Zen Engine (禅引擎) simplification work:
- **Stack size optimization**: Box `McpStdioClient` inside `McpClientHandle::Stdio` in [`crates/mcp/src/transport.rs`](crates/mcp/src/transport.rs), shrinking the enum variant size difference and reclaiming ~250 bytes per handle on the stack.
- **Type hygiene**: Factored out complex async future signatures in [`crates/core/src/tool_scheduler.rs`](crates/core/src/tool_scheduler.rs) into concise `BoxFuture<T>`, `TaskItem<T>`, and `InFlightTasks<T>` aliases.
- **Logic clarity**: Replaced complex inline block in `if` condition in [`crates/core/src/tool_executor.rs`](crates/core/src/tool_executor.rs) with `is_tool_blocked_by_plan_mode`.
- **Idiomatic Rust**: Replaced chained `.min().max()` with `.clamp(1, 4)` in [`crates/context/src/compaction.rs`](crates/context/src/compaction.rs).

## Verification
- Local quality gates passed:
  - `cargo fmt --check`
  - `cargo clippy --workspace --locked`
  - `cargo test --workspace --locked`