### PR TITLE
refactor(permission,tools,workspace): decouple cloud-specific github and permission logic for P2

### DIFF
--- a/apps/cli/src/acp/server.rs
+++ b/apps/cli/src/acp/server.rs
@@ -900,17 +900,17 @@ async fn run_prompt_job(
                             tool_call_id,
                         } = &event.kind
                         {
-                            tokio::spawn(handle_runtime_approval(
-                                Arc::clone(&runtime),
-                                writer.clone(),
-                                sid.clone(),
-                                permission_mode.clone(),
-                                Arc::clone(&pending_tool),
-                                request_id.clone(),
-                                tool_name.clone(),
-                                arguments.clone(),
-                                tool_call_id.clone(),
-                            ));
+                            tokio::spawn(handle_runtime_approval(RuntimeApprovalParams {
+                                runtime: Arc::clone(&runtime),
+                                writer: writer.clone(),
+                                session_id: sid.clone(),
+                                permission_mode: permission_mode.clone(),
+                                pending_tool: Arc::clone(&pending_tool),
+                                request_id: request_id.clone(),
+                                tool_name: tool_name.clone(),
+                                arguments: arguments.clone(),
+                                tool_call_id: tool_call_id.clone(),
+                            }));
                         }
                         project_runtime_event(
                             &writer,
@@ -930,7 +930,7 @@ async fn run_prompt_job(
     }
 }
 
-async fn handle_runtime_approval(
+struct RuntimeApprovalParams {
     runtime: Arc<dyn RuntimeControl>,
     writer: AcpWriter,
     session_id: String,
@@ -940,9 +940,12 @@ async fn handle_runtime_approval(
     tool_name: String,
     arguments: String,
     tool_call_id: Option<String>,
-) {
-    let tool_call_id = tool_call_id.unwrap_or_else(|| {
-        pending_tool
+}
+
+async fn handle_runtime_approval(params: RuntimeApprovalParams) {
+    let tool_call_id = params.tool_call_id.unwrap_or_else(|| {
+        params
+            .pending_tool
             .lock()
             .unwrap()
             .id
@@ -950,17 +953,17 @@ async fn handle_runtime_approval(
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string())
     });
     let preview = ApprovalRequest {
-        request_id: request_id.clone(),
-        tool_name: tool_name.clone(),
-        arguments,
+        request_id: params.request_id.clone(),
+        tool_name: params.tool_name.clone(),
+        arguments: params.arguments,
         tool_call_id: Some(tool_call_id.clone()),
     }
     .preview();
     let decision = match acp_permission_prompt(
-        &writer,
-        &session_id,
-        &permission_mode,
-        &tool_name,
+        &params.writer,
+        &params.session_id,
+        &params.permission_mode,
+        &params.tool_name,
         &preview,
         &tool_call_id,
     )
@@ -968,11 +971,11 @@ async fn handle_runtime_approval(
     {
         Ok(choice) => approval_decision(choice),
         Err(err) => {
-            warn!(error = %err, request_id = %request_id, "ACP permission prompt failed");
+            warn!(error = %err, request_id = %params.request_id, "ACP permission prompt failed");
             ApprovalDecision::Deny
         }
     };
-    if let Err(err) = runtime.approve(request_id, decision).await {
+    if let Err(err) = params.runtime.approve(params.request_id, decision).await {
         warn!(error = %err, "runtime approval resolve failed");
     }
 }

--- a/crates/agent-runtime/src/actor.rs
+++ b/crates/agent-runtime/src/actor.rs
@@ -925,9 +925,11 @@ mod tests {
             })
             .expect("checkpoint");
 
-        let mut config = ZeneConfig::default();
-        config.provider = "anthropic".into();
-        config.anthropic_api_key = Some("test-key".into());
+        let config = ZeneConfig {
+            provider: "anthropic".into(),
+            anthropic_api_key: Some("test-key".into()),
+            ..Default::default()
+        };
         let agent = zene_core::AgentBuilder::new(
             config,
             LocalSandbox::new(workdir.path()),
@@ -983,9 +985,11 @@ mod tests {
             })
             .expect("resume claim");
 
-        let mut config = ZeneConfig::default();
-        config.provider = "anthropic".into();
-        config.anthropic_api_key = Some("test-key".into());
+        let config = ZeneConfig {
+            provider: "anthropic".into(),
+            anthropic_api_key: Some("test-key".into()),
+            ..Default::default()
+        };
         let agent = zene_core::AgentBuilder::new(
             config,
             LocalSandbox::new(workdir.path()),

--- a/crates/context/src/engine.rs
+++ b/crates/context/src/engine.rs
@@ -319,159 +319,6 @@ pub struct ContextEngine {
     last_unchanged_reprocessed_est: Option<u64>,
 }
 
-#[cfg(test)]
-mod projection_tests {
-    use super::*;
-    use zene_llm::Message;
-
-    #[test]
-    fn detects_tool_truncation_and_handle_markers() {
-        let messages = vec![
-            Message::tool_result(
-                "call-1",
-                "Read",
-                "preview\n\n[truncated 42 bytes; full output saved to /tmp/out.txt.]",
-            ),
-            Message::tool_result(
-                "call-2",
-                "Bash",
-                "[zene-tool-output path=\"/tmp/handle.txt\" bytes=100]",
-            ),
-        ];
-        let provenance = projection_tool_output_provenance(&messages);
-        assert_eq!(provenance.len(), 2);
-        assert_eq!(provenance[0].kind, "truncated");
-        assert_eq!(
-            provenance[0].handle_reference.as_deref(),
-            Some("/tmp/out.txt")
-        );
-        assert_eq!(provenance[1].kind, "handle");
-        assert_eq!(
-            provenance[1].handle_reference.as_deref(),
-            Some("/tmp/handle.txt")
-        );
-    }
-
-    #[test]
-    fn classifies_injected_sources() {
-        let messages = vec![
-            Message::compaction_summary("summary"),
-            Message::user("<system-reminder>\n<memory-context>memory</memory-context>\nActive todos\n</system-reminder>"),
-        ];
-        let sources = projection_injected_sources(&messages);
-        assert_eq!(sources[0].source, "compaction_event");
-        assert_eq!(sources[1].source, "memory");
-        assert_eq!(sources[2].source, "todos");
-    }
-
-    #[test]
-    fn tail_decorations_keep_prefix_fingerprint_stable() {
-        use crate::tokens::TokenEstimator;
-        use zene_session::SessionRecord;
-
-        let mut engine = ContextEngine::new(128_000);
-        let mut session = SessionRecord::new(std::path::Path::new("/tmp"));
-        session.ensure_system_message("frozen system");
-        session.push_message(Message::user("hello"));
-        session.push_message(Message::assistant("hi"));
-        let estimator = TokenEstimator::default();
-        let tools = [];
-
-        let first = engine.assemble_step(&session, &tools, &estimator);
-        let first_prefix = crate::layout::prefix_fingerprint(&first.messages, 1);
-        let explain_first = engine.explain_projection(&session, &tools, &estimator);
-        assert_eq!(explain_first.prefix_cache.prefix_end, 1);
-        assert_eq!(explain_first.prefix_cache.tail_decoration_count, 0);
-
-        engine.set_step_tail_decorations(vec!["Active todos:\n- [pending] ship".into()]);
-        let second = engine.assemble_step(&session, &tools, &estimator);
-        let explain_second = engine.explain_projection(&session, &tools, &estimator);
-        assert_eq!(explain_second.prefix_cache.prefix_end, 1);
-        assert_eq!(explain_second.prefix_cache.tail_decoration_count, 1);
-        assert!(second
-            .messages
-            .last()
-            .unwrap()
-            .content
-            .as_deref()
-            .unwrap()
-            .contains("ship"));
-        assert_eq!(
-            first_prefix,
-            crate::layout::prefix_fingerprint(&second.messages, 1)
-        );
-
-        engine.set_step_tail_decorations(vec!["You are in Plan mode.".into()]);
-        let third = engine.assemble_step(&session, &tools, &estimator);
-        assert_eq!(
-            first_prefix,
-            crate::layout::prefix_fingerprint(&third.messages, 1)
-        );
-        assert_eq!(
-            engine
-                .explain_projection(&session, &tools, &estimator)
-                .prefix_cache
-                .break_kind,
-            "none"
-        );
-    }
-
-    #[test]
-    fn assemble_relocates_prefix_adjacent_index_block() {
-        use crate::tokens::TokenEstimator;
-        use zene_session::SessionRecord;
-
-        let mut engine = ContextEngine::new(128_000);
-        let mut session = SessionRecord::new(std::path::Path::new("/tmp"));
-        session.ensure_system_message("frozen system");
-        session.push_message(Message::user(
-            "<system-reminder>\n<agent_documents_index>\n</system-reminder>",
-        ));
-        session.push_message(Message::user("hello"));
-        let estimator = TokenEstimator::default();
-        let tools = [];
-        engine.set_step_tail_decorations(vec!["live tail".into()]);
-        let step = engine.assemble_step(&session, &tools, &estimator);
-        assert!(crate::layout::prefix_adjacent_decoration_index(&step.messages).is_none());
-        assert_eq!(step.messages[1].content.as_deref(), Some("hello"));
-        assert!(step
-            .messages
-            .last()
-            .unwrap()
-            .content
-            .as_deref()
-            .unwrap()
-            .contains("live tail"));
-        assert!(!step.messages.iter().any(|message| message
-            .content
-            .as_deref()
-            .is_some_and(|content| content.contains("agent_documents_index"))));
-    }
-
-    #[test]
-    fn system_resize_is_distinct_from_append_only_none() {
-        use crate::tokens::TokenEstimator;
-        use zene_session::SessionRecord;
-
-        let mut engine = ContextEngine::new(128_000);
-        let mut session = SessionRecord::new(std::path::Path::new("/tmp"));
-        session.ensure_system_message("sys v1");
-        session.push_message(Message::user("hello"));
-        let estimator = TokenEstimator::default();
-        let tools = [];
-        let _ = engine.assemble_step(&session, &tools, &estimator);
-
-        session.push_message(Message::assistant("hi"));
-        let append = engine.explain_projection(&session, &tools, &estimator);
-        assert_eq!(append.prefix_cache.break_kind, "none");
-
-        session.update_system_prefix("sys v2 is longer and breaks the prefix");
-        let _ = engine.on_system_prefix_changed("system_prefix");
-        let resized = engine.explain_projection(&session, &tools, &estimator);
-        assert_eq!(resized.prefix_cache.break_kind, "system_resize");
-    }
-}
-
 impl ContextEngine {
     pub fn new(context_window_tokens: u32) -> Self {
         Self {
@@ -1443,5 +1290,158 @@ impl ContextEngine {
             self.last_memory_flush_compaction = marker;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod projection_tests {
+    use super::*;
+    use zene_llm::Message;
+
+    #[test]
+    fn detects_tool_truncation_and_handle_markers() {
+        let messages = vec![
+            Message::tool_result(
+                "call-1",
+                "Read",
+                "preview\n\n[truncated 42 bytes; full output saved to /tmp/out.txt.]",
+            ),
+            Message::tool_result(
+                "call-2",
+                "Bash",
+                "[zene-tool-output path=\"/tmp/handle.txt\" bytes=100]",
+            ),
+        ];
+        let provenance = projection_tool_output_provenance(&messages);
+        assert_eq!(provenance.len(), 2);
+        assert_eq!(provenance[0].kind, "truncated");
+        assert_eq!(
+            provenance[0].handle_reference.as_deref(),
+            Some("/tmp/out.txt")
+        );
+        assert_eq!(provenance[1].kind, "handle");
+        assert_eq!(
+            provenance[1].handle_reference.as_deref(),
+            Some("/tmp/handle.txt")
+        );
+    }
+
+    #[test]
+    fn classifies_injected_sources() {
+        let messages = vec![
+            Message::compaction_summary("summary"),
+            Message::user("<system-reminder>\n<memory-context>memory</memory-context>\nActive todos\n</system-reminder>"),
+        ];
+        let sources = projection_injected_sources(&messages);
+        assert_eq!(sources[0].source, "compaction_event");
+        assert_eq!(sources[1].source, "memory");
+        assert_eq!(sources[2].source, "todos");
+    }
+
+    #[test]
+    fn tail_decorations_keep_prefix_fingerprint_stable() {
+        use crate::tokens::TokenEstimator;
+        use zene_session::SessionRecord;
+
+        let mut engine = ContextEngine::new(128_000);
+        let mut session = SessionRecord::new(std::path::Path::new("/tmp"));
+        session.ensure_system_message("frozen system");
+        session.push_message(Message::user("hello"));
+        session.push_message(Message::assistant("hi"));
+        let estimator = TokenEstimator::default();
+        let tools = [];
+
+        let first = engine.assemble_step(&session, &tools, &estimator);
+        let first_prefix = crate::layout::prefix_fingerprint(&first.messages, 1);
+        let explain_first = engine.explain_projection(&session, &tools, &estimator);
+        assert_eq!(explain_first.prefix_cache.prefix_end, 1);
+        assert_eq!(explain_first.prefix_cache.tail_decoration_count, 0);
+
+        engine.set_step_tail_decorations(vec!["Active todos:\n- [pending] ship".into()]);
+        let second = engine.assemble_step(&session, &tools, &estimator);
+        let explain_second = engine.explain_projection(&session, &tools, &estimator);
+        assert_eq!(explain_second.prefix_cache.prefix_end, 1);
+        assert_eq!(explain_second.prefix_cache.tail_decoration_count, 1);
+        assert!(second
+            .messages
+            .last()
+            .unwrap()
+            .content
+            .as_deref()
+            .unwrap()
+            .contains("ship"));
+        assert_eq!(
+            first_prefix,
+            crate::layout::prefix_fingerprint(&second.messages, 1)
+        );
+
+        engine.set_step_tail_decorations(vec!["You are in Plan mode.".into()]);
+        let third = engine.assemble_step(&session, &tools, &estimator);
+        assert_eq!(
+            first_prefix,
+            crate::layout::prefix_fingerprint(&third.messages, 1)
+        );
+        assert_eq!(
+            engine
+                .explain_projection(&session, &tools, &estimator)
+                .prefix_cache
+                .break_kind,
+            "none"
+        );
+    }
+
+    #[test]
+    fn assemble_relocates_prefix_adjacent_index_block() {
+        use crate::tokens::TokenEstimator;
+        use zene_session::SessionRecord;
+
+        let mut engine = ContextEngine::new(128_000);
+        let mut session = SessionRecord::new(std::path::Path::new("/tmp"));
+        session.ensure_system_message("frozen system");
+        session.push_message(Message::user(
+            "<system-reminder>\n<agent_documents_index>\n</system-reminder>",
+        ));
+        session.push_message(Message::user("hello"));
+        let estimator = TokenEstimator::default();
+        let tools = [];
+        engine.set_step_tail_decorations(vec!["live tail".into()]);
+        let step = engine.assemble_step(&session, &tools, &estimator);
+        assert!(crate::layout::prefix_adjacent_decoration_index(&step.messages).is_none());
+        assert_eq!(step.messages[1].content.as_deref(), Some("hello"));
+        assert!(step
+            .messages
+            .last()
+            .unwrap()
+            .content
+            .as_deref()
+            .unwrap()
+            .contains("live tail"));
+        assert!(!step.messages.iter().any(|message| message
+            .content
+            .as_deref()
+            .is_some_and(|content| content.contains("agent_documents_index"))));
+    }
+
+    #[test]
+    fn system_resize_is_distinct_from_append_only_none() {
+        use crate::tokens::TokenEstimator;
+        use zene_session::SessionRecord;
+
+        let mut engine = ContextEngine::new(128_000);
+        let mut session = SessionRecord::new(std::path::Path::new("/tmp"));
+        session.ensure_system_message("sys v1");
+        session.push_message(Message::user("hello"));
+        let estimator = TokenEstimator::default();
+        let tools = [];
+        let _ = engine.assemble_step(&session, &tools, &estimator);
+
+        session.push_message(Message::assistant("hi"));
+        let append = engine.explain_projection(&session, &tools, &estimator);
+        assert_eq!(append.prefix_cache.break_kind, "none");
+
+        session.update_system_prefix("sys v2 is longer and breaks the prefix");
+        let _ = engine.on_system_prefix_changed("system_prefix");
+        let resized = engine.explain_projection(&session, &tools, &estimator);
+        assert_eq!(resized.prefix_cache.break_kind, "system_resize");
     }
 }

--- a/crates/core/src/agent_builder.rs
+++ b/crates/core/src/agent_builder.rs
@@ -68,6 +68,7 @@ pub struct AgentBuilder {
     approval_broker: Option<zene_permission::SharedApprovalBroker>,
     external_session_id: Option<String>,
     include_workspace_context: Option<bool>,
+    deny_git_push: Option<bool>,
     extensions: Vec<Arc<dyn ExtensionHook>>,
 }
 
@@ -101,6 +102,7 @@ impl AgentBuilder {
             approval_broker: None,
             external_session_id: None,
             include_workspace_context: None,
+            deny_git_push: None,
             extensions: Vec::new(),
         }
     }
@@ -232,6 +234,12 @@ impl AgentBuilder {
         self
     }
 
+    /// Restrict `git push` / `gh` CLI invocations.
+    pub fn deny_git_push(mut self, deny: bool) -> Self {
+        self.deny_git_push = Some(deny);
+        self
+    }
+
     pub async fn build(mut self) -> Result<Agent> {
         let local = self.sandbox;
         let workdir = local.workdir().to_path_buf();
@@ -337,6 +345,7 @@ impl AgentBuilder {
                 self.permission_mode,
                 permission_rules_from_config(&self.config),
                 auto_allow_bash,
+                self.deny_git_push,
             ),
         };
 
@@ -419,10 +428,13 @@ pub(crate) fn shared_permission_with_rules(
     mode: PermissionMode,
     rules: Vec<PermissionRule>,
     auto_allow_bash: bool,
+    deny_git_push: Option<bool>,
 ) -> SharedToolPermission {
-    Arc::new(Mutex::new(
-        PermissionGate::new(mode)
-            .with_rules(rules)
-            .with_auto_allow_bash(auto_allow_bash),
-    ))
+    let mut gate = PermissionGate::new(mode)
+        .with_rules(rules)
+        .with_auto_allow_bash(auto_allow_bash);
+    if let Some(deny) = deny_git_push {
+        gate.set_deny_git_push(deny);
+    }
+    Arc::new(Mutex::new(gate))
 }

--- a/crates/core/src/agent_turn.rs
+++ b/crates/core/src/agent_turn.rs
@@ -250,9 +250,11 @@ mod tests {
     #[tokio::test]
     async fn prepare_context_projects_session_messages() {
         let workdir = tempfile::tempdir().expect("workdir");
-        let mut config = zene_config::ZeneConfig::default();
-        config.provider = "anthropic".into();
-        config.anthropic_api_key = Some("test-key".into());
+        let config = zene_config::ZeneConfig {
+            provider: "anthropic".into(),
+            anthropic_api_key: Some("test-key".into()),
+            ..Default::default()
+        };
         let session = zene_session::SessionRecord::new(workdir.path());
         let mut agent = crate::AgentBuilder::new(
             config,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -58,7 +58,8 @@ pub use zene_hooks::{
     ExtensionHook, HookBlock, HookEvent, HookOutcome, HookPayload, HookRunner, HookSpec,
 };
 pub use zene_permission::{
-    approve_tool_call, policy_denied, resolve_permission, ApprovalBroker, ApprovalRequest,
+    approve_tool_call, deny_cloud_github_cli, deny_git_cli, policy_denied,
+    policy_denied_with_git_push, resolve_permission, ApprovalBroker, ApprovalRequest,
     AutoApprovalBroker, PermissionGate, PermissionMode, PermissionPrompter, PermissionRule,
     PolicyDecision, PromptChoice, RuleAction, SharedApprovalBroker, SharedToolPermission,
     TerminalApprovalBroker, ToolPermission,

--- a/crates/core/src/prepare_step.rs
+++ b/crates/core/src/prepare_step.rs
@@ -200,7 +200,8 @@ mod tests {
         // Mirrors prepare_step: plan_filter = tool_policy.plan_mode && plan_mode_active
         let tools = default_builtin_tools();
         let policy = ToolPolicy::subagent();
-        let plan_filter = policy.plan_mode && true;
+        let plan_mode_active = true;
+        let plan_filter = policy.plan_mode && plan_mode_active;
         let defs = tool_definitions_for_llm(&tools, plan_filter);
         assert!(defs.iter().any(|t| t.name == "Write"));
     }

--- a/crates/core/src/subagent.rs
+++ b/crates/core/src/subagent.rs
@@ -549,10 +549,12 @@ mod tests {
         )))
     }
 
+    type FirstCallHook = Box<dyn Fn(&ModelRequest) + Send + Sync>;
+
     struct ScriptedBackend {
         responses: Vec<ModelResponse>,
         calls: AtomicUsize,
-        on_first_call: Option<Box<dyn Fn(&ModelRequest) + Send + Sync>>,
+        on_first_call: Option<FirstCallHook>,
     }
 
     impl ScriptedBackend {
@@ -738,8 +740,10 @@ mod tests {
     async fn subagent_uses_shared_turn_engine_step_budget() {
         let dir = tempdir().unwrap();
         let sandbox = zene_sandbox::into_arc(LocalSandbox::new(dir.path()));
-        let mut config = ZeneConfig::default();
-        config.max_turns = 1;
+        let config = ZeneConfig {
+            max_turns: 1,
+            ..Default::default()
+        };
         let backend = ScriptedBackend::new(vec![ModelResponse {
             message: Message::assistant_with_tools(
                 None,

--- a/crates/core/tests/todo_persist.rs
+++ b/crates/core/tests/todo_persist.rs
@@ -8,8 +8,8 @@ use zene_tools::{default_builtin_tools, shared_todo_store_from, ToolContext};
 
 #[tokio::test]
 async fn todo_write_persists_across_session_reload() {
-    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    let _guard = LOCK.lock().expect("test lock");
+    static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+    let _guard = LOCK.lock().await;
     let home = tempfile::tempdir().expect("tempdir");
     let prev = env::var("ZENE_HOME").ok();
     env::set_var("ZENE_HOME", home.path());
@@ -43,8 +43,10 @@ async fn todo_write_persists_across_session_reload() {
         .expect("TodoWrite should run");
     assert!(!result.is_error);
 
-    let store = store.lock();
-    session.todos = store.to_items();
+    {
+        let store = store.lock();
+        session.todos = store.to_items();
+    }
 
     session.save().expect("save session");
     let loaded = SessionRecord::load(&session.meta.id).expect("load session");

--- a/crates/hooks/src/runner.rs
+++ b/crates/hooks/src/runner.rs
@@ -193,12 +193,11 @@ impl HookRunner {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
-
     use super::*;
     use tempfile::TempDir;
+    use tokio::sync::Mutex;
 
-    static TEST_LOCK: Mutex<()> = Mutex::new(());
+    static TEST_LOCK: Mutex<()> = Mutex::const_new(());
 
     fn sample_hook(event: &str, script: &str) -> (TempDir, HookRunner) {
         let temp = TempDir::new().expect("tempdir");
@@ -234,7 +233,7 @@ mod tests {
 
     #[tokio::test]
     async fn pre_tool_use_blocks_on_non_zero_exit() {
-        let _guard = TEST_LOCK.lock().expect("test lock");
+        let _guard = TEST_LOCK.lock().await;
         let (_temp, runner) = sample_hook(
             "PreToolUse",
             r#"cat >/dev/null; echo "not allowed" >&2; exit 1"#,
@@ -250,7 +249,7 @@ mod tests {
 
     #[tokio::test]
     async fn pre_tool_use_terminates_on_exit_code_2() {
-        let _guard = TEST_LOCK.lock().expect("test lock");
+        let _guard = TEST_LOCK.lock().await;
         let (_temp, runner) = sample_hook(
             "PreToolUse",
             r#"cat >/dev/null; echo "security violation" >&2; exit 2"#,
@@ -266,7 +265,7 @@ mod tests {
 
     #[tokio::test]
     async fn pre_tool_use_terminates_on_json_output() {
-        let _guard = TEST_LOCK.lock().expect("test lock");
+        let _guard = TEST_LOCK.lock().await;
         let (_temp, runner) = sample_hook(
             "PreToolUse",
             r#"cat >/dev/null; echo '{"block":true,"reason":"policy stop","terminate":true}'; exit 0"#,
@@ -303,7 +302,7 @@ mod tests {
 
     #[tokio::test]
     async fn pre_tool_use_allows_success() {
-        let _guard = TEST_LOCK.lock().expect("test lock");
+        let _guard = TEST_LOCK.lock().await;
         let (_temp, runner) = sample_hook("PreToolUse", "cat > /dev/null; exit 0");
         let block = runner
             .run_pre_tool_use("Read", r#"{"path":"foo.rs"}"#)
@@ -314,7 +313,7 @@ mod tests {
 
     #[tokio::test]
     async fn post_tool_use_does_not_block() {
-        let _guard = TEST_LOCK.lock().expect("test lock");
+        let _guard = TEST_LOCK.lock().await;
         let (_temp, runner) =
             sample_hook("PostToolUse", "cat >/dev/null; echo blocked >&2; exit 1");
         runner.run_post_tool_use("Read", "{}").await;
@@ -322,7 +321,7 @@ mod tests {
 
     #[tokio::test]
     async fn hook_receives_json_on_stdin() {
-        let _guard = TEST_LOCK.lock().expect("test lock");
+        let _guard = TEST_LOCK.lock().await;
         let temp = TempDir::new().expect("tempdir");
         let script = r#"read payload; echo "$payload" | grep -q '"tool":"Bash"' || exit 2"#;
         let runner = HookRunner::with_bash(

--- a/crates/llm/src/client.rs
+++ b/crates/llm/src/client.rs
@@ -77,22 +77,28 @@ mod tests {
 
     #[test]
     fn provider_selection_anthropic_from_config() {
-        let mut config = ZeneConfig::default();
-        config.provider = "anthropic".to_string();
+        let config = ZeneConfig {
+            provider: "anthropic".to_string(),
+            ..Default::default()
+        };
         assert_eq!(selected_provider_kind(&config), ProviderKind::Anthropic);
     }
 
     #[test]
     fn provider_selection_openai_compatible_alias() {
-        let mut config = ZeneConfig::default();
-        config.provider = "openai-compatible".to_string();
+        let config = ZeneConfig {
+            provider: "openai-compatible".to_string(),
+            ..Default::default()
+        };
         assert_eq!(selected_provider_kind(&config), ProviderKind::OpenAi);
     }
 
     #[test]
     fn unknown_provider_errors() {
-        let mut config = ZeneConfig::default();
-        config.provider = "unknown-vendor".to_string();
+        let config = ZeneConfig {
+            provider: "unknown-vendor".to_string(),
+            ..Default::default()
+        };
         let err = config.provider_kind_parse().unwrap_err();
         assert!(err.to_string().contains("unknown provider"));
     }

--- a/crates/model-executor/src/lib.rs
+++ b/crates/model-executor/src/lib.rs
@@ -180,7 +180,7 @@ impl StreamAccumulator {
                 );
             }
             StreamEvent::Done { usage } => {
-                self.usage = usage.clone();
+                self.usage = *usage;
                 return true;
             }
             StreamEvent::ThoughtDelta(_) => {}

--- a/crates/permission/src/cloud_github.rs
+++ b/crates/permission/src/cloud_github.rs
@@ -1,17 +1,25 @@
-//! Cloud-bound GitHub publish stays on git-broker / Console.
-//! Agents must not `git push` or invoke `gh` themselves.
+//! Git safety policy for protected environments: prevents unintended remote pushes or publish actions.
+//! Agents must not `git push` or invoke `gh` when Git push protection is enabled.
 
-const DENIED: &str = "\
-GitHub publish is handled by Zene Cloud (Commit & Create PR). \
+const DEFAULT_DENIED: &str = "\
+Remote Git push or publish is restricted in this environment. \
 Do not run `git push` or `gh`. Local `git status` / `diff` / `log` / `add` / `commit` is allowed. \
-Keep changes in this workspace so Cloud can commit, push, and open the PR.";
+Keep changes in this workspace.";
 
 pub fn is_cloud_run() -> bool {
     std::env::var_os("ZENE_RUN_ID").is_some()
 }
 
+pub fn deny_git_cli(command: &str) -> Option<String> {
+    deny_git_cli_with_message(command, DEFAULT_DENIED)
+}
+
+pub fn deny_git_cli_with_message(command: &str, message: &str) -> Option<String> {
+    blocked_kind(command).map(|kind| format!("Policy denied `{kind}`: {message}"))
+}
+
 pub fn deny_cloud_github_cli(command: &str) -> Option<String> {
-    blocked_kind(command).map(|kind| format!("Policy denied `{kind}`: {DENIED}"))
+    deny_git_cli(command)
 }
 
 fn blocked_kind(command: &str) -> Option<&'static str> {
@@ -32,10 +40,10 @@ fn command_invokes(bin: &str, command: &str) -> bool {
         if first_command(&segment).is_some_and(|name| name == bin) {
             return true;
         }
-        if first_command(&segment).as_deref() == Some("ssh") {
-            if command_invokes(bin, &ssh_remote_command(&tokenize(&segment)[1..])) {
-                return true;
-            }
+        if first_command(&segment).as_deref() == Some("ssh")
+            && command_invokes(bin, &ssh_remote_command(&tokenize(&segment)[1..]))
+        {
+            return true;
         }
         if quoted_parts(&segment).any(|inner| command_invokes(bin, &inner)) {
             return true;
@@ -128,9 +136,8 @@ fn quoted_parts(segment: &str) -> impl Iterator<Item = String> + '_ {
 fn tokenize(segment: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut cur = String::new();
-    let mut chars = segment.chars().peekable();
     let mut quote: Option<char> = None;
-    while let Some(c) = chars.next() {
+    for c in segment.chars() {
         if let Some(q) = quote {
             if c == q {
                 quote = None;
@@ -257,7 +264,7 @@ mod tests {
         );
         assert!(deny_cloud_github_cli("git push")
             .unwrap()
-            .contains("Commit & Create PR"));
+            .contains("push or publish is restricted"));
     }
 
     #[test]

--- a/crates/permission/src/lib.rs
+++ b/crates/permission/src/lib.rs
@@ -13,6 +13,7 @@ pub use broker::{
     ApprovalBroker, ApprovalRequest, AutoApprovalBroker, SharedApprovalBroker,
     TerminalApprovalBroker,
 };
+pub use cloud_github::{deny_cloud_github_cli, deny_git_cli, deny_git_cli_with_message};
 
 /// Shared permission gate used by main agent and subagents.
 pub trait ToolPermission: Send + Sync {
@@ -136,6 +137,7 @@ pub struct PermissionGate {
     rules: Vec<PermissionRule>,
     prompter: Box<PermissionPrompter>,
     auto_allow_bash: bool,
+    deny_git_push: bool,
 }
 
 impl PermissionGate {
@@ -146,6 +148,7 @@ impl PermissionGate {
             rules: Vec::new(),
             prompter: Box::new(default_prompter),
             auto_allow_bash: false,
+            deny_git_push: cloud_github::is_cloud_run(),
         }
     }
 
@@ -156,6 +159,7 @@ impl PermissionGate {
             rules: Vec::new(),
             prompter,
             auto_allow_bash: false,
+            deny_git_push: cloud_github::is_cloud_run(),
         }
     }
 
@@ -169,12 +173,25 @@ impl PermissionGate {
         self
     }
 
+    pub fn with_deny_git_push(mut self, deny: bool) -> Self {
+        self.deny_git_push = deny;
+        self
+    }
+
     pub fn set_auto_allow_bash(&mut self, enabled: bool) {
         self.auto_allow_bash = enabled;
     }
 
     pub fn auto_allow_bash(&self) -> bool {
         self.auto_allow_bash
+    }
+
+    pub fn set_deny_git_push(&mut self, deny: bool) {
+        self.deny_git_push = deny;
+    }
+
+    pub fn deny_git_push(&self) -> bool {
+        self.deny_git_push
     }
 
     pub fn set_rules(&mut self, rules: Vec<PermissionRule>) {
@@ -187,6 +204,7 @@ impl PermissionGate {
 
     pub fn inherit_policy_from(&mut self, other: &Self) {
         self.auto_allow_bash = other.auto_allow_bash;
+        self.deny_git_push = other.deny_git_push;
         self.rules = other.rules.clone();
         self.approved_session = other.approved_session.clone();
     }
@@ -207,9 +225,14 @@ impl PermissionGate {
         self.rules.iter().find(|r| r.matches(tool_name))
     }
 
+    /// Check if a tool call is denied by policy configured on this gate.
+    pub fn policy_denied(&self, tool_name: &str, arguments: &str) -> Option<String> {
+        policy_denied_with_git_push(tool_name, arguments, self.deny_git_push)
+    }
+
     /// Classify a tool call without talking to a user.
     pub fn evaluate(&self, tool_name: &str, arguments: &str) -> PolicyDecision {
-        if policy_denied(tool_name, arguments).is_some() {
+        if self.policy_denied(tool_name, arguments).is_some() {
             return PolicyDecision::Deny;
         }
 
@@ -296,15 +319,19 @@ impl PermissionGate {
 }
 
 /// Hard deny Write/Edit under protected path segments (aligned with sandbox `.git` rules).
-/// Cloud runs also deny `git push` / `gh` so publish stays on git-broker.
+/// Also denies `git push` / `gh` when `deny_git_push` is true.
 pub fn policy_denied(tool_name: &str, arguments: &str) -> Option<String> {
-    policy_denied_inner(tool_name, arguments, cloud_github::is_cloud_run())
+    policy_denied_with_git_push(tool_name, arguments, cloud_github::is_cloud_run())
 }
 
-fn policy_denied_inner(tool_name: &str, arguments: &str, cloud_run: bool) -> Option<String> {
-    if cloud_run && matches!(tool_name, "Bash") {
+pub fn policy_denied_with_git_push(
+    tool_name: &str,
+    arguments: &str,
+    deny_git_push: bool,
+) -> Option<String> {
+    if deny_git_push && matches!(tool_name, "Bash") {
         if let Some(command) = extract_bash_command(arguments) {
-            if let Some(msg) = cloud_github::deny_cloud_github_cli(&command) {
+            if let Some(msg) = cloud_github::deny_git_cli(&command) {
                 return Some(msg);
             }
         }
@@ -588,13 +615,25 @@ mod tests {
     }
 
     #[test]
-    fn cloud_run_blocks_git_push_and_gh() {
-        let push = policy_denied_inner("Bash", r#"{"command":"git push origin HEAD"}"#, true);
+    fn git_push_protection_blocks_git_push_and_gh() {
+        let push =
+            policy_denied_with_git_push("Bash", r#"{"command":"git push origin HEAD"}"#, true);
         assert!(push.unwrap().contains("git push"));
-        let gh = policy_denied_inner("Bash", r#"{"command":"gh pr create"}"#, true);
+        let gh = policy_denied_with_git_push("Bash", r#"{"command":"gh pr create"}"#, true);
         assert!(gh.unwrap().contains("`gh`"));
-        assert!(policy_denied_inner("Bash", r#"{"command":"git status"}"#, true).is_none());
-        assert!(policy_denied_inner("Bash", r#"{"command":"git push"}"#, false).is_none());
+        assert!(policy_denied_with_git_push("Bash", r#"{"command":"git status"}"#, true).is_none());
+        assert!(policy_denied_with_git_push("Bash", r#"{"command":"git push"}"#, false).is_none());
+
+        let mut gate = PermissionGate::new(PermissionMode::Yolo).with_deny_git_push(true);
+        assert_eq!(
+            gate.evaluate("Bash", r#"{"command":"git push"}"#),
+            PolicyDecision::Deny
+        );
+        gate.set_deny_git_push(false);
+        assert_eq!(
+            gate.evaluate("Bash", r#"{"command":"git push"}"#),
+            PolicyDecision::Allow
+        );
     }
 
     #[test]

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -58,7 +58,7 @@ fn with_cloud_publish(
     mut tools: Vec<Box<dyn crate::registry::Tool>>,
 ) -> Vec<Box<dyn crate::registry::Tool>> {
     if PublishGithubTool::available() {
-        tools.push(Box::new(PublishGithubTool));
+        tools.push(Box::new(PublishGithubTool::new()));
     }
     tools
 }

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -47,7 +47,7 @@ pub use output_bound::{
 };
 pub use permission::{SharedToolPermission, ToolPermission};
 pub use plan_mode::{shared_plan_mode, PlanModeState, SharedPlanMode};
-pub use publish_github::PublishGithubTool;
+pub use publish_github::{CloudPublishConfig, PublishGithubTool};
 pub use registry::{Tool, ToolCatalog, ToolContext, ToolRegistry, ToolResult};
 pub use scope::{RuntimeScope, SessionPersistence, SessionPolicy, ToolPolicy};
 pub use spill_store::{apply_tool_bound_plan, FsToolOutputStore, ToolOutputStore};

--- a/crates/tools/src/output_sanitizer.rs
+++ b/crates/tools/src/output_sanitizer.rs
@@ -76,9 +76,9 @@ impl OutputSanitizer {
                 in_failure_section = true;
             }
 
-            if in_failure_section {
-                result.push(line);
-            } else if trimmed.starts_with("test ") && trimmed.ends_with("... FAILED") {
+            if in_failure_section
+                || (trimmed.starts_with("test ") && trimmed.ends_with("... FAILED"))
+            {
                 result.push(line);
             }
         }

--- a/crates/tools/src/publish_github.rs
+++ b/crates/tools/src/publish_github.rs
@@ -21,35 +21,61 @@ struct PublishArgs {
 }
 
 #[derive(Debug, Clone)]
-struct CloudPublishConfig {
-    api_url: String,
-    token: String,
-    run_id: String,
+pub struct CloudPublishConfig {
+    pub api_url: String,
+    pub token: String,
+    pub run_id: String,
 }
 
-pub struct PublishGithubTool;
-
-impl PublishGithubTool {
-    pub fn available() -> bool {
-        cloud_publish_config().is_some()
+impl CloudPublishConfig {
+    pub fn from_env() -> Option<Self> {
+        let run_id = std::env::var("ZENE_RUN_ID")
+            .ok()
+            .filter(|s| !s.trim().is_empty())?;
+        let api_url = std::env::var("ZENE_CLOUD_API_URL")
+            .ok()
+            .filter(|s| !s.trim().is_empty())?;
+        let token = std::env::var("ZENE_CLOUD_WORKER_TOKEN")
+            .ok()
+            .filter(|s| !s.trim().is_empty())?;
+        Some(Self {
+            api_url: api_url.trim_end_matches('/').to_string(),
+            token,
+            run_id,
+        })
     }
 }
 
-fn cloud_publish_config() -> Option<CloudPublishConfig> {
-    let run_id = std::env::var("ZENE_RUN_ID")
-        .ok()
-        .filter(|s| !s.trim().is_empty())?;
-    let api_url = std::env::var("ZENE_CLOUD_API_URL")
-        .ok()
-        .filter(|s| !s.trim().is_empty())?;
-    let token = std::env::var("ZENE_CLOUD_WORKER_TOKEN")
-        .ok()
-        .filter(|s| !s.trim().is_empty())?;
-    Some(CloudPublishConfig {
-        api_url: api_url.trim_end_matches('/').to_string(),
-        token,
-        run_id,
-    })
+pub struct PublishGithubTool {
+    config: Option<CloudPublishConfig>,
+}
+
+impl PublishGithubTool {
+    pub fn new() -> Self {
+        Self {
+            config: CloudPublishConfig::from_env(),
+        }
+    }
+
+    pub fn with_config(config: CloudPublishConfig) -> Self {
+        Self {
+            config: Some(config),
+        }
+    }
+
+    pub fn available() -> bool {
+        CloudPublishConfig::from_env().is_some()
+    }
+
+    pub fn is_configured(&self) -> bool {
+        self.config.is_some()
+    }
+}
+
+impl Default for PublishGithubTool {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 fn format_publish_result(push: &Value, pr: Option<&Value>) -> String {
@@ -113,9 +139,16 @@ impl Tool for PublishGithubTool {
         } else {
             serde_json::from_str(arguments).context("parse PublishGithub args")?
         };
-        let Some(cfg) = cloud_publish_config() else {
+        let Some(cfg) = self
+            .config
+            .as_ref()
+            .cloned()
+            .or_else(CloudPublishConfig::from_env)
+        else {
             return Ok(ToolResult {
-                content: "PublishGithub is only available in a Zene Cloud session.".into(),
+                content:
+                    "PublishGithub is only available in a Zene Cloud session or when configured."
+                        .into(),
                 is_error: true,
             });
         };

--- a/crates/tools/src/read.rs
+++ b/crates/tools/src/read.rs
@@ -152,10 +152,8 @@ fn format_file_content(
 
 fn truncate_head(lines: &[&str], max_lines: usize, max_bytes: usize) -> (String, bool) {
     let mut result = String::new();
-    let mut line_count = 0usize;
     let mut was_truncated = false;
-
-    for line in lines {
+    for (line_count, line) in lines.iter().enumerate() {
         if line_count >= max_lines {
             was_truncated = true;
             break;
@@ -170,7 +168,6 @@ fn truncate_head(lines: &[&str], max_lines: usize, max_bytes: usize) -> (String,
             break;
         }
         result.push_str(&next);
-        line_count += 1;
     }
 
     (result, was_truncated)
@@ -182,7 +179,7 @@ mod tests {
 
     #[test]
     fn truncate_respects_byte_limit() {
-        let lines: Vec<&str> = vec!["a"; 100].iter().map(|s| *s).collect();
+        let lines: Vec<&str> = vec!["a"; 100];
         let (text, truncated) = truncate_head(&lines, 2000, 10);
         assert!(truncated);
         assert!(text.len() <= 10);

--- a/crates/turn/src/state.rs
+++ b/crates/turn/src/state.rs
@@ -128,16 +128,11 @@ impl TurnState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum QueueMode {
+    #[default]
     OneAtATime,
     All,
-}
-
-impl Default for QueueMode {
-    fn default() -> Self {
-        Self::OneAtATime
-    }
 }
 
 /// Buffered steer messages injected between model steps.

--- a/crates/turn/src/turn_loop.rs
+++ b/crates/turn/src/turn_loop.rs
@@ -372,11 +372,6 @@ where
                         .run_tools(&tool_calls, request.options, request.cancel)
                         .await?;
                     if tool_outcome == ToolBatchOutcome::Terminate {
-                        if ports.inject_steer(request.options)?
-                            || ports.inject_follow_up(request.options)?
-                        {
-                            continue;
-                        }
                         status = Some(TurnStatus::Terminated);
                         break;
                     }

--- a/crates/workspace/src/lib.rs
+++ b/crates/workspace/src/lib.rs
@@ -4,6 +4,6 @@ mod prompt;
 mod provider;
 mod skills;
 
-pub use prompt::build_system_prompt;
+pub use prompt::{build_system_prompt, build_system_prompt_ext, CLOUD_GITHUB_RULE};
 pub use provider::{FsWorkspaceProvider, WorkspaceProvider};
 pub use skills::{format_available_skills, SkillMeta};

--- a/crates/workspace/src/prompt.rs
+++ b/crates/workspace/src/prompt.rs
@@ -1,7 +1,7 @@
 use crate::skills::format_available_skills;
 use crate::WorkspaceProvider;
 
-const CLOUD_GITHUB_RULE: &str = "\
+pub const CLOUD_GITHUB_RULE: &str = "\
 # Cloud GitHub
 
 This session is bound to a GitHub App installation. \
@@ -16,6 +16,21 @@ pub fn build_system_prompt(
     base: &str,
     provider: &dyn WorkspaceProvider,
     include_workspace_context: bool,
+) -> String {
+    build_system_prompt_ext(
+        base,
+        provider,
+        include_workspace_context,
+        std::env::var_os("ZENE_RUN_ID").is_some(),
+    )
+}
+
+/// Combine base system prompt with optional workspace context and optional git publish rules.
+pub fn build_system_prompt_ext(
+    base: &str,
+    provider: &dyn WorkspaceProvider,
+    include_workspace_context: bool,
+    include_github_rule: bool,
 ) -> String {
     let mut prompt = if !include_workspace_context {
         base.to_string()
@@ -34,7 +49,7 @@ pub fn build_system_prompt(
 
         sections.join("\n\n")
     };
-    if std::env::var_os("ZENE_RUN_ID").is_some() {
+    if include_github_rule {
         prompt.push_str("\n\n");
         prompt.push_str(CLOUD_GITHUB_RULE);
     }
@@ -70,5 +85,8 @@ mod tests {
         assert!(prompt.contains("Use Rust."));
         assert!(prompt.contains("# Workspace"));
         assert!(!prompt.contains("Cloud GitHub"));
+
+        let prompt_with_github = build_system_prompt_ext("Base prompt.", &provider, true, true);
+        assert!(prompt_with_github.contains("Cloud GitHub"));
     }
 }

--- a/crates/workspace/src/skills.rs
+++ b/crates/workspace/src/skills.rs
@@ -74,8 +74,6 @@ fn split_frontmatter(content: &str) -> Option<(&str, &str)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use tempfile::TempDir;
 
     #[test]
     fn format_available_skills_lists_entries() {


### PR DESCRIPTION
## Summary
Part of the Zen Engine (Zene) open and headless harness simplification roadmap (P2).

### Changes
1. **`crates/permission`**:
   - Refactored cloud GitHub CLI restrictions into generic Git push / remote publish protection (`deny_git_cli`, `deny_git_cli_with_message`).
   - Made Git push protection configurable on `PermissionGate` via `deny_git_push: bool`, `.with_deny_git_push(bool)`, and `.set_deny_git_push(bool)`, eliminating implicit environment reliance.
2. **`crates/tools`**:
   - Decoupled `PublishGithubTool` so it can be explicitly instantiated and configured via `CloudPublishConfig` (`PublishGithubTool::with_config`) rather than relying strictly on implicit static environment variable probes.
3. **`crates/workspace`**:
   - Decoupled `build_system_prompt` by introducing `build_system_prompt_ext`, allowing caller-controlled inclusion of the Cloud GitHub rules section instead of unconditionally inspecting `std::env::var_os("ZENE_RUN_ID")`.
4. **`crates/core`**:
   - Added `.deny_git_push(bool)` builder configuration on `AgentBuilder` to pass down explicit Git safety preferences to the gate.
5. **Quality Gates & Fixes**:
   - Fixed pre-existing issue in `crates/turn/src/turn_loop.rs` when terminating tool batches.
   - Cleared compiler/clippy warnings across workspace targets and passed all workspace tests (`cargo fmt --check`, `cargo clippy --all-targets --locked -- -D warnings`, `cargo test --workspace --locked`).