### PR TITLE
refactor(tools,core): add core toolsets and streamline agent facade for P3 and P4

### DIFF
--- a/crates/agent-runtime/src/actor.rs
+++ b/crates/agent-runtime/src/actor.rs
@@ -902,7 +902,6 @@ mod tests {
         use chrono::Utc;
         use tempfile::tempdir;
         use zene_config::ZeneConfig;
-        use zene_sandbox::LocalSandbox;
         use zene_session::{
             AgentRecordWriter, ExecutionCheckpointState, RecordEntry, SessionRecord,
         };
@@ -930,17 +929,15 @@ mod tests {
             anthropic_api_key: Some("test-key".into()),
             ..Default::default()
         };
-        let agent = zene_core::AgentBuilder::new(
-            config,
-            LocalSandbox::new(workdir.path()),
-            session,
-            zene_permission::PermissionMode::BypassPermissions,
-        )
-        .without_mcp()
-        .record_writer(writer)
-        .build()
-        .await
-        .expect("build agent without network calls");
+        let agent = zene_core::Agent::builder(workdir.path())
+            .config(config)
+            .session(session)
+            .bypass_permissions()
+            .without_mcp()
+            .record_writer(writer)
+            .build()
+            .await
+            .expect("build agent without network calls");
         let (runtime, task) = RuntimeHandle::spawn_with_automatic_recovery(agent);
 
         assert_eq!(
@@ -962,7 +959,6 @@ mod tests {
         use chrono::Utc;
         use tempfile::tempdir;
         use zene_config::ZeneConfig;
-        use zene_sandbox::LocalSandbox;
         use zene_session::{
             AgentRecordWriter, ExecutionCheckpointState, RecordEntry, SessionRecord,
         };
@@ -990,17 +986,15 @@ mod tests {
             anthropic_api_key: Some("test-key".into()),
             ..Default::default()
         };
-        let agent = zene_core::AgentBuilder::new(
-            config,
-            LocalSandbox::new(workdir.path()),
-            session,
-            zene_permission::PermissionMode::BypassPermissions,
-        )
-        .without_mcp()
-        .record_writer(writer)
-        .build()
-        .await
-        .expect("build agent without network calls");
+        let agent = zene_core::Agent::builder(workdir.path())
+            .config(config)
+            .session(session)
+            .bypass_permissions()
+            .without_mcp()
+            .record_writer(writer)
+            .build()
+            .await
+            .expect("build agent without network calls");
         let (runtime, task) = RuntimeHandle::spawn(agent);
 
         assert_eq!(

--- a/crates/core/src/agent_builder.rs
+++ b/crates/core/src/agent_builder.rs
@@ -107,6 +107,58 @@ impl AgentBuilder {
         }
     }
 
+    /// Construct a builder initialized with default configuration and runtime primitives for `workdir`.
+    pub fn for_workdir(workdir: impl AsRef<std::path::Path>) -> Self {
+        let workdir = workdir.as_ref();
+        let config = ZeneConfig::load(workdir).unwrap_or_default();
+        let sandbox = LocalSandbox::new(workdir);
+        let session = SessionRecord::new(workdir);
+        let permission_mode = PermissionMode::parse(&config.permission_mode);
+        Self::new(config, sandbox, session, permission_mode)
+    }
+
+    /// Override the agent configuration.
+    pub fn config(mut self, config: ZeneConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Override the sandbox.
+    pub fn sandbox(mut self, sandbox: LocalSandbox) -> Self {
+        self.sandbox = sandbox;
+        self
+    }
+
+    /// Override the session record.
+    pub fn session(mut self, session: SessionRecord) -> Self {
+        self.session = session;
+        self
+    }
+
+    /// Override the permission mode.
+    pub fn permission_mode(mut self, permission_mode: PermissionMode) -> Self {
+        self.permission_mode = permission_mode;
+        self
+    }
+
+    /// Bypass permission checks (convenience for scripts and testing).
+    pub fn bypass_permissions(mut self) -> Self {
+        self.permission_mode = PermissionMode::BypassPermissions;
+        self
+    }
+
+    /// Use the minimalist core toolset (read, write, edit, bash, grep, glob).
+    pub fn core_tools(mut self) -> Self {
+        self.tools = Some(zene_tools::core_tools());
+        self
+    }
+
+    /// Use the read-only minimal toolset (read, grep, glob).
+    pub fn minimal_tools(mut self) -> Self {
+        self.tools = Some(zene_tools::minimal_tools());
+        self
+    }
+
     /// Use a pre-built chat client instead of `ChatClient::from_config`.
     pub fn client(mut self, client: ChatClient) -> Self {
         self.client = Some(client);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -3,22 +3,25 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
-use zene_config::ZeneConfig;
+pub use zene_config::ZeneConfig;
 use zene_context::{ContextDeps, ContextEngine, PrefireClientFactory};
-use zene_llm::{ChatClient, Message, TokenUsage, ToolCall};
+pub use zene_llm::ChatClient;
+use zene_llm::{Message, TokenUsage, ToolCall};
 
 use zene_mcp::McpManager;
 use zene_model_executor::ModelExecutor;
-use zene_sandbox::{LocalSandbox, Sandbox};
+pub use zene_sandbox::{LocalSandbox, Sandbox};
 use zene_session::{
     fork_session, latest_checkpoint_id, load_checkpoint, restore_checkpoint, save_checkpoint,
-    AgentRecordWriter, ExecutionCheckpointState, RecordEntry, SessionRecord,
+    AgentRecordWriter, ExecutionCheckpointState, RecordEntry,
 };
-pub use zene_session::{RecoveryDisposition, RecoveryExecution, RecoverySnapshot};
-pub use zene_tools::AskUserOption;
+pub use zene_session::{RecoveryDisposition, RecoveryExecution, RecoverySnapshot, SessionRecord};
+pub use zene_tools::{
+    builtin_tools, core_tools, minimal_tools, AskUserOption, ToolCatalog, ToolRegistry,
+};
 use zene_tools::{
     shared_todo_store_from, RuntimeScope, SharedAskUserPrompter, SharedBackgroundTasks,
-    SharedPlanMode, SharedTodoStore, ToolCatalog, ToolRegistry,
+    SharedPlanMode, SharedTodoStore,
 };
 
 mod agent_builder;
@@ -127,6 +130,25 @@ impl Default for PromptOptions {
 }
 
 impl Agent {
+    /// Create a fluent builder initialized with defaults for `workdir`.
+    pub fn builder(workdir: impl AsRef<std::path::Path>) -> AgentBuilder {
+        AgentBuilder::for_workdir(workdir)
+    }
+
+    /// Create a minimalist agent builder with core tools only (read, write, edit, bash, grep, glob) and no MCP.
+    pub fn core(workdir: impl AsRef<std::path::Path>) -> AgentBuilder {
+        AgentBuilder::for_workdir(workdir)
+            .without_mcp()
+            .core_tools()
+    }
+
+    /// Create a read-only minimal agent builder (read, grep, glob) and no MCP.
+    pub fn minimal(workdir: impl AsRef<std::path::Path>) -> AgentBuilder {
+        AgentBuilder::for_workdir(workdir)
+            .without_mcp()
+            .minimal_tools()
+    }
+
     pub async fn new(
         config: ZeneConfig,
         sandbox: LocalSandbox,

--- a/crates/core/tests/agent_facade.rs
+++ b/crates/core/tests/agent_facade.rs
@@ -1,0 +1,75 @@
+use tempfile::tempdir;
+use zene_core::{Agent, ZeneConfig};
+
+#[tokio::test]
+async fn test_agent_minimal_facade() {
+    let dir = tempdir().unwrap();
+    let config = ZeneConfig {
+        provider: "anthropic".into(),
+        anthropic_api_key: Some("test-key".into()),
+        ..Default::default()
+    };
+
+    let agent = Agent::minimal(dir.path())
+        .config(config)
+        .bypass_permissions()
+        .build()
+        .await
+        .expect("build minimal agent");
+
+    let tools = agent.active_tool_names();
+    assert!(tools.contains(&"Read".to_string()));
+    assert!(tools.contains(&"Grep".to_string()));
+    assert!(tools.contains(&"Glob".to_string()));
+    assert!(!tools.contains(&"Bash".to_string()));
+    assert!(!tools.contains(&"Write".to_string()));
+    assert!(!tools.contains(&"Edit".to_string()));
+}
+
+#[tokio::test]
+async fn test_agent_core_facade() {
+    let dir = tempdir().unwrap();
+    let config = ZeneConfig {
+        provider: "anthropic".into(),
+        anthropic_api_key: Some("test-key".into()),
+        ..Default::default()
+    };
+
+    let agent = Agent::core(dir.path())
+        .config(config)
+        .bypass_permissions()
+        .build()
+        .await
+        .expect("build core agent");
+
+    let tools = agent.active_tool_names();
+    assert!(tools.contains(&"Read".to_string()));
+    assert!(tools.contains(&"Grep".to_string()));
+    assert!(tools.contains(&"Glob".to_string()));
+    assert!(tools.contains(&"Bash".to_string()));
+    assert!(tools.contains(&"Write".to_string()));
+    assert!(tools.contains(&"Edit".to_string()));
+    // Builtin extras should not be present in core
+    assert!(!tools.contains(&"Task".to_string()));
+    assert!(!tools.contains(&"TodoWrite".to_string()));
+}
+
+#[tokio::test]
+async fn test_agent_builder_defaults() {
+    let dir = tempdir().unwrap();
+    let config = ZeneConfig {
+        provider: "anthropic".into(),
+        anthropic_api_key: Some("test-key".into()),
+        ..Default::default()
+    };
+
+    let agent = Agent::builder(dir.path())
+        .config(config)
+        .without_mcp()
+        .build()
+        .await
+        .expect("build default agent");
+
+    assert_eq!(agent.current_session_mode(), "default");
+    assert!(!agent.is_plan_mode_active());
+}

--- a/crates/tools/src/builtin.rs
+++ b/crates/tools/src/builtin.rs
@@ -22,6 +22,28 @@ pub fn builtin_tools(web_search: WebSearchConfig) -> ToolRegistry {
     ToolRegistry::new(all_builtin_tool_boxes(web_search))
 }
 
+/// Minimal core harness tools: file operations (Read, Write, Edit), search (Grep, Glob), and shell (Bash).
+/// Excludes external services, browser web search, and plan/todo collaboration suites.
+pub fn core_tools() -> ToolRegistry {
+    ToolRegistry::new(vec![
+        Box::new(ReadTool),
+        Box::new(WriteTool),
+        Box::new(EditTool),
+        Box::new(BashTool),
+        Box::new(GrepTool),
+        Box::new(GlobTool),
+    ])
+}
+
+/// Read-only inspection tools: Read, Grep, Glob.
+pub fn minimal_tools() -> ToolRegistry {
+    ToolRegistry::new(vec![
+        Box::new(ReadTool),
+        Box::new(GrepTool),
+        Box::new(GlobTool),
+    ])
+}
+
 pub fn agent_tools(profile: AgentProfile, web_search: WebSearchConfig) -> ToolRegistry {
     match profile {
         AgentProfile::Full => builtin_tools(web_search),
@@ -164,5 +186,29 @@ mod tests {
         {
             assert!(!names.iter().any(|n| n == "PublishGithub"));
         }
+    }
+
+    #[test]
+    fn core_and_minimal_tools_contain_expected_tools() {
+        let core = core_tools();
+        let core_names: Vec<String> = core.definitions().into_iter().map(|d| d.name).collect();
+        assert_eq!(core_names.len(), 6);
+        assert!(core_names.contains(&"Read".into()));
+        assert!(core_names.contains(&"Write".into()));
+        assert!(core_names.contains(&"Edit".into()));
+        assert!(core_names.contains(&"Bash".into()));
+        assert!(core_names.contains(&"Grep".into()));
+        assert!(core_names.contains(&"Glob".into()));
+        assert!(!core_names.contains(&"WebSearch".into()));
+        assert!(!core_names.contains(&"FetchUrl".into()));
+
+        let minimal = minimal_tools();
+        let min_names: Vec<String> = minimal.definitions().into_iter().map(|d| d.name).collect();
+        assert_eq!(min_names.len(), 3);
+        assert!(min_names.contains(&"Read".into()));
+        assert!(min_names.contains(&"Grep".into()));
+        assert!(min_names.contains(&"Glob".into()));
+        assert!(!min_names.contains(&"Write".into()));
+        assert!(!min_names.contains(&"Bash".into()));
     }
 }

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -35,7 +35,9 @@ pub use background::{
     shared_background_tasks, BackgroundTask, BackgroundTaskKind, BackgroundTaskStatus,
     BackgroundTaskStore, SharedBackgroundTasks,
 };
-pub use builtin::{agent_tools, builtin_tools, default_builtin_tools, tools_for_profile};
+pub use builtin::{
+    agent_tools, builtin_tools, core_tools, default_builtin_tools, minimal_tools, tools_for_profile,
+};
 pub use fetch_url::FetchUrlTool;
 pub use line_endings::{
     detect_line_ending_style, make_carriage_returns_visible, materialize_model_text,


### PR DESCRIPTION
## Summary

Completes P3 & P4 simplification optimization for Zene as an open, minimalist agent harness:

- **P3 Core Toolsets Convergence ()**:
  - Adds `core_tools()` (6 core tools: `Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`), providing a lightweight zero-dependency toolset for standalone agent harnesses.
  - Adds `minimal_tools()` (3 read-only tools: `Read`, `Grep`, `Glob`) for safe read-only inspection agents.
  - Re-exports them in `zene-tools` top-level without breaking existing `builtin_tools()` backwards compatibility.

- **P4 Minimalist API Facade Convergence (`crates/core`)**:
  - Adds `Agent::builder(workdir)` and `AgentBuilder::for_workdir(workdir)`, automatically resolving default config, sandbox, and session with zero boilerplate.
  - Adds convenient factory presets `Agent::core(workdir)` and `Agent::minimal(workdir)` that disable MCP and attach core/minimal tools out-of-the-box.
  - Provides chainable builder methods: `.core_tools()`, `.minimal_tools()`, `.bypass_permissions()`, `.config()`, `.session()`, etc.
  - Re-exports core types (`ZeneConfig`, `ChatClient`, `LocalSandbox`, `Sandbox`, `SessionRecord`, `core_tools`, `minimal_tools`, `ToolRegistry`, `ToolCatalog`) directly from `zene-core` so downstream consumers can build agents from a single unified facade.

## Verification
- Added unit and integration tests:
  - `crates/tools/src/builtin.rs`: `core_and_minimal_tools_contain_expected_tools`
  - `crates/core/tests/agent_facade.rs`: `test_agent_minimal_facade`, `test_agent_core_facade`, `test_agent_builder_defaults`
- Full local gates passed:
  - `cargo fmt --check`
  - `cargo clippy --workspace --locked --all-targets -- -D warnings`
  - `cargo test --workspace --locked`